### PR TITLE
DM - remove "internal" from set accessors in Options classes

### DIFF
--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Configuration/MessageBrokerOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Configuration/MessageBrokerOptions.cs
@@ -6,8 +6,8 @@ namespace Chatter.MessageBrokers.Configuration
 {
     public class MessageBrokerOptions
     {
-        public TransactionMode TransactionMode { get; internal set; }
-        public ReliabilityOptions Reliability { get; internal set; }
-        public RecoveryOptions Recovery { get; internal set; }
+        public TransactionMode TransactionMode { get; set; }
+        public ReliabilityOptions Reliability { get; set; }
+        public RecoveryOptions Recovery { get; set; }
     }
 }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Recovery/CircuitBreaker/CircuitBreakerOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Recovery/CircuitBreaker/CircuitBreakerOptions.cs
@@ -2,10 +2,10 @@
 {
     public class CircuitBreakerOptions
     {
-        public int OpenToHalfOpenWaitTimeInSeconds { get; internal set; }
-        public int ConcurrentHalfOpenAttempts { get; internal set; }
-        public int NumberOfFailuresBeforeOpen { get; internal set; }
-        public int NumberOfHalfOpenSuccessesToClose { get; internal set; }
-        public int SecondsOpenBeforeCriticalFailureNotification { get; internal set; }
+        public int OpenToHalfOpenWaitTimeInSeconds { get; set; }
+        public int ConcurrentHalfOpenAttempts { get; set; }
+        public int NumberOfFailuresBeforeOpen { get; set; }
+        public int NumberOfHalfOpenSuccessesToClose { get; set; }
+        public int SecondsOpenBeforeCriticalFailureNotification { get; set; }
     }
 }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Recovery/Options/RecoveryOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Recovery/Options/RecoveryOptions.cs
@@ -4,7 +4,7 @@ namespace Chatter.MessageBrokers.Recovery.Options
 {
     public class RecoveryOptions
     {
-        public int MaxRetryAttempts { get; internal set; }
-        public CircuitBreakerOptions CircuitBreakerOptions { get; internal set; }
+        public int MaxRetryAttempts { get; set; }
+        public CircuitBreakerOptions CircuitBreakerOptions { get; set; }
     }
 }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Reliability/Configuration/ReliabilityOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Reliability/Configuration/ReliabilityOptions.cs
@@ -2,9 +2,9 @@
 {
     public class ReliabilityOptions
     {
-        public bool RouteMessagesToOutbox { get; internal set; }
-        public double MinutesToLiveInMemory { get; internal set; }
-        public bool EnableOutboxPollingProcessor { get; internal set; }
-        public int OutboxProcessingIntervalInMilliseconds { get; internal set; }
+        public bool RouteMessagesToOutbox { get; set; }
+        public double MinutesToLiveInMemory { get; set; }
+        public bool EnableOutboxPollingProcessor { get; set; }
+        public int OutboxProcessingIntervalInMilliseconds { get; set; }
     }
 }


### PR DESCRIPTION
Make set accessors in options classes public to allow JSON deserializer to set values (can't replace with init due to .NET standard 2.1 support)