### PR TITLE
chore: seed hivemind plugin + domain context map

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,30 @@
+{
+  "enabledPlugins": {
+    "hivemind@brenpike": true
+  },
+  "agent": "hivemind:overlord",
+  "permissions": {
+    "allow": [
+      "Bash(echo *)",
+      "Bash(printf *)",
+      "Bash(cat *)",
+      "Bash(grep *)",
+      "Bash(jq *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(ls *)",
+      "Bash(wc *)",
+      "Bash(sort *)",
+      "Bash(uniq *)",
+      "Bash(git ls-files *)",
+      "Bash(git ls-tree *)",
+      "Bash(git grep *)",
+      "Bash(git tag)",
+      "Bash(git tag -l*)",
+      "Bash(git tag --list*)",
+      "Bash(git stash list)",
+      "Bash(git stash show *)",
+      "Bash(node /path/to/.claude/plugins/cache/openai-codex/codex/*)"
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,30 +1,86 @@
 {
-  "enabledPlugins": {
-    "hivemind@brenpike": true
-  },
-  "agent": "hivemind:overlord",
   "permissions": {
     "allow": [
-      "Bash(echo *)",
-      "Bash(printf *)",
-      "Bash(cat *)",
+      "Bash(git -C * status *)",
+      "Bash(git -C * branch *)",
+      "Bash(git -C * log *)",
+      "Bash(git -C * diff *)",
+      "Bash(git -C * show *)",
+      "Bash(git -C * stash show *)",
+      "Bash(git -C * stash list)",
+      "Bash(git -C * fetch *)",
+      "Bash(git -C * rev-list *)",
+      "Bash(git -C * show-ref *)",
+      "Bash(git diff *)",
+      "Bash(git status *)",
+      "Bash(git log *)",
+      "Bash(git show *)",
+      "Bash(git branch *)",
+      "Bash(git fetch *)",
+      "Bash(git rev-parse *)",
+      "Bash(git stash list)",
+      "Bash(git stash show *)",
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(sed -n *)",
+      "Bash(gh api user *)",
+      "Bash(gh api graphql *)",
+      "Bash(gh pr checks *)",
+      "Bash(gh pr comment *)",
+      "Bash(gh pr view *)",
+      "Bash(gh pr list *)",
+      "Bash(gh pr checkout *)",
+      "Bash(gh repo view *)",
       "Bash(grep *)",
+      "Bash(cat > .hivemind/*)",
+      "Write(.hivemind/review-loop/*)",
+      "Bash(mkdir -p .hivemind/review-loop)",
+      "Monitor",
       "Bash(jq *)",
       "Bash(head *)",
       "Bash(tail *)",
       "Bash(ls *)",
       "Bash(wc *)",
-      "Bash(sort *)",
       "Bash(uniq *)",
+      "Bash(echo *)",
+      "Bash(printf *)",
+      "Bash(cat *)",
+      "Bash(sort *)",
       "Bash(git ls-files *)",
       "Bash(git ls-tree *)",
-      "Bash(git grep *)",
       "Bash(git tag)",
       "Bash(git tag -l*)",
       "Bash(git tag --list*)",
-      "Bash(git stash list)",
-      "Bash(git stash show *)",
-      "Bash(node /path/to/.claude/plugins/cache/openai-codex/codex/*)"
+      "Bash(git grep *)",
+      "Bash(bash tools/policy_check.sh*)",
+      "Bash(bash tools/validate_reports.sh*)",
+      "Bash(bash -n *)"
     ]
+  },
+  "hooks": {
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/caveman-ultra-subagent.sh"
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "caveman@caveman": true,
+    "claude-mem@thedotmack": true,
+    "codex@openai-codex": true,
+    "hivemind@brenpike": true
+  },
+  "agent": "hivemind:overlord",
+  "pluginConfigs": {
+    "caveman@caveman": {
+      "options": {
+        "defaultLevel": "ultra"
+      }
+    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -333,3 +333,4 @@ ASALocalRun/
 .vscode
 
 Publish/
+.hivemind/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# Chatter
+
+## Validation
+
+```
+dotnet test
+```

--- a/CONTEXT-MAP.md
+++ b/CONTEXT-MAP.md
@@ -1,0 +1,23 @@
+# Chatter — Context Map
+
+Library suite for building domain-driven .NET Core Web APIs and microservices via CQRS and technology-agnostic message broker infrastructure. Each bounded context below owns its own ubiquitous language in a local `CONTEXT.md`.
+
+## Bounded Contexts
+
+| Context | Path | Responsibility |
+|---|---|---|
+| CQRS | [src/Chatter.CQRS/CONTEXT.md](./src/Chatter.CQRS/CONTEXT.md) | Command/Query/Event dispatch via mediator; command pipeline. |
+| Message Brokers | [src/Chatter.MessageBrokers/CONTEXT.md](./src/Chatter.MessageBrokers/CONTEXT.md) | Technology-agnostic brokered messaging: receiving, sending, routing, reliability, recovery. |
+| Azure Service Bus | [src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md](./src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md) | Azure Service Bus implementation of the broker interfaces. |
+| Azure Service Bus Auth | [src/Chatter.MessageBrokers.AzureServiceBus.Auth/CONTEXT.md](./src/Chatter.MessageBrokers.AzureServiceBus.Auth/CONTEXT.md) | AAD token-based authentication for Azure Service Bus. |
+| Reliability (EntityFramework) | [src/Chatter.MessageBrokers.Reliability.EntityFramework/CONTEXT.md](./src/Chatter.MessageBrokers.Reliability.EntityFramework/CONTEXT.md) | EF Core persistence for inbox/outbox and unit of work. |
+| SQL Service Broker | [src/Chatter.MessageBrokers.SqlServiceBroker/CONTEXT.md](./src/Chatter.MessageBrokers.SqlServiceBroker/CONTEXT.md) | SQL Server Service Broker implementation of the broker interfaces. |
+| SQL Change Feed | [src/Chatter.SqlChangeFeed/CONTEXT.md](./src/Chatter.SqlChangeFeed/CONTEXT.md) | Table-change notifications sourced from SQL Server. |
+
+## Context Relationships
+
+- **Message Brokers** builds on **CQRS**, reusing its dispatch and Command/Event handling.
+- **Azure Service Bus**, **SQL Service Broker** implement the broker interfaces defined by **Message Brokers**.
+- **Azure Service Bus Auth** supplies credentials to **Azure Service Bus**.
+- **Reliability (EntityFramework)** implements the inbox/outbox persistence ports defined by **Message Brokers**.
+- **SQL Change Feed** emits change notifications that can be relayed through **Message Brokers**, often over **SQL Service Broker**.

--- a/README.md
+++ b/README.md
@@ -1,53 +1,124 @@
 # Chatter
 
-Chatter enables rapid development of domain driven .NET Core Web APIs and Microservices. The core libraries of Chatter are:
-* [Chatter.CQRS](./src/Chatter.CQRS/src/README.md#chatter-cqrs), and
-* [Chatter.MessageBrokers](./src/Chatter.MessageBrokers/src/README.md#chatter-messagebrokers).  
+Chatter is a suite of modular .NET libraries for building domain-driven Web APIs and microservices. It pairs an in-process **CQRS + mediator** core with **technology-agnostic message broker** infrastructure, so the same Command/Event handlers serve both internal dispatch and cross-service integration over the transport of your choice.
 
+## Architecture at a glance
 
-##### <a name="intro-cqrs"></a> Chatter.Cqrs 
+```
+                        ┌─────────────────────────────┐
+                        │        Chatter.CQRS         │  in-process mediator:
+                        │  Commands · Queries · Events │  dispatch & handle
+                        │      + Command Pipeline      │
+                        └──────────────┬──────────────┘
+                                       │ built on
+                        ┌──────────────▼──────────────┐
+                        │    Chatter.MessageBrokers    │  technology-agnostic
+                        │  receive · send · route ·    │  brokered messaging
+                        │  inbox/outbox · recovery     │
+                        └──────┬───────────────┬───────┘
+              implements       │               │      reliability port
+        ┌────────────────┬─────┘               └─────────────┐
+        ▼                ▼                                    ▼
+ AzureServiceBus   SqlServiceBroker              Reliability.EntityFramework
+   (+ .Auth AAD)     (SQL Server)                 (durable EF inbox/outbox)
 
-[Chatter.CQRS](./src/Chatter.CQRS/src/README.md#chatter-cqrs) enables the implementation of a CQRS architecture through the use of the mediator pattern. 
-Commands are used to change the state of an aggregate, while Queries are used to retrieve data or "read models". 
-In addition, the CQRS library allows the dispatching and handling of Events. Events originate as "Domain Events" 
-from an API's internal aggregate(s) and once dispatched, may be handled within the originating domain or published as
-"Integration Events" so that other APIs or Microservices can subscribe and take action. Dispatching and subscribing to "Integration Events"
-requires the use of message broker infrastructure which is accomplished through leveraging [Chatter.MessageBrokers](#####intro-messagebrokers).
+ Chatter.SqlChangeFeed — emits SQL Server row-change notifications (Service Broker)
+```
 
-The CQRS library also exposes "Command Pipeline" functionality which allows implementation of cross-cutting concerns
-applied across all command handlers, such as logging.
+Chatter.MessageBrokers defines the transport interfaces; you pick a concrete implementation (**Azure Service Bus** or **SQL Server Service Broker**) and, optionally, durable reliability storage (**Entity Framework**). A 'from scratch' walkthrough lives in the [samples](./samples/README.md).
 
+## Modules
 
-##### <a name="intro-messagebrokers"></a> Chatter.MessageBrokers
+### [Chatter.CQRS](./src/Chatter.CQRS/src/README.md#chatter-cqrs)
+`dotnet add package Chatter.CQRS`
 
-[Chatter.MessageBrokers](./src/Chatter.MessageBrokers/src/README.md#chatter-messagebrokers) exposes technology agnostic message broker functionality.
-At its core, it enables the dispatching and subscribing of messages to message broker infrastructure, however, it also exposes advanced messaging functionality,
-such as sagas, inbox, outbox, routing slips, etc. It is built on top of [Chatter.CQRS](#####intro-cqrs), leveraging the message dispatching and Command and Event handling
-capabilities that it exposes. Brokered messages recieved from the infrastructure are relayed (dispatched) to Command or Event handlers, depending on the type of messages
-received, giving a unified message handling experience for messages that originate internally or from external systems.
+A lightweight CQRS framework that dispatches Commands, Queries, and Events to their handlers via an in-process mediator, with automatic assembly-scanning registration and an optional command behavior pipeline.
 
-As mentioned, Chatter.MessageBrokers is technology/infrastructure agnostic, so it exposes interfaces that must be implemented for the message broker
-infrastructure of choice. [Chatter.MessageBrokers.AzureServiceBus](./src/Chatter.MessageBrokers.AzureServiceBus/src/README.md#chatter-azureservicebus)
-is one such implementation for Azure Service Bus.
+- Commands → a single `IMessageHandler<TCommand>`; Events → fan-out to many handlers; Queries → `IQueryHandler<TQuery,TResult>`.
+- Marker-based message model (`IMessage`, `ICommand`, `IEvent`, `IQuery<T>`) with automatic handler discovery.
+- Composable cross-cutting **Command Pipeline** via `ICommandBehavior<TMessage>`.
+- Extensible per-dispatch **Message Context**.
+- Entry point: `services.AddChatterCqrs(...)`.
 
-The advanced features mentioned earlier often require other types of infrastructure, such as persistance. Interfaces exist which when implemented using
-the technology/infrastructure of choice and will enable seamless integration with Chatter.
+### [Chatter.MessageBrokers](./src/Chatter.MessageBrokers/src/README.md#chatter-messagebrokers)
+`dotnet add package Chatter.MessageBrokers`
 
-A step-by-step guide for creating a 'from scratch' scenario can be found [here](./samples/README.md). The scenario creates two brand new .NET Core Web APIs from scratch
-and Chatter is used to facilitate communication between them.
+Technology-agnostic brokered messaging built on Chatter.CQRS — receiving, sending/publishing/forwarding, routing, reliability, and recovery. Requires a concrete broker implementation for the transport.
 
+- Single-instance background-service receiver per message type marked with `[BrokeredMessage(...)]`, dispatching to your existing CQRS handlers.
+- Unified outbound `IBrokeredMessageDispatcher` (Send / Publish / Forward) + in-memory dispatch.
+- **Inbox** (idempotent once-only handling) and **Outbox** (reliable publish) patterns.
+- **Recovery**: retry, circuit breaker, max-receives-exceeded → Error Queue, Critical Failure events.
+- **Routing Slips** for itinerary-style choreography.
+- Entry point: `IChatterBuilder.AddMessageBrokers(...)`.
 
-# Table of Contents
+### [Chatter.MessageBrokers.AzureServiceBus](./src/Chatter.MessageBrokers.AzureServiceBus/src/README.md#chatter-azureservicebus)
+`dotnet add package Chatter.MessageBrokers.AzureServiceBus`
 
-##### Library Docs
+The Azure Service Bus transport for Chatter.MessageBrokers — concrete senders and receivers (queues for commands, topic subscriptions for events) wired into the broker abstraction.
 
-* [Chatter.CQRS](./src/Chatter.CQRS/src/README.md#chatter-cqrs)
-* [Chatter.MessageBrokers](./src/Chatter.MessageBrokers/src/README.md#chatter-messagebrokers)
-* [Chatter.MessageBrokers.AzureServiceBus](./src/Chatter.MessageBrokers.AzureServiceBus/src/README.md#chatter-azureservicebus)
+- `AddQueueReceiver<TMessage>` (commands) and `AddTopicSubscription<TMessage>` (events), each with error-queue path and max-receive attempts.
+- Options in code or from config (`Chatter:Infrastructure:AzureServiceBus`): connection, concurrency, prefetch, retry policy.
+- ASB-aware transient-exception detection feeding the core retry/circuit-breaker recovery.
+- Entry point: `IChatterBuilder.AddAzureServiceBus(...)` (chained off `AddMessageBrokers`).
 
-##### Getting Started
+### [Chatter.MessageBrokers.AzureServiceBus.Auth](./src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/README.md#chatter-azureservicebus-auth)
+`dotnet add package Chatter.MessageBrokers.AzureServiceBus.Auth`
 
-* [Building a 'from scratch' scenario](./samples/README.md)
+Azure Active Directory token authentication for the Azure Service Bus broker — connect with AAD bearer tokens (or `DefaultAzureCredential`) instead of a connection-string shared key.
 
+- Opt-in builder extensions: client-secret, client-certificate (X509 thumbprint), and interactive auth.
+- Automatic fallback to `DefaultAzureCredential` (managed identity, env, Azure CLI) when no explicit credential is given.
+- Applied only when the connection string carries no SAS key — additive by design.
+- Entry point: `ServiceBusOptionsBuilder.UseAadTokenProviderWith...` (inside `AddAzureServiceBus`).
 
+### [Chatter.MessageBrokers.SqlServiceBroker](./src/Chatter.MessageBrokers.SqlServiceBroker/src/README.md#chatter-sqlservicebroker)
+`dotnet add package Chatter.MessageBrokers.SqlServiceBroker`
 
+A SQL Server Service Broker transport for Chatter.MessageBrokers — sends and receives brokered messages over Service Broker dialogs, with no external broker dependency.
+
+- `SqlServiceBrokerReceiver`/`SqlServiceBrokerSender` over `BEGIN DIALOG` / `SEND` / `WAITFOR RECEIVE`.
+- Fluent options: connection, `WAITFOR` timeout, conversation lifetime/encryption, gzip body compression, dead-letter routing.
+- SQL-aware transient-exception predicates feeding the core retry/circuit-breaker recovery.
+- **Does not auto-provision** Service Broker objects — queues, services, contracts, and `ENABLE_BROKER` are set up manually.
+- Entry point: `IChatterBuilder.AddSqlServiceBroker(...)` (chained off `AddMessageBrokers`).
+
+### [Chatter.MessageBrokers.Reliability.EntityFramework](./src/Chatter.MessageBrokers.Reliability.EntityFramework/src/README.md#chatter-reliability-entityframework)
+`dotnet add package Chatter.MessageBrokers.Reliability.EntityFramework`
+
+EF Core implementation of the Chatter.MessageBrokers reliability ports — durable inbox, transactional outbox, and unit of work backed by your own `DbContext`, replacing the in-memory defaults.
+
+- Idempotent inbox keyed on `MessageId`; transactional outbox writing in the same DB transaction as domain state.
+- Atomic `UnitOfWork<TContext>` over EF execution strategies, exposed via `IPersistanceTransaction`.
+- Ships `IEntityTypeConfiguration` types applied in your `DbContext.OnModelCreating` — messaging tables live alongside domain tables.
+- Entry point: `CommandPipelineBuilder.WithInboxBehavior<TContext>()` / `WithOutboxProcessingBehavior<TContext>()` / `WithUnitOfWorkBehavior<TContext>()`.
+
+### [Chatter.SqlChangeFeed](./src/Chatter.SqlChangeFeed/src/README.md#chatter-sqlchangefeed)
+`dotnet add package Chatter.SqlChangeFeed`
+
+Emits strongly-typed notifications when rows in a watched SQL Server table are inserted, updated, or deleted — trigger-based via SQL Server Service Broker, no polling. (Formerly *Table Watcher*.)
+
+- Default fan-out to `RowInsertedEvent<T>` / `RowUpdatedEvent<T>` / `RowDeletedEvent<T>`, handled through `IMessageHandler<T>`.
+- Opt-in manual mode delivering the raw `ProcessChangeFeedCommand<T>` batch.
+- Selectable change types (`Insert | Update | Delete`), schema/database overrides, dead-letter and compression options.
+- Manual, idempotent SQL provisioning via `UseChangeFeedSqlMigrations<T>`.
+- Entry point: `IChatterBuilder.AddSqlChangeFeed<TRowChangedData>(...)`.
+
+## Getting started
+
+1. Install **Chatter.CQRS** and register it: `services.AddChatterCqrs(...)`.
+2. To exchange messages across services, add **Chatter.MessageBrokers** plus a transport — **AzureServiceBus** or **SqlServiceBroker**.
+3. For durable reliability, add **Reliability.EntityFramework** and apply its entity configurations to your `DbContext`.
+4. Walk through a complete two-API scenario in the [samples](./samples/README.md).
+
+Each module's README (linked above) has installation, configuration, and worked examples.
+
+## Domain language
+
+Chatter's ubiquitous language is documented per bounded context — see [CONTEXT-MAP.md](./CONTEXT-MAP.md) and the `CONTEXT.md` in each module directory.
+
+## Building & testing
+
+```
+dotnet test
+```

--- a/src/Chatter.CQRS/CONTEXT.md
+++ b/src/Chatter.CQRS/CONTEXT.md
@@ -24,15 +24,20 @@ _Avoid_: middleware.
 
 **Message Context**: Per-dispatch contextual data flowing alongside a message through dispatch and handling.
 
-**Dispatcher**: The component that routes a message to its registered handler(s).
+**Message Dispatcher**: Routes a Command (to one handler) or an Event (to many) — `IMessageDispatcher`.
 _Avoid_: mediator (used as the pattern name, not the type).
+
+**Query Dispatcher**: Routes a Query to its `IQueryHandler<TQuery,TResult>` — `IQueryDispatcher`, separate from the Message Dispatcher.
+
+**External Dispatcher**: The outbound-publish seam (`IExternalDispatcher`), a no-op by default (`NoOpExternalDispatcher`); a broker module replaces it to publish Integration Events.
 
 ## Relationships
 
 - An Aggregate is changed by Commands and produces Domain Events.
 - A Command is dispatched to exactly one handler; an Event fans out to many.
+- Commands and Events go through the Message Dispatcher; Queries go through the separate Query Dispatcher.
 - A Command Pipeline wraps all Command handlers.
-- A Domain Event may be promoted to an Integration Event for cross-service publish.
+- A Domain Event may be promoted to an Integration Event, published outward via the External Dispatcher (replaced by a broker module).
 - Message Context accompanies every dispatch through the pipeline and handlers.
 
 ## Example dialogue

--- a/src/Chatter.CQRS/CONTEXT.md
+++ b/src/Chatter.CQRS/CONTEXT.md
@@ -1,0 +1,45 @@
+# Chatter.CQRS
+
+CQRS architecture via the mediator pattern: dispatch and handling of Commands, Queries, and Events.
+
+## Language
+
+**Command**: A message that changes the state of an aggregate, dispatched to exactly one handler.
+
+**Query**: A message that retrieves data (a read model) without mutating state.
+_Avoid_: read request.
+
+**Read Model**: The data shape returned by a Query, optimized for retrieval rather than mutation.
+
+**Event**: A message representing something that happened, dispatchable to zero or many handlers.
+
+**Domain Event**: An Event originating from an internal aggregate, handled within the originating domain.
+
+**Integration Event**: An Event published outward so other APIs or microservices can subscribe (requires broker infrastructure — see Message Brokers context).
+
+**Aggregate**: A domain consistency boundary whose state changes via Commands and which emits Domain Events.
+
+**Command Pipeline**: An ordered chain applying cross-cutting concerns (e.g. logging) across all command handlers.
+_Avoid_: middleware.
+
+**Message Context**: Per-dispatch contextual data flowing alongside a message through dispatch and handling.
+
+**Dispatcher**: The component that routes a message to its registered handler(s).
+_Avoid_: mediator (used as the pattern name, not the type).
+
+## Relationships
+
+- An Aggregate is changed by Commands and produces Domain Events.
+- A Command is dispatched to exactly one handler; an Event fans out to many.
+- A Command Pipeline wraps all Command handlers.
+- A Domain Event may be promoted to an Integration Event for cross-service publish.
+- Message Context accompanies every dispatch through the pipeline and handlers.
+
+## Example dialogue
+
+> **Dev:** "Should this be a Command or an Event?"
+> **Domain expert:** "If it instructs the aggregate to change state and has one owner, it's a Command. If it announces that state already changed and others may react, it's an Event."
+
+## Flagged ambiguities
+
+None detected during bootstrap.

--- a/src/Chatter.CQRS/src/README.md
+++ b/src/Chatter.CQRS/src/README.md
@@ -1,1 +1,241 @@
 # <a name="chatter-cqrs"></a> Chatter.CQRS
+
+A lightweight CQRS framework for .NET that dispatches Commands, Queries, and Events to their handlers via the mediator pattern.
+
+## Overview
+
+Chatter.CQRS is the foundational module of the Chatter library suite. It implements **Command Query Responsibility Segregation (CQRS)** using an in-process **mediator** pattern: instead of calling handler classes directly, your code dispatches messages and the framework routes each one to the registered handler(s).
+
+The module distinguishes three kinds of message, all of which derive from the `IMessage` marker interface:
+
+- **Commands** (`ICommand`) — instruct an aggregate to change state; dispatched to exactly **one** handler.
+- **Queries** (`IQuery<T>`) — retrieve a read model without mutating state; dispatched to exactly one handler that returns a result.
+- **Events** (`IEvent`) — announce that something happened; fanned out to **zero or many** handlers.
+
+Handlers are discovered automatically by assembly scanning (powered by [Scrutor](https://github.com/khellang/Scrutor)) and registered into the standard `Microsoft.Extensions.DependencyInjection` container. Commands additionally flow through an optional **command pipeline** of cross-cutting behaviors.
+
+## Installation
+
+```bash
+dotnet add package Chatter.CQRS
+```
+
+## Getting Started
+
+### 1. Register Chatter.CQRS with DI
+
+The entry point is the `AddChatterCqrs` extension method on `IServiceCollection`. It scans the supplied assemblies for handlers and wires up the dispatchers. Several overloads control how handler assemblies are located:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+// Locate handler assemblies via marker types (the assembly each type lives in is scanned)
+services.AddChatterCqrs(configuration, typeof(CreateOrderHandler), typeof(SomeOtherHandler));
+
+// ...or pass explicit assemblies
+services.AddChatterCqrs(configuration, typeof(Program).Assembly);
+
+// ...or select assemblies by namespace/assembly-name with '*' and '?' wildcards
+services.AddChatterCqrs(configuration, "MyApp.*");
+
+// ...or use the full builder form with a command pipeline + assembly source filter
+services.AddChatterCqrs(
+    configuration,
+    pipelineBuilder: pipeline => pipeline.WithBehavior(typeof(LoggingBehavior<>)),
+    messageHandlerSourceBuilder: source => source.WithMarkerTypes(typeof(CreateOrderHandler)));
+```
+
+`AddChatterCqrs` returns an `IChatterBuilder`, which exposes the `Services`, `Configuration`, and `AssemblySourceFilter` used by other Chatter modules (such as the message brokers) to extend the registration.
+
+### 2. Define a command and its handler
+
+```csharp
+using Chatter.CQRS;
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using System.Threading.Tasks;
+
+public class CreateOrder : ICommand
+{
+    public string CustomerId { get; set; }
+    public decimal Total { get; set; }
+}
+
+public class CreateOrderHandler : IMessageHandler<CreateOrder>
+{
+    public Task Handle(CreateOrder message, IMessageHandlerContext context)
+    {
+        // ... change aggregate state
+        return Task.CompletedTask;
+    }
+}
+```
+
+### 3. Dispatch the command
+
+Inject `IMessageDispatcher` and dispatch:
+
+```csharp
+public class OrdersController
+{
+    private readonly IMessageDispatcher _dispatcher;
+
+    public OrdersController(IMessageDispatcher dispatcher)
+        => _dispatcher = dispatcher;
+
+    public Task Post(CreateOrder command)
+        => _dispatcher.Dispatch(command);
+}
+```
+
+## Core Concepts
+
+### Messages
+
+`IMessage` is the root marker interface. `ICommand` and `IEvent` both extend it. Queries use the separate `IQuery` / `IQuery<T>` markers.
+
+### Commands
+
+A `ICommand` is dispatched through `IMessageDispatcher` to a single `IMessageHandler<TCommand>`. During scanning, command handlers are registered with a *replace* strategy, enforcing that a command resolves to exactly one handler.
+
+```csharp
+Task Dispatch<TMessage>(TMessage message) where TMessage : IMessage;
+Task Dispatch<TMessage>(TMessage message, IMessageHandlerContext messageHandlerContext) where TMessage : IMessage;
+```
+
+### Queries and Read Models
+
+A query implements `IQuery<TResult>`, where `TResult` is the read model returned. Query handlers implement `IQueryHandler<TQuery, TResult>` and are dispatched through `IQueryDispatcher`:
+
+```csharp
+public class GetOrderById : IQuery<OrderReadModel>
+{
+    public string OrderId { get; set; }
+}
+
+public class GetOrderByIdHandler : IQueryHandler<GetOrderById, OrderReadModel>
+{
+    public Task<OrderReadModel> Handle(GetOrderById query, IQueryHandlerContext context)
+        => Task.FromResult(new OrderReadModel(/* ... */));
+}
+```
+
+```csharp
+public class OrdersService
+{
+    private readonly IQueryDispatcher _queries;
+    public OrdersService(IQueryDispatcher queries) => _queries = queries;
+
+    public Task<OrderReadModel> Get(string id)
+        => _queries.Query(new GetOrderById { OrderId = id });
+}
+```
+
+`IQueryDispatcher` offers overloads that take the query alone or with an explicit `IQueryHandlerContext`, and strongly-typed `Query<TQuery, TResult>` forms.
+
+### Events: Domain vs Integration
+
+An `IEvent` is dispatched through the same `IMessageDispatcher` but is fanned out to **all** registered `IMessageHandler<TEvent>` handlers (event handlers are appended during scanning rather than replaced). Handlers are invoked sequentially.
+
+- A **Domain Event** is handled in-process within the originating domain.
+- An **Integration Event** is published outward to other services. Cross-service publishing requires broker infrastructure provided by the Chatter Message Brokers modules.
+
+```csharp
+public class OrderCreated : IEvent
+{
+    public string OrderId { get; set; }
+}
+
+public class SendConfirmationEmail : IMessageHandler<OrderCreated>
+{
+    public Task Handle(OrderCreated message, IMessageHandlerContext context)
+        => /* ... */ Task.CompletedTask;
+}
+```
+
+### Message Context
+
+Every dispatch carries a context object that flows alongside the message through the pipeline and into handlers:
+
+- `IMessageHandlerContext` (concrete: `MessageHandlerContext`) is passed to message handlers and exposes a `CancellationToken`.
+- `IQueryHandlerContext` (concrete: `QueryHandlerContext`) is passed to query handlers.
+
+Both implement `IContainContext`, which exposes a `ContextContainer Container`. The container is an extensible, type-keyed bag for attaching arbitrary contextual data:
+
+```csharp
+public Task Handle(CreateOrder message, IMessageHandlerContext context)
+{
+    // store
+    context.Container.Include(new TenantInfo("acme"));
+
+    // retrieve
+    var tenant = context.Container.Get<TenantInfo>();
+    if (context.Container.TryGet<TenantInfo>(out var t)) { /* ... */ }
+
+    // get-or-create helpers
+    var settings = context.Container.GetOrNew<Settings>();
+
+    return Task.CompletedTask;
+}
+```
+
+A `ContextContainer` can be created with an inherited container, in which case lookups fall through to the parent. When you dispatch without supplying a context, `MessageDispatcher` creates a fresh `MessageHandlerContext` and seeds the container with the active `IMessageDispatcher` and `IExternalDispatcher`.
+
+### Dispatch
+
+`IMessageDispatcher` is the unified entry point for both commands and events. Internally it resolves the correct `IDispatchMessages` implementation (`CommandDispatcher` for `ICommand`, `EventDispatcher` for `IEvent`) via the `IMessageDispatcherProvider`, based on the message type. `IQueryDispatcher` handles queries separately.
+
+The default in-memory dispatchers are registered automatically by `AddChatterCqrs` (and are also available via `AddInMemoryMessageDispatchers()` / `AddInMemoryQueryDispatcher()`).
+
+## Command Pipeline
+
+Commands can be wrapped in an ordered chain of cross-cutting **behaviors** — the equivalent of middleware for command handling (e.g. logging, validation, transactions). A behavior implements `ICommandBehavior<TMessage>`:
+
+```csharp
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.CQRS.Pipeline;
+using System.Threading.Tasks;
+
+public class LoggingBehavior<TMessage> : ICommandBehavior<TMessage> where TMessage : ICommand
+{
+    public async Task Handle(TMessage message, IMessageHandlerContext context, CommandHandlerDelegate next)
+    {
+        // before the handler / next behavior
+        await next();
+        // after
+    }
+}
+```
+
+`next` is a `CommandHandlerDelegate` that invokes the next behavior in the chain, ending with the actual command handler. Behaviors execute in registration order (the pipeline composes them so the first-registered behavior is the outermost).
+
+Add behaviors when registering, via the `CommandPipelineBuilder`:
+
+```csharp
+services.AddChatterCqrs(
+    configuration,
+    pipelineBuilder: pipeline =>
+    {
+        // open-generic behavior applied to ALL commands
+        pipeline.WithBehavior(typeof(LoggingBehavior<>));
+        // closed-generic behavior scoped to one command
+        pipeline.WithBehavior(typeof(ValidateCreateOrderBehavior));
+    },
+    messageHandlerSourceBuilder: source => source.WithMarkerTypes(typeof(CreateOrderHandler)));
+```
+
+Under the hood the pipeline is `ICommandBehaviorPipeline<TMessage>` (default implementation `CommandBehaviorPipeline<TMessage>`). When a command is dispatched, `CommandDispatcher` runs the pipeline if one exists; otherwise it invokes the handler directly.
+
+You can also register behaviors directly on the `IServiceCollection`:
+
+```csharp
+services.AddPipelineBehavior(typeof(LoggingBehavior<>)); // open generic → all commands
+services.AddPipelineBehavior(typeof(ValidateCreateOrderBehavior)); // closed generic → one command
+```
+
+## Domain Language
+
+Terms such as Command, Query, Read Model, Event (Domain vs Integration), Aggregate, Command Pipeline, Message Context, and Dispatcher follow the project's ubiquitous language. See [../CONTEXT.md](../CONTEXT.md) for the full glossary and relationships.
+
+[← All Chatter modules](../../../README.md)

--- a/src/Chatter.MessageBrokers.AzureServiceBus.Auth/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus.Auth/CONTEXT.md
@@ -4,15 +4,19 @@ Azure Active Directory token-based authentication for the Azure Service Bus brok
 
 ## Language
 
-**AAD Token Provider**: Supplies Azure Active Directory access tokens used to authenticate the Service Bus connection.
+**AAD Token Provider**: Supplies Azure Active Directory access tokens (scoped to `https://servicebus.azure.net/.default`) used to authenticate the Service Bus connection — `AzureActiveDirectoryTokenProvider`.
 _Avoid_: credential provider.
 
-**Token Provider Factory**: Builds an AAD Token Provider from configured options.
+**Token Provider Factory**: Builds an AAD Token Provider from configured options (`AadTokenProviderFactory`), via MSAL confidential-client.
+
+**Credential Mode**: How the token is acquired — client-secret, client-certificate (X509 thumbprint), or interactive (`UseAadTokenProviderWithSecret` / `WithCert` / `Interactively`).
+
+**Default Credential Fallback**: When no explicit credential is supplied, `DefaultAzureCredential` is used (managed identity, env, Azure CLI, etc.).
 
 ## Relationships
 
-- Supplies credentials to the Azure Service Bus context's connection.
-- Wired in via Service Bus Options builder extensions.
+- Supplies credentials to the Azure Service Bus context's connection, applied only when the connection string carries no SAS token/key.
+- Wired in via Service Bus Options builder extensions (a Credential Mode method).
 
 ## Example dialogue
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus.Auth/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus.Auth/CONTEXT.md
@@ -1,0 +1,24 @@
+# Chatter.MessageBrokers.AzureServiceBus.Auth
+
+Azure Active Directory token-based authentication for the Azure Service Bus broker.
+
+## Language
+
+**AAD Token Provider**: Supplies Azure Active Directory access tokens used to authenticate the Service Bus connection.
+_Avoid_: credential provider.
+
+**Token Provider Factory**: Builds an AAD Token Provider from configured options.
+
+## Relationships
+
+- Supplies credentials to the Azure Service Bus context's connection.
+- Wired in via Service Bus Options builder extensions.
+
+## Example dialogue
+
+> **Dev:** "Can I connect to Service Bus without a connection-string secret?"
+> **Domain expert:** "Yes — register the AAD Token Provider; the Token Provider Factory issues Azure AD tokens for the connection instead of a shared key."
+
+## Flagged ambiguities
+
+None detected during bootstrap.

--- a/src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/README.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/README.md
@@ -1,1 +1,68 @@
 # <a name="chatter-azureservicebus-auth"></a> Chatter.MessageBrokers.AzureServiceBus.Auth
+
+Azure Active Directory (AAD) token-based authentication for the Chatter Azure Service Bus broker.
+
+## Overview
+
+`Chatter.MessageBrokers.AzureServiceBus.Auth` lets the [Chatter.MessageBrokers.AzureServiceBus](../../../README.md#chatter-azureservicebus) broker authenticate to Azure Service Bus with **Azure Active Directory access tokens** instead of a connection-string shared-access key (SAS).
+
+Instead of embedding a `SharedAccessKey`/`SharedAccessSignature` in the connection string, you supply a service-principal client ID (and a secret, certificate, or interactive redirect URI). The package builds an `AzureActiveDirectoryTokenProvider` that acquires bearer tokens scoped to `https://servicebus.azure.net/.default` and hands them to the Service Bus connection. When no explicit credential is supplied, it falls back to `DefaultAzureCredential` (managed identity, environment, Azure CLI, etc.), so the same code works locally and in Azure-hosted environments.
+
+The package extends the `ServiceBusOptionsBuilder` exposed by the base broker — you opt in by calling one of the `UseAadTokenProvider*` extension methods. The base broker only applies the token provider when the configured connection string does **not** already contain a SAS token or key, so AAD auth is purely additive.
+
+## Installation
+
+```sh
+dotnet add package Chatter.MessageBrokers.AzureServiceBus.Auth
+```
+
+## Getting Started
+
+Enable AAD auth inside the `AddAzureServiceBus` options builder. Supply a connection string **without** a shared-access key (just the `Endpoint`), then call one of the `UseAadTokenProvider*` extensions:
+
+```csharp
+using Chatter.MessageBrokers;
+using Microsoft.Extensions.DependencyInjection;
+
+services.AddChatter()
+        .AddAzureServiceBus(sb =>
+        {
+            // Endpoint only — no SharedAccessKey/SharedAccessSignature
+            sb.WithConnectionString("Endpoint=sb://my-namespace.servicebus.windows.net/");
+
+            // Authenticate with an AAD app registration + client secret
+            sb.UseAadTokenProviderWithSecret(
+                clientId:     "00000000-0000-0000-0000-000000000000",
+                clientSecret: "<client-secret>",
+                authority:    "https://login.microsoftonline.com/<tenant-id>/");
+        });
+```
+
+Three extension methods are available on `ServiceBusOptionsBuilder`:
+
+- **`UseAadTokenProviderWithSecret(clientId, clientSecret, authority, optBuilder = null)`** — authenticate as a confidential client using a client secret.
+- **`UseAadTokenProviderWithCert(clientId, thumbPrint, authority, optBuilder = null, validCertsOnly = true)`** — authenticate using a client certificate located by thumbprint in the `CurrentUser`/`LocalMachine` `My` store. Set `validCertsOnly: false` for self-signed certs.
+- **`UseAadTokenProviderInteractively(clientId, redirectUri, optBuilder = null)`** — authenticate via an interactive flow using the supplied redirect URI.
+
+If the credential argument (`clientSecret` / `thumbPrint` / `redirectUri`) is null or whitespace, the provider falls back to `DefaultAzureCredential`. Use the optional `optBuilder` delegate to configure `DefaultAzureCredentialOptions` for that fallback:
+
+```csharp
+sb.UseAadTokenProviderWithSecret(
+    clientId:     "00000000-0000-0000-0000-000000000000",
+    clientSecret: null,                       // fall back to DefaultAzureCredential
+    authority:    "https://login.microsoftonline.com/<tenant-id>/",
+    optBuilder:   opts => opts.ManagedIdentityClientId = "<user-assigned-mi-client-id>");
+```
+
+## How It Works
+
+- **AAD Token Provider** — every extension method ultimately produces an `AzureActiveDirectoryTokenProvider` (from `Microsoft.Azure.ServiceBus.Primitives`). This is registered on the builder via `ServiceBusOptionsBuilder.AddTokenProvider(Func<ITokenProvider>)`, deferring construction until the options are built.
+- **`AadTokenProviderFactory`** — created with `AadTokenProviderFactory.Create(clientId)`, the factory exposes `WithSecret(...)`, `WithCert(...)`, and `WithInteractive(...)`, each returning a configured `AzureActiveDirectoryTokenProvider`. The factory pins the token request scope to `https://servicebus.azure.net/.default`.
+- **Token acquisition** — for explicit credentials the factory uses MSAL's `ConfidentialClientApplicationBuilder` (`AcquireTokenForClient`) to obtain the access token from the configured `authority`. With a certificate, it is resolved from the X509 store by thumbprint (throwing if not found). When no explicit credential is provided, it calls `DefaultAzureCredential.GetTokenAsync(...)` for the same scope.
+- **Connection wiring** — during `ServiceBusOptionsBuilder.Build()`, the token provider is assigned to the Service Bus options **only if** the connection string has no `SasToken` and no `SasKey`. The Service Bus connection then uses the issued AAD bearer token in place of a shared key.
+
+## Domain Language
+
+See the module domain glossary: [`../CONTEXT.md`](../CONTEXT.md).
+
+[← All Chatter modules](../../../README.md)

--- a/src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md
@@ -4,9 +4,11 @@ Azure Service Bus implementation of the Chatter.MessageBrokers interfaces for se
 
 ## Language
 
-**Service Bus Receiver**: Azure Service Bus realization of the Brokered Message Receiver, pulling from queues/topics.
+**Queue Receiver**: Receiver bound to an ASB queue for Commands (`AddQueueReceiver<TMessage>`).
 
-**Service Bus Sender**: Azure Service Bus realization of the message sender, publishing to queues/topics.
+**Topic Subscription**: Receiver bound to an ASB topic subscription for Events (`AddTopicSubscription<TMessage>`).
+
+**Service Bus Sender**: Azure Service Bus realization of the message sender, publishing to queues/topics; outbound handler API via `IMessageHandlerContext.AzureServiceBus()`.
 
 **Service Bus Options**: Configuration (connection, paths, retry, circuit breaker) for the Azure Service Bus connection.
 
@@ -17,6 +19,7 @@ Azure Service Bus implementation of the Chatter.MessageBrokers interfaces for se
 ## Relationships
 
 - Implements the receiver/sender/path interfaces defined in the Message Brokers context.
+- Commands map to a Queue Receiver; Events map to a Topic Subscription.
 - Service Bus Options configure recovery (Retry, Circuit Breaker) for receiving.
 - Authentication is supplied by the Azure Service Bus Auth context.
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md
@@ -1,0 +1,30 @@
+# Chatter.MessageBrokers.AzureServiceBus
+
+Azure Service Bus implementation of the Chatter.MessageBrokers interfaces for sending and receiving brokered messages.
+
+## Language
+
+**Service Bus Receiver**: Azure Service Bus realization of the Brokered Message Receiver, pulling from queues/topics.
+
+**Service Bus Sender**: Azure Service Bus realization of the message sender, publishing to queues/topics.
+
+**Service Bus Options**: Configuration (connection, paths, retry, circuit breaker) for the Azure Service Bus connection.
+
+**Service Bus Retry**: ASB-specific Retry recovery policy applied during receiving.
+
+**Service Bus Circuit Breaker**: ASB-specific Circuit Breaker recovery policy applied during receiving.
+
+## Relationships
+
+- Implements the receiver/sender/path interfaces defined in the Message Brokers context.
+- Service Bus Options configure recovery (Retry, Circuit Breaker) for receiving.
+- Authentication is supplied by the Azure Service Bus Auth context.
+
+## Example dialogue
+
+> **Dev:** "How do I point Chatter at my Service Bus namespace?"
+> **Domain expert:** "Configure Service Bus Options with the connection and paths; the Service Bus Receiver and Sender wire into the broker abstraction automatically."
+
+## Flagged ambiguities
+
+None detected during bootstrap.

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/README.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/README.md
@@ -1,1 +1,169 @@
 # <a name="chatter-azureservicebus"></a> Chatter.MessageBrokers.AzureServiceBus
+
+Azure Service Bus transport for the technology-agnostic `Chatter.MessageBrokers` abstractions.
+
+## Overview
+
+`Chatter.MessageBrokers.AzureServiceBus` is the Azure Service Bus (ASB) implementation of the broker-agnostic interfaces defined in `Chatter.MessageBrokers`. It plugs an ASB sender and receiver into the messaging infrastructure so that messages dispatched and handled through your `Chatter.CQRS` command/event handlers flow over Azure Service Bus queues and topic subscriptions.
+
+The core `Chatter.MessageBrokers` package registers the broker abstraction via `IChatterBuilder.AddMessageBrokers(...)`. This package adds an `AddAzureServiceBus(...)` extension on `IChatterBuilder` that wires the concrete ASB sending/receiving components and `ServiceBusOptions`, registering an `IMessagingInfrastructure` keyed to the `ASBMessageContext.InfrastructureType`.
+
+Key components registered:
+
+- `ServiceBusReceiver` / `ServiceBusReceiverFactory` — pulls messages from queues and topic subscriptions.
+- `ServiceBusMessageSender` / `ServiceBusMessageSenderFactory` / `BrokeredMessageSenderPool` — sends/publishes outbound messages.
+- `AzureServiceBusEntityPathBuilder` — resolves queue/topic/subscription/rule paths (`IBrokeredMessagePathBuilder`).
+- `ServiceBusRetryExceptionPredicatesProvider` / `ServiceBusCircuitBreakerExceptionPredicatesProvider` — feed ASB transient-exception detection into the Chatter retry and circuit-breaker recovery policies.
+
+## Installation
+
+```
+dotnet add package Chatter.MessageBrokers.AzureServiceBus
+```
+
+## Getting Started
+
+Register Chatter CQRS, the message broker abstraction, and then the Azure Service Bus transport. `AddAzureServiceBus` is chained off the `IChatterBuilder` returned by `AddMessageBrokers`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+services
+    .AddChatterCqrs(configuration)
+    .AddMessageBrokers()
+    .AddAzureServiceBus(asb =>
+    {
+        // connection can come from configuration (see Configuration below) or be set explicitly
+        asb.WithConnectionString(configuration.GetConnectionString("ServiceBus"));
+        asb.WithMaxConcurrentCalls(5);
+        asb.WithPrefetchCount(10);
+
+        // register the queues/subscriptions to receive from
+        asb.AddQueueReceiver<CreateOrder>("orders-queue");
+        asb.AddTopicSubscription<OrderCreated>("order-events-topic", "order-created-subscription");
+    });
+```
+
+If `WithConnectionString` is omitted, the builder reads `ServiceBusOptions` from configuration (default section `Chatter:Infrastructure:AzureServiceBus`) — see [Configuration](#configuration). A connection string from either source is required; otherwise `Build()` throws.
+
+### Receiving
+
+Receivers are registered while configuring options:
+
+```csharp
+// commands -> queue (TMessage : ICommand)
+asb.AddQueueReceiver<CreateOrder>(
+    queueName: "orders-queue",
+    errorQueuePath: "orders-error",
+    transactionMode: TransactionMode.ReceiveOnly,
+    maxReceiveAttempts: 10);
+
+// events -> topic subscription (TMessage : IEvent)
+asb.AddTopicSubscription<OrderCreated>(
+    topicName: "order-events-topic",
+    subscriptionName: "order-created-subscription",
+    maxReceiveAttempts: 10);
+```
+
+Received messages are dispatched to the matching `Chatter.CQRS` handler:
+
+```csharp
+public class CreateOrderHandler : IMessageHandler<CreateOrder>
+{
+    public Task Handle(CreateOrder message, IMessageHandlerContext context)
+    {
+        // handle the command
+        return Task.CompletedTask;
+    }
+}
+```
+
+### Sending
+
+Within a handler you can reach ASB-specific send/publish/forward operations via the `AzureServiceBus()` extension on `IMessageHandlerContext`, which returns an `IAzureServiceBusContextDispatcher`:
+
+```csharp
+using Chatter.CQRS.Context;
+
+public class OrderCreatedHandler : IMessageHandler<OrderCreated>
+{
+    public async Task Handle(OrderCreated message, IMessageHandlerContext context)
+    {
+        await context.AzureServiceBus()
+                     .Publish(new OrderShipped { OrderId = message.OrderId });
+    }
+}
+```
+
+`IAzureServiceBusContextDispatcher` composes the broker abstractions `IMessageBrokerContextPublisher`, `IMessageBrokerContextSender`, and `IMessageBrokerContextForwarder`.
+
+## Configuration
+
+`ServiceBusOptions` is bound from configuration when a connection string is not supplied in code. The default configuration section is `Chatter:Infrastructure:AzureServiceBus` (override with `UseConfig("Your:Section")`).
+
+```json
+{
+  "Chatter": {
+    "Infrastructure": {
+      "AzureServiceBus": {
+        "ConnectionString": "Endpoint=sb://your-namespace.servicebus.windows.net/;SharedAccessKeyName=...;SharedAccessKey=...",
+        "MaxConcurrentCalls": 1,
+        "PrefetchCount": 0,
+        "RetryPolicy": {
+          "MinimumBackoffInSeconds": 0,
+          "MaximumBackoffInSeconds": 0,
+          "DeltaBackoffInSeconds": 0,
+          "MaximumRetryCount": 0
+        }
+      }
+    }
+  }
+}
+```
+
+`ServiceBusOptions` properties:
+
+| Property | Default | Description |
+| --- | --- | --- |
+| `ConnectionString` | (required) | Azure Service Bus namespace connection string. |
+| `MaxConcurrentCalls` | `1` | Maximum number of messages processed concurrently. |
+| `PrefetchCount` | `0` | Number of messages eagerly fetched from the broker. |
+| `Policy` (`RetryPolicy`) | `RetryPolicy.Default` | ASB client-level retry policy derived from the `RetryPolicy` config section. |
+| `TokenProvider` | `NullTokenProvider` | AAD/token credential (see [Authentication](#authentication)). |
+
+The `RetryPolicy` configuration section maps to an ASB `RetryExponential` policy via `MinimumBackoffInSeconds`, `MaximumBackoffInSeconds`, `DeltaBackoffInSeconds`, and `MaximumRetryCount`. When all values are `0`, `RetryPolicy.NoRetry` is used; when the section is absent, `RetryPolicy.Default` applies.
+
+### `ServiceBusOptionsBuilder` methods
+
+The `AddAzureServiceBus(asb => ...)` delegate exposes a `ServiceBusOptionsBuilder`:
+
+| Method | Purpose |
+| --- | --- |
+| `WithConnectionString(string)` | Sets the namespace connection string in code. |
+| `WithMaxConcurrentCalls(int)` | Sets `MaxConcurrentCalls`. |
+| `WithPrefetchCount(int)` | Sets `PrefetchCount`. |
+| `WithNoRetry()` | Uses `RetryPolicy.NoRetry` for the ASB client. |
+| `WithExponentialDelay(maximumRetryCount, maximumBackoffInSeconds, minimumBackoffInSeconds, deltaBackoffInSeconds)` | Configures a `RetryExponential` client retry policy. |
+| `UseConfig(configSectionName)` | Binds `ServiceBusOptions` from the given configuration section (default `Chatter:Infrastructure:AzureServiceBus`). |
+| `AddTokenProvider(ITokenProvider)` / `AddTokenProvider(Func<ITokenProvider>)` | Supplies an AAD token provider (see [Authentication](#authentication)). |
+| `AddQueueReceiver<TMessage>(...)` | Registers a queue receiver for an `ICommand`. |
+| `AddTopicSubscription<TMessage>(...)` | Registers a topic subscription receiver for an `IEvent`. |
+
+### Retry and Circuit Breaker (receiving)
+
+Receive-side recovery is driven by the broker-agnostic retry and circuit-breaker policies in `Chatter.MessageBrokers.Recovery`. This package contributes ASB-aware transient-exception detection:
+
+- `ServiceBusRetryExceptionPredicatesProvider` (`IRetryExceptionPredicatesProvider`)
+- `ServiceBusCircuitBreakerExceptionPredicatesProvider` (`ICircuitBreakerExceptionPredicatesProvider`)
+
+Both treat the following as transient (when `IsTransient` is `true`): `ServiceBusException`, `ServiceBusCommunicationException`, `ServerBusyException`, and `ServiceBusTimeoutException`. The per-receiver `maxReceiveAttempts` (default `10`) bounds redelivery attempts before a message is routed to its configured `errorQueuePath`.
+
+## Authentication
+
+The connection string above uses SAS-based auth. Azure Active Directory (AAD) authentication — token providers such as managed identity / `ITokenProvider` integrations — is provided by the sibling package [`Chatter.MessageBrokers.AzureServiceBus.Auth`](#chatter-azureservicebus-auth). When a token provider is supplied (via `AddTokenProvider(...)`) and the connection string contains no SAS token/key, that token provider is used to authenticate to the namespace.
+
+## Domain Language
+
+See the [domain glossary](../CONTEXT.md) for definitions of Service Bus Receiver, Service Bus Sender, Service Bus Options, Service Bus Retry, and Service Bus Circuit Breaker.
+
+[← All Chatter modules](../../../README.md)

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/CONTEXT.md
@@ -14,8 +14,10 @@ EF Core persistence implementing the inbox/outbox reliability ports and unit-of-
 
 ## Relationships
 
-- Implements the Outbox and Inbox persistence ports defined in the Message Brokers context.
-- The Unit of Work commits domain changes together with Outbox/Inbox writes via a Persistance Transaction.
+- Implements the Outbox and Inbox persistence ports defined in the Message Brokers context, replacing their in-memory defaults.
+- All types are generic over the consumer's own `DbContext` (`TContext : DbContext`) — no separate Chatter context; entity configs are applied in the consumer's `OnModelCreating`.
+- Wired through the Command Pipeline as behaviors (`WithInboxBehavior<TContext>()`, `WithOutboxProcessingBehavior<TContext>()`, `WithUnitOfWorkBehavior<TContext>()`), not a standalone DI registration.
+- The Unit of Work commits domain changes together with Outbox/Inbox writes via a Persistance Transaction (`IPersistanceTransaction`).
 
 ## Example dialogue
 

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/CONTEXT.md
@@ -1,0 +1,27 @@
+# Chatter.MessageBrokers.Reliability.EntityFramework
+
+EF Core persistence implementing the inbox/outbox reliability ports and unit-of-work for Chatter.MessageBrokers.
+
+## Language
+
+**Brokered Message Outbox**: EF-backed store of outgoing messages, persisted in the same transaction as local state for reliable publish.
+
+**Brokered Message Inbox**: EF-backed store of received message ids enforcing once-only, idempotent handling.
+
+**Unit of Work**: Coordinates a single atomic commit spanning domain state and inbox/outbox writes.
+
+**Persistance Transaction**: The transaction abstraction wrapping the Unit of Work commit (note: spelled `Persistance` in code).
+
+## Relationships
+
+- Implements the Outbox and Inbox persistence ports defined in the Message Brokers context.
+- The Unit of Work commits domain changes together with Outbox/Inbox writes via a Persistance Transaction.
+
+## Example dialogue
+
+> **Dev:** "How do I guarantee the message publishes only if my DB write succeeds?"
+> **Domain expert:** "Write to the Brokered Message Outbox inside the same Unit of Work as your aggregate; the Persistance Transaction commits both or neither."
+
+## Flagged ambiguities
+
+- **Persistance** is misspelled in the codebase; keep the spelling when referencing the type, use _persistence_ in prose.

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/src/README.md
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/src/README.md
@@ -1,0 +1,147 @@
+# <a name="chatter-reliability-entityframework"></a> Chatter.MessageBrokers.Reliability.EntityFramework
+
+Durable EF Core inbox/outbox and unit-of-work for [Chatter.MessageBrokers](#chatter-messagebrokers).
+
+## Overview
+
+`Chatter.MessageBrokers.Reliability.EntityFramework` is the EF Core implementation of the reliability ports defined by [Chatter.MessageBrokers](#chatter-messagebrokers): the brokered message **inbox**, **outbox**, and **unit of work**. Out of the box Chatter wires these ports to in-memory defaults; registering this package **replaces those in-memory defaults with durable, relational storage** backed by your application's `DbContext`.
+
+This gives you:
+
+- **Idempotent (once-only) message handling** via a persisted inbox of processed message ids.
+- **Reliable publish** via the transactional outbox pattern — outgoing messages are written to your database in the *same* transaction as your domain state, then dispatched separately.
+- **Atomic units of work** that commit your domain changes and inbox/outbox writes together (or roll them all back) through a single EF transaction.
+
+Because the inbox, outbox, and unit of work all run against the same `DbContext`, your business state and the messaging bookkeeping share one transaction and one commit.
+
+## Installation
+
+```sh
+dotnet add package Chatter.MessageBrokers.Reliability.EntityFramework
+```
+
+The package targets `netstandard2.1`, `net5.0`, and `net6.0`, and pulls in `Microsoft.EntityFrameworkCore` / `Microsoft.EntityFrameworkCore.Relational` for the matching framework.
+
+## Getting Started
+
+Registration happens against the **command pipeline builder**, which Chatter exposes through the `pipelineBuilder` action on `AddChatterCqrs(...)` (the same `IChatterBuilder` you call `AddMessageBrokers(...)` on). Each extension method is generic over *your* `DbContext` type (`TContext : DbContext`).
+
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    // Register your DbContext as usual.
+    services.AddDbContext<MyDbContext>(opt =>
+        opt.UseSqlServer(Configuration.GetConnectionString("Chatter")));
+
+    services.AddChatterCqrs(Configuration, pipeline =>
+            {
+                // Replace the in-memory inbox with the durable EF inbox
+                // (idempotent / once-only handling).
+                pipeline.WithInboxBehavior<MyDbContext>();
+
+                // Process the EF outbox for reliable publish.
+                pipeline.WithOutboxProcessingBehavior<MyDbContext>();
+
+                // Or, to opt into transactional units of work only:
+                // pipeline.WithUnitOfWorkBehavior<MyDbContext>();
+            })
+            .AddMessageBrokers(/* message broker options */);
+}
+```
+
+The available pipeline extension methods (`Microsoft.Extensions.DependencyInjection.Extensions`):
+
+| Method | Effect |
+| --- | --- |
+| `WithUnitOfWorkBehavior<TContext>()` | Replaces `IUnitOfWork` with the EF `UnitOfWork<TContext>` (scoped) and adds the `UnitOfWorkBehavior`. |
+| `WithInboxBehavior<TContext>()` | Adds the unit of work, replaces `IBrokeredMessageInbox` with `BrokeredMessageInbox<TContext>`, and adds the `InboxBehavior`. |
+| `WithOutboxProcessingBehavior<TContext>()` | Adds the `OutboxProcessingBehavior`, replaces `IBrokeredMessageOutbox` with `BrokeredMessageOutbox<TContext>` and `IRouteBrokeredMessages` with the outbox router, and adds the unit of work. |
+
+### Configuring the DbContext
+
+The inbox and outbox entities — `InboxMessage` and `OutboxMessage` (from `Chatter.MessageBrokers.Reliability.Inbox` / `.Outbox`) — must be mapped onto your `DbContext`. This package ships `IEntityTypeConfiguration<>` classes for both. Apply them in `OnModelCreating`:
+
+```csharp
+using Chatter.MessageBrokers.Reliability.EntityFramework;
+using Chatter.MessageBrokers.Reliability.Inbox;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using Microsoft.EntityFrameworkCore;
+
+public class MyDbContext : DbContext
+{
+    public MyDbContext(DbContextOptions<MyDbContext> options) : base(options) { }
+
+    // Your own aggregates / tables also live here.
+    public DbSet<InboxMessage> InboxMessages { get; set; }
+    public DbSet<OutboxMessage> OutboxMessages { get; set; }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+
+        modelBuilder.ApplyConfiguration(new InboxMessageConfiguration());
+        modelBuilder.ApplyConfiguration(new OutboxMessageConfiguration());
+    }
+}
+```
+
+There is no separate "Chatter DbContext" — you supply your own, and the inbox/outbox tables live alongside your domain tables so they share the same transaction. Use EF migrations to create the tables.
+
+## Inbox & Outbox
+
+### Inbox (idempotency)
+
+`BrokeredMessageInbox<TContext>` enforces **once-only handling**. When a message arrives, the inbox checks for its `MessageId`:
+
+- If the id is already present, the handler is skipped (the message was already processed).
+- Otherwise the handler runs, and on success an `InboxMessage` row is added recording the id and `ReceivedByInboxAtUtc`.
+
+If the incoming message has no message id, the inbox simply executes the handler (no idempotency tracking is possible). The inbox add participates in the surrounding unit of work, so the handler's effects and the inbox record commit together.
+
+### Outbox (reliable publish)
+
+`BrokeredMessageOutbox<TContext>` implements the transactional outbox. Outgoing messages are serialized and written as `OutboxMessage` rows *inside the same transaction* as the work that produced them, so a message is never published unless the local state change commits. Each row captures the serialized body, message context (JSON), destination, content type, send time, and a `BatchId` (the current transaction id).
+
+Processing then drains the outbox separately:
+
+- `GetUnprocessedMessagesFromOutbox` / `GetUnprocessedBatch(batchId)` return rows whose `ProcessedFromOutboxAtUtc` is `null`.
+- After a row is dispatched, `UpdateProcessedDate` stamps `ProcessedFromOutboxAtUtc`. This column is an **optimistic concurrency token**, so two processors racing on the same row produce a `DbUpdateConcurrencyException` — the loser logs and treats the row as already processed rather than double-publishing.
+
+### Unit of Work / Persistance Transaction
+
+`UnitOfWork<TContext>` coordinates a single atomic commit. Its `ExecuteAsync` runs your operation inside an EF execution strategy: it begins a `ReadCommitted` transaction (reusing the ambient one if a transaction is already active), runs the operation, calls `SaveChangesAsync`, and commits — rolling back on any exception.
+
+The transaction itself is exposed through `IPersistanceTransaction`, implemented by `PersistanceTransaction`, which wraps EF's `IDbContextTransaction` and surfaces `TransactionId`, `CommitAsync`, and `RollbackAsync`. The current transaction is also published into the `TransactionContext` container so the outbox can stamp each message's `BatchId` with the active transaction id.
+
+> Note: the type is intentionally spelled **`Persistance`** (and `IPersistanceTransaction`) in the codebase. The README uses the correct English spelling _persistence_ in prose, but you must use `Persistance` when referencing the actual type.
+
+## Database Schema
+
+The entity configurations map two tables (table names default to the `DbSet`/entity names unless you override them).
+
+### Inbox — `InboxMessage`
+
+| Column | Type | Constraints |
+| --- | --- | --- |
+| `MessageId` | `string` | Primary key, required |
+| `ReceivedByInboxAtUtc` | `DateTime?` | When the message was recorded in the inbox |
+
+### Outbox — `OutboxMessage`
+
+| Column | Type | Constraints |
+| --- | --- | --- |
+| `Id` | `int` | Primary key, required, generated on add (identity) |
+| `MessageId` | `string` | Required |
+| `ProcessedFromOutboxAtUtc` | `DateTime?` | Nullable; **concurrency token**; `null` until dispatched |
+| `SentToOutboxAtUtc` | `DateTime` | Required |
+| `MessageBody` | `string` | Required; serialized message payload |
+| `MessageContext` | `string` | Required; JSON-serialized message context |
+| `MessageContentType` | `string` | Required |
+| `Destination` | `string` | Required |
+| `BatchId` | `Guid` | Required; the transaction id the message was written under |
+
+## Domain Language
+
+See [CONTEXT.md](../CONTEXT.md) for the domain glossary (Brokered Message Inbox/Outbox, Unit of Work, Persistance Transaction).
+
+[← All Chatter modules](../../../README.md)

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/CONTEXT.md
@@ -10,23 +10,24 @@ SQL Server Service Broker implementation of the Chatter.MessageBrokers interface
 
 **Queue**: The SQL Service Broker queue a message is received from or sent to.
 
-**Conversation**: A SQL Service Broker dialog over which messages flow between services.
+**Conversation**: A SQL Service Broker dialog over which messages flow between services (`BEGIN DIALOG` / `END CONVERSATION`).
 
-**Setup Scripts**: SQL scripts that provision the Service Broker objects (queues, services, message types).
+**Dialog Command**: A runtime SQL DML command this package issues to drive a conversation — `BeginDialogConversationCommand`, `SendOnConversationCommand`, `ReceiveMessageFromQueueCommand`, `EndDialogConversationCommand`. These do NOT create infrastructure.
+_Avoid_: setup script (this package provisions nothing).
 
-**Service Broker Options**: Configuration for the SQL connection, queue, and recovery policies.
+**Service Broker Options**: Configuration for the SQL connection, queue, recovery policies, conversation lifetime/encryption, and body compression.
 
 ## Relationships
 
 - Implements the receiver/sender interfaces defined in the Message Brokers context.
-- Setup Scripts provision the Queue and Conversation objects the Receiver/Sender depend on.
+- The Receiver/Sender drive an existing Queue and Conversation via Dialog Commands; they assume the SQL Service Broker objects already exist.
 - Recovery (Retry, Circuit Breaker) wraps receiving, mirroring the Message Brokers abstraction.
 
 ## Example dialogue
 
 > **Dev:** "Do I need to create the queues myself?"
-> **Domain expert:** "No — run the Setup Scripts; they provision the SQL Service Broker Queue and Conversation that the Service Broker Receiver reads from."
+> **Domain expert:** "Yes — this package issues only runtime Dialog Commands; you provision the Queue, service, contract, message types, and `ENABLE_BROKER` yourself. Automatic provisioning lives in the SQL Change Feed context, not here."
 
 ## Flagged ambiguities
 
-None detected during bootstrap.
+- **Provisioning ownership**: this package does NOT create Service Broker infrastructure (contrast with SQL Change Feed, which can provision via migrations).

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/CONTEXT.md
@@ -1,0 +1,32 @@
+# Chatter.MessageBrokers.SqlServiceBroker
+
+SQL Server Service Broker implementation of the Chatter.MessageBrokers interfaces for sending and receiving brokered messages.
+
+## Language
+
+**Service Broker Receiver**: SQL Service Broker realization of the Brokered Message Receiver, dequeuing via `RECEIVE`.
+
+**Service Broker Sender**: SQL Service Broker realization of the message sender, enqueuing onto a conversation/queue.
+
+**Queue**: The SQL Service Broker queue a message is received from or sent to.
+
+**Conversation**: A SQL Service Broker dialog over which messages flow between services.
+
+**Setup Scripts**: SQL scripts that provision the Service Broker objects (queues, services, message types).
+
+**Service Broker Options**: Configuration for the SQL connection, queue, and recovery policies.
+
+## Relationships
+
+- Implements the receiver/sender interfaces defined in the Message Brokers context.
+- Setup Scripts provision the Queue and Conversation objects the Receiver/Sender depend on.
+- Recovery (Retry, Circuit Breaker) wraps receiving, mirroring the Message Brokers abstraction.
+
+## Example dialogue
+
+> **Dev:** "Do I need to create the queues myself?"
+> **Domain expert:** "No — run the Setup Scripts; they provision the SQL Service Broker Queue and Conversation that the Service Broker Receiver reads from."
+
+## Flagged ambiguities
+
+None detected during bootstrap.

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/README.md
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/README.md
@@ -1,1 +1,120 @@
 # <a name="chatter-sqlservicebroker"></a> Chatter.MessageBrokers.SqlServiceBroker
+
+A SQL Server Service Broker transport for Chatter.MessageBrokers — send and receive brokered messages over SQL Service Broker dialogs.
+
+## Overview
+
+`Chatter.MessageBrokers.SqlServiceBroker` is a concrete, SQL Server Service Broker implementation of the technology-agnostic interfaces defined by [Chatter.MessageBrokers](../../Chatter.MessageBrokers/src/README.md#chatter-messagebrokers) (itself built on [Chatter.CQRS](../../Chatter.CQRS/src/README.md#chatter-cqrs)).
+
+Where the core library defines `IMessagingInfrastructureReceiver`, `IMessagingInfrastructureDispatcher`, and the recovery abstractions (retry, circuit breaker), this package supplies the SQL Service Broker realizations:
+
+- `SqlServiceBrokerReceiver` dequeues messages with `WAITFOR (RECEIVE ...)`.
+- `SqlServiceBrokerSender` enqueues messages by opening a dialog (`BEGIN DIALOG`), `SEND ON CONVERSATION`, and (optionally) `END CONVERSATION`.
+- `SqlCircuitBreakerExceptionPredicatesProvider` and `SqlRetryExceptionPredicatesProvider` teach the core recovery pipeline which SQL exceptions are transient.
+
+It registers itself with Chatter through an `IChatterBuilder` extension, `AddSqlServiceBroker(...)`, chained off `AddMessageBrokers(...)` — the same way the sibling `Chatter.MessageBrokers.AzureServiceBus` package adds `AddAzureServiceBus(...)`.
+
+## Installation
+
+```bash
+dotnet add package Chatter.MessageBrokers.SqlServiceBroker
+```
+
+## Getting Started
+
+Register Chatter CQRS, add message brokers, then add the SQL Service Broker infrastructure with a connection string. The DI entry point is `AddSqlServiceBroker` (in the `Microsoft.Extensions.DependencyInjection` namespace), configured via the `SqlServiceBrokerOptionsBuilder`.
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+services.AddChatterCqrs(Configuration, builder =>
+{
+    builder
+        .AddMessageBrokers()
+        .AddSqlServiceBroker(ssb =>
+        {
+            ssb.AddSqlServiceBrokerOptions(
+                    Configuration.GetValue<string>("ConnectionStrings:MyDatabase"))
+               // register a receiver for a message type bound to a Service Broker queue
+               .AddQueueReceiver<MyIntegrationEvent>("Chatter_Queue_MyIntegrationEvent");
+        });
+});
+```
+
+`AddQueueReceiver<TMessage>` binds a `Chatter.CQRS.IMessage` type to a Service Broker queue (the queue name is used as both the receive path and the message description). Optional parameters let you set an error/dead-letter service path, transaction mode, and `maxReceiveAttempts` (default `10`):
+
+```csharp
+ssb.AddQueueReceiver<MyIntegrationEvent>(
+    queueName: "Chatter_Queue_MyIntegrationEvent",
+    errorQueuePath: "Chatter_Service_DeadLetter",
+    transactionMode: TransactionMode.FullAtomicityViaInfrastructure,
+    deadLetterServicePath: "Chatter_Service_DeadLetter",
+    maxReceiveAttempts: 8);
+```
+
+### Sending / publishing
+
+Within a message handler, dispatch out through the broker using the standard Chatter context, or via the SQL Service Broker-specific dispatcher extension:
+
+```csharp
+using Chatter.CQRS.Context;
+
+public class MyHandler : IMessageHandler<SomeCommand>
+{
+    public Task Handle(SomeCommand message, IMessageHandlerContext context)
+    {
+        // SqlServiceBroker() returns an ISqlServiceBrokerContextDispatcher
+        return context.SqlServiceBroker()
+                      .Send(new AnotherCommand(), "Chatter_Service_AnotherCommand");
+    }
+}
+```
+
+The `context.SqlServiceBroker()` extension returns an `ISqlServiceBrokerContextDispatcher`, which exposes `Send`, `Publish`, and `Forward` and pins the outbound message to the SQL Service Broker infrastructure. The `destinationPath` is the **target Service Broker service** the sender opens a dialog *TO*.
+
+## Configuration
+
+Options are modeled by `SqlServiceBrokerOptions` and assembled with `SqlServiceBrokerOptionsBuilder`. Configure them either by passing values to `AddSqlServiceBrokerOptions(...)` or by using the fluent `With...`/`Use...` methods.
+
+| Property | Builder method | Default | Purpose |
+| --- | --- | --- | --- |
+| `ConnectionString` | `AddSqlServiceBrokerOptions(connectionString)` / `WithConnectionString(...)` | _(required)_ | SQL Server connection string used for all Service Broker communication. |
+| `MessageBodyType` | `WithMessageBodyType(...)` / `WithJsonBodyType()` | `application/json; charset=utf-16` | Content type used to encode/decode the message body. |
+| `ReceiverTimeoutInMilliseconds` | `WithReceiverTimeout(...)` | `-1` (wait indefinitely) | Timeout passed to `WAITFOR (RECEIVE ...)`. `-1` waits forever; an elapsed timeout yields an empty result. |
+| `ConversationLifetimeInSeconds` | `WithConversationLifetime(...)` | `0` (no `LIFETIME`) | Maximum time a dialog stays open (`BEGIN DIALOG ... WITH LIFETIME`). |
+| `ConversationEncryption` | `UseConversationEncryption()` | `false` | Whether dialog messages are encrypted when leaving the SQL Server instance. |
+| `CompressMessageBody` | `WithMessageBodyCompression()` | `true` | Gzip the body on send via T-SQL `compress(...)`; the receiver auto-decompresses when it detects the `0x1F8B` gzip header. |
+| `CleanupOnEndConversation` | `WithConversationCleanup()` | `false` | Issue `END CONVERSATION ... WITH CLEANUP` to forcibly drop conversations that cannot complete normally. |
+| `EndConversationAfterDispatch` | `EndConversationAfterDispatch(bool)` | `true` | When `true`, the sender ends the dialog after each dispatch (emits an `EndDialog` message). |
+
+`SqlServiceBrokerOptionsBuilder.Build()` throws if no options were configured, if the connection string is null/whitespace, or if the message body type is missing.
+
+Recovery (retry and circuit breaker) is supplied automatically: `AddSqlServiceBroker` registers `SqlRetryExceptionPredicatesProvider` and `SqlCircuitBreakerExceptionPredicatesProvider`, which classify SQL failures as transient (e.g. `SqlException.IsTransient` on net5.0+, known transient error numbers, and error `208` "invalid object name") so the core Chatter recovery pipeline retries or trips the breaker appropriately.
+
+## SQL Setup
+
+This package is a **transport over existing SQL Service Broker objects** — it does not provision them. At runtime it only emits Service Broker DML against the objects you have already created:
+
+| `Scripts/` command | T-SQL emitted | When |
+| --- | --- | --- |
+| `BeginDialogConversationCommand` | `BEGIN DIALOG ... FROM SERVICE ... TO SERVICE ... [ON CONTRACT ...] WITH ENCRYPTION = ON\|OFF [, LIFETIME ...]` | Sender, per outbound message. |
+| `SendOnConversationCommand` | `SEND ON CONVERSATION @handle [MESSAGE TYPE ...] (@body)` (wrapped in `compress(...)` when compression is on) | Sender, after the dialog opens. |
+| `EndDialogConversationCommand` | `END CONVERSATION @handle [WITH ERROR ... DESCRIPTION ...] [WITH CLEANUP]` | Sender (when `EndConversationAfterDispatch`), and receiver on ack/deadletter/`EndDialog`. |
+| `ReceiveMessageFromQueueCommand` | `WAITFOR (RECEIVE TOP(1) ... FROM <queue>) [, TIMEOUT ...]` | Receiver, to dequeue. |
+
+You are responsible for provisioning the Service Broker schema **manually** (or via your own migration tooling) before using this package. At minimum you need:
+
+- `ALTER DATABASE [Db] SET ENABLE_BROKER;` on the target database.
+- A **message type** and **contract** — the library tags Chatter-originated messages with message type `//Chatter/BrokeredMessage` and service contract `//Chatter` (see `ServicesMessageTypes`). It also accepts the built-in `DEFAULT` message type.
+- The **queues** you reference in `AddQueueReceiver<T>(queueName, ...)` (the receive path) and any dead-letter queue/service path you configure.
+- The **services** you send to (the `destinationPath` / target service supplied when sending).
+
+On receive, the library filters by message type: only `//Chatter/BrokeredMessage` and `DEFAULT` are surfaced to handlers; `http://schemas.microsoft.com/SQL/ServiceBroker/EndDialog` messages are acknowledged and ended, and any other type is discarded. The receiver also handles dialog lifecycle (ack = `END CONVERSATION`, nack = transaction rollback, deadletter = resend to the configured dead-letter service path).
+
+> Note: automatic provisioning of Service Broker objects (queues, services, contracts, message types, `ENABLE_BROKER`) lives in the separate `Chatter.SqlChangeFeed` package, not here.
+
+## Domain Language
+
+See the [domain glossary](../CONTEXT.md) for definitions of Service Broker Receiver, Service Broker Sender, Queue, Conversation, Setup Scripts, and Service Broker Options.
+
+[← All Chatter modules](../../../README.md)

--- a/src/Chatter.MessageBrokers/CONTEXT.md
+++ b/src/Chatter.MessageBrokers/CONTEXT.md
@@ -1,0 +1,53 @@
+# Chatter.MessageBrokers
+
+Technology-agnostic brokered messaging built on Chatter.CQRS: receiving, sending, routing, reliability, and recovery, with interfaces left to infrastructure-specific implementations.
+
+## Language
+
+**Brokered Message**: A message received from or sent to broker infrastructure, relayed (dispatched) to a Command or Event handler.
+
+**Brokered Message Receiver**: The component that consumes brokered messages from infrastructure; runs as a background service, capped at one instance.
+_Avoid_: consumer, listener.
+
+**Brokered Message Dispatcher**: Relays a received Brokered Message to the matching Command or Event handler.
+
+**Brokered Message Router**: Routes / forwards a brokered message to its destination path.
+_Avoid_: forwarder (a Router specialization).
+
+**Brokered Message Attribute**: Metadata declaration that maps a message type to its broker path/queue.
+
+**Outbox**: Persistence pattern recording outgoing messages for reliable publish alongside local state changes.
+
+**Inbox**: Persistence pattern recording received messages to enforce idempotent, once-only handling.
+
+**Routing Slip**: A message carrying its own itinerary of steps/destinations to visit in sequence.
+
+**Recovery**: Resilience policies applied to receiving — Retry and Circuit Breaker.
+
+**Circuit Breaker**: A recovery policy that halts processing after repeated failures.
+
+**Critical Failure**: An unrecoverable receive error; raises a Critical Failure Event and may route the message to the Error Queue.
+
+**Error Queue**: Destination for messages that exhausted recovery and cannot be handled.
+
+**Max Receives Exceeded**: The condition where a message has been delivered more times than allowed, triggering a configured action.
+
+**Body Converter**: Serializes/deserializes a brokered message body to/from a domain message type.
+
+## Relationships
+
+- A Brokered Message Receiver consumes infrastructure messages and hands them to the Brokered Message Dispatcher.
+- The Dispatcher relays to a Command or Event handler (Chatter.CQRS) by message type.
+- Recovery (Retry, Circuit Breaker) wraps receiving; exhausting it yields a Critical Failure routed to the Error Queue.
+- Outbox and Inbox depend on a persistence implementation (see Reliability EntityFramework context).
+- A Routing Slip drives a Router across a sequence of destinations.
+- Concrete brokers (Azure Service Bus, SQL Service Broker) implement the receiver/sender/path interfaces defined here.
+
+## Example dialogue
+
+> **Dev:** "A handler keeps throwing — where does the message end up?"
+> **Domain expert:** "Recovery retries it under the Circuit Breaker. Once Max Receives is exceeded it's a Critical Failure, so it's moved to the Error Queue and a Critical Failure Event fires."
+
+## Flagged ambiguities
+
+- **Router vs Forwarder**: ForwardingRouter and IBrokeredMessageForwarder overlap; treat Forwarder as a Router specialization.

--- a/src/Chatter.MessageBrokers/CONTEXT.md
+++ b/src/Chatter.MessageBrokers/CONTEXT.md
@@ -20,9 +20,9 @@ _Avoid_: forwarder (a Router specialization).
 
 **Inbox**: Persistence pattern recording received messages to enforce idempotent, once-only handling.
 
-**Routing Slip**: A message carrying its own itinerary of steps/destinations to visit in sequence.
+**Routing Slip**: A message carrying its own itinerary of steps/destinations to visit in sequence (`RoutingSlipBuilder`).
 
-**Recovery**: Resilience policies applied to receiving — Retry and Circuit Breaker.
+**Recovery**: Resilience policies applied to receiving — Retry and Circuit Breaker (`RetryWithCircuitBreakerStrategy`).
 
 **Circuit Breaker**: A recovery policy that halts processing after repeated failures.
 
@@ -39,7 +39,7 @@ _Avoid_: forwarder (a Router specialization).
 - A Brokered Message Receiver consumes infrastructure messages and hands them to the Brokered Message Dispatcher.
 - The Dispatcher relays to a Command or Event handler (Chatter.CQRS) by message type.
 - Recovery (Retry, Circuit Breaker) wraps receiving; exhausting it yields a Critical Failure routed to the Error Queue.
-- Outbox and Inbox depend on a persistence implementation (see Reliability EntityFramework context).
+- Inbox and Outbox use in-memory implementations by default; durable storage is supplied by the Reliability.EntityFramework context.
 - A Routing Slip drives a Router across a sequence of destinations.
 - Concrete brokers (Azure Service Bus, SQL Service Broker) implement the receiver/sender/path interfaces defined here.
 

--- a/src/Chatter.MessageBrokers/src/README.md
+++ b/src/Chatter.MessageBrokers/src/README.md
@@ -1,1 +1,192 @@
 # <a name="chatter-messagebrokers"></a> Chatter.MessageBrokers
+
+Technology-agnostic brokered messaging for .NET, built on Chatter.CQRS.
+
+## Overview
+
+`Chatter.MessageBrokers` adds brokered (out-of-process) messaging on top of [Chatter.CQRS](../../Chatter.CQRS/src/README.md). It lets you receive messages from a broker and dispatch them to your existing `IMessageHandler<TMessage>` commands and events, and send/publish/forward messages back out — all without coupling your domain code to a specific broker technology.
+
+The package defines the abstractions and the orchestration (receiving loop, dispatching, routing, reliability, recovery) but ships **no concrete transport**. The broker-facing interfaces (`IMessagingInfrastructureReceiver`, `IMessagingInfrastructureDispatcher`, `IBrokeredMessagePathBuilder`, etc.) are implemented by a sibling package. Pick one:
+
+- **Chatter.MessageBrokers.AzureServiceBus** — Azure Service Bus queues/topics.
+- **Chatter.MessageBrokers.SqlServiceBroker** — SQL Server Service Broker.
+
+You register `Chatter.MessageBrokers` plus one infrastructure package, and the core wires everything together.
+
+## Installation
+
+```bash
+dotnet add package Chatter.MessageBrokers
+```
+
+Then add a concrete broker, e.g.:
+
+```bash
+dotnet add package Chatter.MessageBrokers.AzureServiceBus
+```
+
+## Getting Started
+
+### 1. Register with DI
+
+`Chatter.MessageBrokers` extends the Chatter.CQRS builder. The primary entry point is `AddMessageBrokers` on `IChatterBuilder`:
+
+```csharp
+using Microsoft.Extensions.DependencyInjection;
+
+services.AddChatterCqrs(configuration)
+        .AddMessageBrokers(options =>
+        {
+            options.WithTransactionMode(TransactionMode.ReceiveOnly);
+        })
+        // then add a concrete infrastructure, e.g.:
+        .AddAzureServiceBus(/* ... */);
+```
+
+`AddMessageBrokers` scans your assemblies for message types decorated with `BrokeredMessageAttribute`, and for every type whose `receivingPath` is set it auto-registers a receiver as a hosted background service. It also registers the dispatcher, routers, recovery strategy, in-memory inbox/outbox, and the default body converters (`JsonBodyConverter`, `TextPlainBodyConverter`).
+
+There are several overloads to control which assemblies are scanned for receivers — by marker type, explicit `Assembly[]`, or a namespace wildcard selector:
+
+```csharp
+.AddMessageBrokers("MyApp.Messages.*", options => { /* ... */ });
+.AddMessageBrokers(options => { /* ... */ }, typeof(SomeMarkerType));
+```
+
+### 2. Mark a message
+
+Decorate a Chatter.CQRS `ICommand` or `IEvent` with `[BrokeredMessage(...)]` to map it to broker paths. Supplying `receivingPath` tells Chatter to start a receiver for that message automatically.
+
+```csharp
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers;
+
+[BrokeredMessage(sendingPath: "orders.out", receivingPath: "orders.in")]
+public class PlaceOrder : ICommand
+{
+    public Guid OrderId { get; set; }
+    public string Sku { get; set; }
+}
+```
+
+`BrokeredMessageAttribute` also accepts `errorQueueName`, `messageDescription`, `infrastructureType`, and `deadletterQueueName`. Either `sendingPath` or `receivingPath` is required.
+
+### 3. Handle the received message
+
+Write a normal Chatter.CQRS handler. When the message arrives on the broker, the receiver deserializes the body and dispatches it to your handler, passing an `IMessageBrokerContext` (which is an `IMessageHandlerContext`).
+
+```csharp
+using Chatter.CQRS;
+using Chatter.CQRS.Context;
+
+public class PlaceOrderHandler : IMessageHandler<PlaceOrder>
+{
+    public async Task Handle(PlaceOrder message, IMessageHandlerContext context)
+    {
+        // ... do work ...
+
+        // reply / send / publish back out over the same infrastructure:
+        await context.Publish(new OrderPlaced { OrderId = message.OrderId });
+    }
+}
+```
+
+### 4. Send / publish without a handler
+
+Inject `IBrokeredMessageDispatcher` anywhere to send commands or publish events directly:
+
+```csharp
+public class OrderApi
+{
+    private readonly IBrokeredMessageDispatcher _dispatcher;
+    public OrderApi(IBrokeredMessageDispatcher dispatcher) => _dispatcher = dispatcher;
+
+    public Task PlaceAsync(PlaceOrder cmd) => _dispatcher.Send(cmd);          // path from attribute
+    public Task PlaceAsync(PlaceOrder cmd, string path) => _dispatcher.Send(cmd, path);
+}
+```
+
+## Core Concepts
+
+### Brokered Message
+A message received from or sent to broker infrastructure. `OutboundBrokeredMessage` represents what you send; `InboundBrokeredMessage` represents what was received (available via `IMessageBrokerContext.BrokeredMessage`). A **Body Converter** (`IBrokeredMessageBodyConverter`, selected by `IBodyConverterFactory`) serializes/deserializes the body to/from your message type.
+
+### Receiver
+`BrokeredMessageReceiver<TMessage>` (interface `IBrokeredMessageReceiver<TMessage>`) consumes messages from the infrastructure in a loop. It runs inside `BrokeredMessageReceiverBackgroundService<TMessage>`, an `IHostedService`. Each decorated, receivable message type gets **its own background service**, and only **one receiver instance per message type** runs. The loop receives a message, deserializes it, dispatches it to the handler, then acks / nacks / deadletters based on the outcome. `ReceiverOptions` carries the receiver path, error/deadletter queue paths, `TransactionMode`, infrastructure type, and `MaxReceiveAttempts` (default 10).
+
+### Dispatcher
+`IReceivedMessageDispatcher` (`ScopedReceivedMessageDispatcher`) relays a received brokered message to the matching Chatter.CQRS handler in a fresh DI scope, bridging to the CQRS message dispatcher by message type.
+
+### Sender / Publisher / Forwarder
+`IBrokeredMessageDispatcher` is the unified outbound surface, composed of:
+
+- `IBrokeredMessageSender` — `Send<TCommand>(...)` a command to one destination.
+- `IBrokeredMessagePublisher` — `Publish<TEvent>(...)` an event (single or batch) to subscribers.
+- `IBrokeredMessageForwarder` — `Forward(...)` a received `InboundBrokeredMessage` to a new destination.
+
+The same operations are available as extension methods on `IMessageHandlerContext` (`context.Send(...)`, `context.Publish(...)`) so a handler can react over the same infrastructure that delivered the inbound message. `context.InMemory()` (`IInMemoryDispatcher`) provides in-process dispatch.
+
+### Routing & Forwarding
+`IRouteBrokeredMessages` (default `BrokeredMessageRouter`) resolves destinations and routes outbound messages to the infrastructure. `ForwardingRouter` (`IForwardMessages`) handles forwarding inbound messages; `ReplyRouter` (`IReplyRouter`) handles reply-to routing. Message IDs are produced by `IMessageIdGenerator` (default `GuidIdGenerator`; `CombGuidIdGenerator` and `HashedBodyGuidGenerator` are also provided).
+
+## Reliability
+
+### Outbox
+The Outbox pattern records outgoing messages so they can be published reliably alongside local state changes. Enable it via `AddReliabilityOptions`:
+
+```csharp
+.AddMessageBrokers(options =>
+{
+    options.AddReliabilityOptions(r => r
+        .WithOutboxRouting()                 // route outbound messages through the outbox
+        .WithOutboxPollingProcessor(5000));  // BrokeredMessageOutboxProcessor drains it every 5s
+});
+```
+
+`WithOutboxRouting()` swaps `IRouteBrokeredMessages` for `OutboxBrokeredMessageRouter`. `WithOutboxPollingProcessor(...)` registers `BrokeredMessageOutboxProcessor` (an `IHostedService`). The default store is `InMemoryBrokeredMessageOutbox`; `WithInMemoryOutboxTimeToLive(minutes)` controls its retention.
+
+### Inbox
+The Inbox pattern records received messages to enforce idempotent, once-only handling (`IBrokeredMessageInbox`, default `InMemoryBrokeredMessageInbox`, applied via `InboxBehavior`).
+
+> **Persistence note:** the in-memory inbox/outbox are for development and single-node scenarios. Durable, transactional EF-backed implementations of `IBrokeredMessageInbox` / `IBrokeredMessageOutbox` (plus `IUnitOfWork` / `IPersistanceTransaction`) live in a sibling EntityFrameworkCore reliability package.
+
+## Recovery
+
+Receiving is wrapped by an `IRecoveryStrategy` — the default `RetryWithCircuitBreakerStrategy` combines Retry and Circuit Breaker. Configure it with `AddRecoveryOptions`:
+
+```csharp
+.AddMessageBrokers(options =>
+{
+    options.AddRecoveryOptions(r => r
+        .UseExponentialDelayRecovery(maxRetryAttempts: 10)   // or UseConstantDelayRecovery(ms) / UseNoDelayRecovery()
+        .RetryWhen<MyTransientException>()                   // restrict which exceptions are retried
+        .UseRouteToErrorQueueRecoveryAction()                // IMaxReceivesExceededAction
+        .WithCircuitBreaker(cb => { /* CircuitBreakerOptionsBuilder */ }));
+});
+```
+
+- **Retry** — `IRetryStrategy` (`RetryStrategy`) with a pluggable `IRetryDelayStrategy`: `NoDelayRetry` (default), `ConstantDelayRetry`, `ExponentialDelayRetry`. Default max attempts is 5. `RetryWhen` / `RetryWhen<TException>` restrict which exceptions are retried.
+- **Circuit Breaker** — `ICircuitBreaker` (`CircuitBreaker`) halts processing after repeated failures; state lives in `ICircuitBreakerStateStore` (default `InMemoryCircuitBreakerStateStore`). Throws `CircuitBreakerOpenException` when open.
+- **Max Receives Exceeded** — when a message's delivery count reaches `MaxReceiveAttempts`, the receiver deadletters it and runs the `IMaxReceivesExceededAction` (default `ErrorQueueDispatcher`). `MaxReceiveAttemptsExceededException` / `MaxRetryAttemptsExceededException` signal the condition.
+- **Critical Failure / Error Queue** — an unrecoverable receive error (`CriticalReceiverException`) stops the receiver loop and raises a Critical Failure via `ICriticalFailureNotifier` (default `CriticalFailureEventDispatcher`, which dispatches a `CriticalFailureEvent`). Failed messages are routed to the **Error Queue** (`ErrorQueueDispatcher`). Poison messages (`PoisonedMessageException`, e.g. a body that won't deserialize) are deadlettered.
+
+## Routing Slips
+
+A **Routing Slip** is a message that carries its own itinerary — an ordered list of destinations to visit. The receiver advances the slip to the next step as each handler completes, enabling itinerary-style choreography without a central orchestrator.
+
+```csharp
+using Chatter.MessageBrokers.Routing.Slips;
+
+var slip = RoutingSlipBuilder.NewRoutingSlip(Guid.NewGuid())
+    .WithRoute("validate.queue")
+    .WithRoute("charge.queue")
+    .WithRoute("ship.queue")
+    .Build();
+```
+
+`RoutingSlipBehavior` advances the slip across the configured `RoutingStep`s; helper extensions (`MessageBrokerContextExtensions`, `SendOptionsExtensions`, `CommandPipelineBuilderExtensions`) attach and read the slip on the message/context.
+
+## Domain Language
+
+Terminology used throughout this module (Brokered Message, Receiver, Dispatcher, Router/Forwarder, Inbox/Outbox, Recovery, Circuit Breaker, Critical Failure, Error Queue, Max Receives Exceeded, Body Converter) is defined in the [domain glossary](../CONTEXT.md).
+
+[← All Chatter modules](../../../README.md)

--- a/src/Chatter.SqlChangeFeed/CONTEXT.md
+++ b/src/Chatter.SqlChangeFeed/CONTEXT.md
@@ -1,0 +1,31 @@
+# Chatter.SqlChangeFeed
+
+Table-change notifications sourced from SQL Server, surfaced as a change feed (a.k.a. Table Watcher).
+
+## Language
+
+**Change Feed**: A stream of notifications emitted when rows in a watched SQL table change.
+_Avoid_: change stream.
+
+**Table Watcher**: The component that subscribes to changes on a specific table and raises change-feed notifications (original library name).
+
+**Trigger**: SQL trigger installed on the watched table that captures inserts/updates/deletes.
+
+**Stored Procedure**: Installed SQL procedure that the change-feed plumbing invokes to read/forward changes.
+
+**Change Feed Options**: Configuration naming the watched table, connection, and feed behavior.
+
+## Relationships
+
+- A Table Watcher installs Triggers and Stored Procedures on the watched table via Setup Scripts.
+- Triggers fire on row changes; the resulting notifications form the Change Feed.
+- Change-feed notifications can be relayed through the Message Brokers context, typically over SQL Service Broker.
+
+## Example dialogue
+
+> **Dev:** "How does Chatter know a row changed without polling?"
+> **Domain expert:** "The Table Watcher installs Triggers that push onto SQL Service Broker; the Change Feed delivers those notifications to your handler."
+
+## Flagged ambiguities
+
+- **Table Watcher vs SQL Change Feed**: code anchors use `chatter-tablewatcher`; the package is `Chatter.SqlChangeFeed`. Treat Table Watcher as the legacy alias.

--- a/src/Chatter.SqlChangeFeed/CONTEXT.md
+++ b/src/Chatter.SqlChangeFeed/CONTEXT.md
@@ -13,19 +13,26 @@ _Avoid_: change stream.
 
 **Stored Procedure**: Installed SQL procedure that the change-feed plumbing invokes to read/forward changes.
 
-**Change Feed Options**: Configuration naming the watched table, connection, and feed behavior.
+**Change Feed Options**: Configuration naming the watched table, database, connection, change types to watch, and feed behavior.
+
+**Row Changed Event**: The default strongly-typed notifications fanned out per change — `RowInsertedEvent<T>`, `RowUpdatedEvent<T>`, `RowDeletedEvent<T>` — handled via `IMessageHandler<T>`.
+
+**Change Feed Item**: A single captured row change (`ChangeFeedItem<T>`); a batch is delivered as `ProcessChangeFeedCommand<T>` in manual mode (`ProcessTableChangesManually()`).
+
+**Change Feed Migration**: Opt-in, idempotent SQL provisioning (`UseChangeFeedSqlMigrations<T>`) that installs the Service Broker objects, table Trigger, and install/uninstall Stored Procedures. Not run automatically at registration.
 
 ## Relationships
 
-- A Table Watcher installs Triggers and Stored Procedures on the watched table via Setup Scripts.
-- Triggers fire on row changes; the resulting notifications form the Change Feed.
-- Change-feed notifications can be relayed through the Message Brokers context, typically over SQL Service Broker.
+- A Change Feed Migration installs the Trigger and Stored Procedures on the watched table; provisioning is opt-in, not automatic.
+- The Trigger fires on row changes and pushes onto SQL Service Broker; the resulting notifications form the Change Feed.
+- By default the Change Feed fans out to Row Changed Events; manual mode delivers raw Change Feed Items instead.
+- Change-feed notifications are handled through Chatter.CQRS handlers and can be relayed via the Message Brokers context.
 
 ## Example dialogue
 
 > **Dev:** "How does Chatter know a row changed without polling?"
-> **Domain expert:** "The Table Watcher installs Triggers that push onto SQL Service Broker; the Change Feed delivers those notifications to your handler."
+> **Domain expert:** "Run the Change Feed Migration once to install the Trigger; it pushes changes onto SQL Service Broker, and the Change Feed delivers a RowInsertedEvent / RowUpdatedEvent / RowDeletedEvent to your handler."
 
 ## Flagged ambiguities
 
-- **Table Watcher vs SQL Change Feed**: code anchors use `chatter-tablewatcher`; the package is `Chatter.SqlChangeFeed`. Treat Table Watcher as the legacy alias.
+- **Table Watcher vs SQL Change Feed**: legacy code anchor was `chatter-tablewatcher`; the package is `Chatter.SqlChangeFeed`. Treat Table Watcher as the legacy alias.

--- a/src/Chatter.SqlChangeFeed/src/README.md
+++ b/src/Chatter.SqlChangeFeed/src/README.md
@@ -1,1 +1,181 @@
-# <a name="chatter-tablewatcher"></a> Chatter.TableWatcher
+# <a name="chatter-sqlchangefeed"></a> Chatter.SqlChangeFeed
+
+Emit strongly-typed notifications whenever rows in a watched SQL Server table are inserted, updated, or deleted.
+
+## Overview
+
+`Chatter.SqlChangeFeed` turns row-level changes in a SQL Server table into a *change feed* of in-process messages, without polling. It provisions a SQL trigger on the watched table that publishes changes onto a SQL Server Service Broker queue; Chatter's Service Broker receiver picks those messages up and dispatches them to your handlers.
+
+This package was originally named **Table Watcher** (`Chatter.TableWatcher`); it is now `Chatter.SqlChangeFeed`. The "watcher" terminology still appears throughout the domain language.
+
+By default, each change is delivered to your code as one of three strongly-typed events:
+
+- `RowInsertedEvent<TRowChangeData>`
+- `RowUpdatedEvent<TRowChangeData>`
+- `RowDeletedEvent<TRowChangeData>`
+
+Alternatively you can opt out of that fan-out and handle the raw `ProcessChangeFeedCommand<TRowChangeData>` (a batch of `ChangeFeedItem<TRowChangeData>`) yourself.
+
+## Installation
+
+```
+dotnet add package Chatter.SqlChangeFeed
+```
+
+This package builds on `Chatter.CQRS` and `Chatter.MessageBrokers.SqlServiceBroker`, which are pulled in transitively.
+
+## Getting Started
+
+### 1. Register the change feed
+
+`AddSqlChangeFeed<TRowChangedData>` is the primary entry point. It is an extension on `IChatterBuilder`, so chain it off your existing Chatter registration. `TRowChangedData` is a type implementing `IMessage` whose properties map to the columns of the watched row.
+
+```csharp
+using Chatter.CQRS.DependencyInjection;
+using Chatter.SqlChangeFeed.DependencyInjection;
+
+public void ConfigureServices(IServiceCollection services)
+{
+    services.AddChatterCqrs(typeof(Startup).Assembly)
+            .AddSqlChangeFeed<MyRow>(
+                connectionString: Configuration.GetConnectionString("Chatter"),
+                databaseName: "MyDatabase",   // optional; falls back to the connection string's Initial Catalog
+                tableName: "MyTable",
+                optionsBuilder: opts => opts
+                    .WithSchema("dbo")
+                    .WithTypesOfChangesToWatch(ChangeTypes.Insert | ChangeTypes.Update | ChangeTypes.Delete));
+}
+
+// The IMessage that maps to a row in MyTable
+public class MyRow : Chatter.CQRS.IMessage
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+}
+```
+
+A non-generic overload, `AddSqlChangeFeed(Type rowChangedDataType, ...)`, is available when the row type is only known at runtime.
+
+### 2. Provision the SQL dependencies
+
+The trigger, stored procedures, and Service Broker objects are **not** created at registration time. Call `UseChangeFeedSqlMigrations<TRowChangedData>` during startup to deploy them:
+
+```csharp
+public void Configure(IApplicationBuilder app)
+{
+    app.UseChangeFeedSqlMigrations<MyRow>();
+}
+```
+
+(Overloads also exist on `IServiceProvider` for non-web hosts.)
+
+### 3. Handle the change notifications
+
+With the default behavior (`ProcessChangeFeedCommandViaChatter = true`), implement `IMessageHandler<T>` for whichever events you care about:
+
+```csharp
+using Chatter.CQRS;
+using Chatter.CQRS.Context;
+using Chatter.SqlChangeFeed;
+
+public class MyRowChangeHandler :
+    IMessageHandler<RowInsertedEvent<MyRow>>,
+    IMessageHandler<RowUpdatedEvent<MyRow>>,
+    IMessageHandler<RowDeletedEvent<MyRow>>
+{
+    public Task Handle(RowInsertedEvent<MyRow> message, IMessageHandlerContext context)
+    {
+        var inserted = message.Inserted;
+        // ...
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(RowUpdatedEvent<MyRow> message, IMessageHandlerContext context)
+    {
+        var before = message.OldValue;
+        var after = message.NewValue;
+        // ...
+        return Task.CompletedTask;
+    }
+
+    public Task Handle(RowDeletedEvent<MyRow> message, IMessageHandlerContext context)
+    {
+        var deleted = message.Deleted;
+        // ...
+        return Task.CompletedTask;
+    }
+}
+```
+
+### Handling the raw change feed instead
+
+If you call `ProcessTableChangesManually()` on the options builder, Chatter does **not** fan out to the row events. Instead, handle the batch command directly:
+
+```csharp
+public class MyChangeFeedHandler : IMessageHandler<ProcessChangeFeedCommand<MyRow>>
+{
+    public Task Handle(ProcessChangeFeedCommand<MyRow> message, IMessageHandlerContext context)
+    {
+        foreach (ChangeFeedItem<MyRow> change in message.Changes)
+        {
+            // change.Inserted and/or change.Deleted are populated depending on the operation
+        }
+        return Task.CompletedTask;
+    }
+}
+```
+
+## Configuration
+
+`AddSqlChangeFeed` takes the connection string, database, and table directly. Everything else is configured through the optional `Action<SqlChangeFeedOptionsBuilder>`, which produces a `SqlChangeFeedOptions`.
+
+### Core arguments / `SqlChangeFeedOptions`
+
+| Property | Meaning |
+| --- | --- |
+| `ConnectionString` | Connection to the SQL Server hosting the watched table. |
+| `DatabaseName` | Database containing the table. Optional; defaults to the connection string's `Initial Catalog`. |
+| `TableName` | The table to watch. |
+| `SchemaName` | Schema of the table. Defaults to `dbo`. |
+| `ChangeFeedTriggerTypes` | Which operations to watch (`ChangeTypes.Insert \| Update \| Delete`). Defaults to all three. |
+| `ChangeFeedQueueName` | Name of the backing Service Broker queue. Defaults to a Chatter-generated name based on the row type. |
+| `ChangeFeedDeadLetterServiceName` | Service Broker service to which dead-lettered messages are routed. Defaults to a generated name. |
+| `ProcessChangeFeedCommandViaChatter` | When `true` (default), Chatter fans changes out as `RowInserted`/`RowUpdated`/`RowDeleted` events. When `false`, you handle `ProcessChangeFeedCommand<T>` directly. |
+
+### `SqlChangeFeedOptionsBuilder` methods
+
+| Method | Effect |
+| --- | --- |
+| `WithNameOfDatabaseToWatch(string)` | Sets the database name. |
+| `WithSchema(string)` | Sets the table schema (default `dbo`). |
+| `WithTypesOfChangesToWatch(ChangeTypes)` | Restricts which operations raise notifications. |
+| `EmitRowChangeEvents()` | Fan out to the row-change events (default). |
+| `ProcessTableChangesManually()` | Deliver the raw `ProcessChangeFeedCommand<T>` instead. |
+| `WithChangeFeedQueueName(string)` | Overrides the Service Broker queue name. |
+| `WithChangeFeedDeadLetterServiceName(string)` | Overrides the dead-letter service name. |
+| `WithErrorQueueName(string)` | Sets the error queue path for the receiver. |
+| `WithTransactionMode(TransactionMode)` | Atomicity of the receiver (default `FullAtomicityViaInfrastructure`). |
+| `WithMaxReceiveAttempts(int)` | Max receive attempts before recovery action (default `10`). |
+| `WithReceiverTimeoutInMilliseconds(int)` | Receiver wait timeout (default `-1`, unlimited). |
+| `WithConversationLifetimeInSeconds(int)` | Service Broker dialog lifetime. |
+| `EnableConversationEncryption()` / `DisableConversationEncryption()` | Toggle Service Broker dialog encryption (default disabled). |
+| `WithCompressedMessageBody()` / `WithUncompressedMessageBody()` | Toggle message-body compression (default compressed). |
+| `WithMessageBodyType(string)` / `WithApplicationJsonUtf16CharsetMessageBodyType()` | Set the message body content type (default `application/json; charset=utf-16`). |
+
+## How It Works
+
+When you call `UseChangeFeedSqlMigrations<T>`, `SqlDependencyManager<T>` runs a set of generated SQL scripts (via `ISqlDependencyManager`) against the target database. For each watched row type it provisions:
+
+1. **Service Broker objects** — enables Service Broker on the database if needed and creates the message type, contract, a conversation queue + service, and a dead-letter queue + service (`InstallAndConfigureSqlServiceBroker`). Names are derived from `ChatterServiceBrokerConstants` and the row type name.
+2. **A trigger on the watched table** (`CreateChangeFeedTrigger`) — an `AFTER INSERT/UPDATE/DELETE` trigger (scoped to `ChangeFeedTriggerTypes`) that serializes the affected `inserted`/`deleted` rows and `SEND`s them onto a Service Broker conversation as a compressed message.
+3. **Install / uninstall stored procedures** (`CreateInstallationProcedure`, `CreateUninstallProcedure`) — the install procedure wires everything together; the uninstall procedure tears the trigger, queues, services, and procedures back down.
+
+At runtime the queue is drained by Chatter's SQL Service Broker receiver. A `ChangeFeedReceiver<T>` (a `BrokeredMessageReceiver`) deserializes each batch into a `ProcessChangeFeedCommand<T>` of `ChangeFeedItem<T>`. Each item carries an `Inserted` and/or `Deleted` snapshot, which the receiver uses to decide whether the change was an insert (inserted only), delete (deleted only), or update (both), dispatching the matching event — unless you chose `ProcessTableChangesManually()`.
+
+**Provisioning is manual, not automatic.** Registration (`AddSqlChangeFeed`) only wires up DI; the SQL objects are created only when `UseChangeFeedSqlMigrations` is invoked at startup. The scripts are idempotent (`IF NOT EXISTS` guards), so running them on each startup is safe.
+
+## Domain Language
+
+See [`../CONTEXT.md`](../CONTEXT.md) for the change-feed / Table Watcher glossary and relationships.
+
+[← All Chatter modules](../../../README.md)


### PR DESCRIPTION
Adopt the hivemind plugin and bootstrap the project's ubiquitous language as a multi-context domain glossary.

## Changes
- `.claude/settings.json`: set `hivemind:overlord` as default agent, add least-privilege `permissions.allow` allowlist
- `.gitignore`: ignore `.hivemind/`
- `CLAUDE.md`: record `dotnet test` under `## Validation`
- `CONTEXT-MAP.md` + per-module `CONTEXT.md` for all 7 `src/` bounded contexts (CQRS, MessageBrokers, AzureServiceBus, AzureServiceBus.Auth, Reliability.EntityFramework, SqlServiceBroker, SqlChangeFeed)

## Notes
- Codex allowlist entry uses placeholder path `/path/to/` — replace with home dir if codex companion is used. Otherwise inert.
- No source/behavior changes; docs + tooling config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)