### PR TITLE
docs: rewrite CLAUDE.md as hivemind-aware project memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -334,3 +334,6 @@ ASALocalRun/
 
 Publish/
 .hivemind/
+
+# Claude Code personal overrides
+CLAUDE.local.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,65 @@
 # Chatter
 
+A suite of modular .NET libraries for building domain-driven Web APIs and microservices, pairing an in-process CQRS + mediator core with technology-agnostic message broker infrastructure.
+
 ## Validation
+
+Hivemind's Validation Procedure runs the command in this block.
 
 ```
 dotnet test
 ```
+
+Solution is `Chatter.sln`; tests live under `src/<Module>/tests/*.Tests.csproj` plus shared `tests/Chatter.Testing.Core.csproj`; all library and shared-test-core projects target `netstandard2.1;net5.0;net6.0`.
+
+## Project Layout
+
+- `src/` — 7 independently-versioned NuGet package modules, each with its own `src/` and `tests/` subtree.
+- `tests/` — shared test core (`Chatter.Testing.Core.csproj`) referenced by all module test projects.
+- `samples/` — runnable end-to-end sample services (CarRental, FlightBooking, HotelBooking, TravelBooking, SharedKernel).
+- `eng/pipelines/` — Azure Pipelines YAML: `chatter-ci-cd.yml`, `ci.yml`, `nuget-cd.yml` under `eng/pipelines/stages/`.
+- `CONTEXT-MAP.md` — entry point to bounded-context docs; lists all 7 contexts, their paths, and relationships.
+
+## Domain Language
+
+Each bounded context owns its ubiquitous language in a local `CONTEXT.md`; start at `CONTEXT-MAP.md`. When introducing a domain term, prefer the existing word from the relevant `CONTEXT.md`; honor `_Avoid_:` aliases (e.g. mediator, middleware, consumer, listener, forwarder, read request).
+
+- `CQRS` → `./src/Chatter.CQRS/CONTEXT.md`
+- `Message Brokers` → `./src/Chatter.MessageBrokers/CONTEXT.md`
+- `Azure Service Bus` → `./src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md`
+- `Azure Service Bus Auth` → `./src/Chatter.MessageBrokers.AzureServiceBus.Auth/CONTEXT.md`
+- `Reliability (EntityFramework)` → `./src/Chatter.MessageBrokers.Reliability.EntityFramework/CONTEXT.md`
+- `SQL Service Broker` → `./src/Chatter.MessageBrokers.SqlServiceBroker/CONTEXT.md`
+- `SQL Change Feed` → `./src/Chatter.SqlChangeFeed/CONTEXT.md`
+
+## Conventions Worth Pinning
+
+- xUnit + FluentAssertions + Moq + coverlet; each module has its own `*.Tests.csproj` and references `tests/Chatter.Testing.Core.csproj`.
+- `Chatter.MessageBrokers.SqlServiceBroker` does NOT auto-provision Service Broker objects — queues/services/contracts/`ENABLE_BROKER` are set up manually (README §SqlServiceBroker).
+- `Chatter.MessageBrokers.Reliability.EntityFramework` ships `IEntityTypeConfiguration` types meant to be applied inside the consumer's `DbContext.OnModelCreating` (README §Reliability).
+- `IExternalDispatcher` is a no-op by default; a broker module replaces it (`./src/Chatter.CQRS/CONTEXT.md`).
+- `Forwarder` is a specialization of `Router` (`ForwardingRouter` / `IBrokeredMessageForwarder` overlap — `./src/Chatter.MessageBrokers/CONTEXT.md`).
+
+## Workflow & Agents
+
+Branch, commit, PR, review, version-bump, agent dispatch, model routing, and skill selection are governed by the hivemind plugin (see `.claude/settings.json` → `enabledPlugins.hivemind@brenpike` and `agent: hivemind:overlord`). Do not restate or override those rules here.
+
+## Versioning
+
+The 7 independently-versioned NuGet packages are: `Chatter.CQRS`, `Chatter.MessageBrokers`, `Chatter.MessageBrokers.AzureServiceBus`, `Chatter.MessageBrokers.AzureServiceBus.Auth`, `Chatter.MessageBrokers.Reliability.EntityFramework`, `Chatter.MessageBrokers.SqlServiceBroker`, and `Chatter.SqlChangeFeed`. Each package's canonical version is the `<Version>` element in its own csproj: `src/Chatter.CQRS/src/Chatter.CQRS/Chatter.CQRS.csproj`, `src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj`, `src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj`, `src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/Chatter.MessageBrokers.AzureServiceBus.Auth/Chatter.MessageBrokers.AzureServiceBus.Auth.csproj`, `src/Chatter.MessageBrokers.Reliability.EntityFramework/src/Chatter.MessageBrokers.Reliability.EntityFramework/Chatter.MessageBrokers.Reliability.EntityFramework.csproj`, `src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj`, `src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj`. No shared version file (`Directory.Build.props`, `version.props`, `version.json`) exists. Bump-trigger logic and dominant-row precedence defer to hivemind `governance/versioning.md`.
+
+## Out of Scope (owned by hivemind)
+
+- branch taxonomy / naming / one-plan-one-branch-one-PR — `plugin/governance/workflow.md`
+- conventional-commit types — `plugin/governance/workflow.md`
+- trunk-freshness check — `plugin/governance/workflow.md`
+- PR opening conditions and required PR content — `plugin/governance/workflow.md`
+- brood execution / strain decomposition — `plugin/governance/workflow.md`
+- SemVer bump-trigger logic and dominant-row precedence — `plugin/governance/versioning.md`
+- CHANGELOG / Keep-a-Changelog format and reset — `plugin/governance/versioning.md`
+- agent roster (cerebrate, drone, changeling, overlord, local-reviewer, github-reviewer) — `plugin/agents/*`
+- model routing per agent — overlord/agent frontmatter
+- skill catalog — plugin marketplace
+- validation procedure semantics (what "passed" means, retry rules) — overlord docs
+- security policy / safety rails — `plugin/governance/{security-policy,safety-rails}.md`
+- report format — `plugin/governance/report-format.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ Each bounded context owns its ubiquitous language in a local `CONTEXT.md`; start
 
 ## Workflow & Agents
 
-Branch, commit, PR, review, version-bump, agent dispatch, model routing, and skill selection are governed by the hivemind plugin (see `.claude/settings.json` → `enabledPlugins.hivemind@brenpike` and `agent: hivemind:overlord`). Do not restate or override those rules here.
+Branch, commit, PR, review, version-bump, agent dispatch, model routing, and skill selection are governed by the [hivemind plugin](https://github.com/brenpike/hivemind) (see `.claude/settings.json` → `enabledPlugins.hivemind@brenpike` and `agent: hivemind:overlord`). Do not restate or override those rules here.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary
- Replace 8-line `CLAUDE.md` stub with a concise (65 lines), hivemind-aware project-memory file following Anthropic CLAUDE.md best practices.
- Preserve the `dotnet test` validation contract (hivemind's Validation Procedure reads `## Validation`).
- Add `CLAUDE.local.md` to `.gitignore` per Anthropic's personal-overrides recommendation.

## What CLAUDE.md now contains
- **Validation** — verbatim `dotnet test` block + one-line solution / TFM note.
- **Project Layout** — top-level dirs (`src/`, `tests/`, `samples/`, `eng/pipelines/`, `CONTEXT-MAP.md`), one line each.
- **Domain Language** — pointer to `CONTEXT-MAP.md` + bullet list of all 7 bounded contexts with relative paths to their `CONTEXT.md`; `_Avoid_:` alias rule pinned.
- **Conventions Worth Pinning** — repo facts Claude cannot infer from code (xUnit/FluentAssertions/Moq/coverlet stack, `SqlServiceBroker` manual provisioning, EF reliability `IEntityTypeConfiguration` wiring, no-op `IExternalDispatcher`, Forwarder/Router overlap).
- **Workflow & Agents** — terse pointer to hivemind plugin, no restating.
- **Versioning** — names the 7 NuGet packages and pins each package's canonical `<Version>` csproj path (audited from disk; no shared version file exists); defers bump-trigger logic to `governance/versioning.md`.
- **Out of Scope (owned by hivemind)** — explicit non-coverage list (branch taxonomy, conventional commits, trunk freshness, PR rules, brood execution, SemVer logic, CHANGELOG, agent roster, model routing, skill catalog, validation semantics, security policy, report format) to prevent future drift into topics governed by the plugin.

## Why this shape
- Single source of truth for domain language stays in `CONTEXT-MAP.md` and per-area `CONTEXT.md`; this file links rather than paraphrases.
- Single source of truth for workflow/agents/versioning stays in `plugin/governance/*`; this file refuses to restate.
- Target <80 lines (Anthropic warns bloated CLAUDE.md gets ignored); landed at 65.

## Test plan
- [x] Local Codex review (adaptation cycle) — clean, 0 findings.
- [ ] `dotnet test` — not run in this session (dotnet binary unavailable in dev sandbox); change is documentation-only, no source or build files modified.
- [ ] Manual: open `CLAUDE.md` on GitHub and confirm the 7 `./src/<context>/CONTEXT.md` relative links render and resolve.

## Files
- `CLAUDE.md` (rewrite, 8 → 65 lines)
- `.gitignore` (+3 lines: `# Claude Code personal overrides` section + `CLAUDE.local.md`)