### PR TITLE
test(cqrs): complete Chatter.CQRS test coverage

### DIFF
--- a/src/Chatter.CQRS/src/Chatter.CQRS/DependencyInjection/CqrsExtensions.cs
+++ b/src/Chatter.CQRS/src/Chatter.CQRS/DependencyInjection/CqrsExtensions.cs
@@ -92,11 +92,6 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             var pipeline = chatterBuilder.Services.CreatePipelineBuilder();
 
-            if (pipeline is null)
-            {
-                return chatterBuilder;
-            }
-
             chatterBuilder.Services.AddTransient(typeof(ICommandBehaviorPipeline<>), typeof(CommandBehaviorPipeline<>));
 
             pipelineBuilder?.Invoke(pipeline);

--- a/src/Chatter.CQRS/src/Chatter.CQRS/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Chatter.CQRS/src/Chatter.CQRS/DependencyInjection/ServiceCollectionExtensions.cs
@@ -14,7 +14,7 @@ namespace Chatter.CQRS.DependencyInjection
         public static IServiceCollection AddPipelineBehavior(this IServiceCollection services, Type behaviorType)
         {
             _ = behaviorType ?? throw new ArgumentNullException(nameof(behaviorType), "Cannot add null behavior type to command pipeline.");
-            var ii = behaviorType.GetTypeInfo()?.ImplementedInterfaces ?? throw new NullReferenceException($"Unable to get implemented interfaces for '{behaviorType.Name}'.");
+            var ii = behaviorType.GetTypeInfo().ImplementedInterfaces ?? throw new NullReferenceException($"Unable to get implemented interfaces for '{behaviorType.Name}'.");
 
             if (!ii.Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(ICommandBehavior<>)))
             {

--- a/src/Chatter.CQRS/tests/DependencyInjection/UsingCrqsExtensions/WhenAddingCommandPipeline.cs
+++ b/src/Chatter.CQRS/tests/DependencyInjection/UsingCrqsExtensions/WhenAddingCommandPipeline.cs
@@ -1,0 +1,78 @@
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.CQRS.DependencyInjection;
+using Chatter.CQRS.Pipeline;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.CQRS.Tests.DependencyInjection.UsingCrqsExtensions
+{
+    public class WhenAddingCommandPipeline
+    {
+        private static IChatterBuilder CreateChatterBuilder(IServiceCollection services)
+            => ChatterBuilder.Create(
+                services,
+                new Mock<IConfiguration>().Object,
+                new Mock<IAssemblySourceFilter>().Object);
+
+        [Fact]
+        public void MustRegisterOpenGenericCommandPipelineAndRunSuppliedAction()
+        {
+            // AddCommandPipeline(IChatterBuilder, Action<CommandPipelineBuilder>) — CqrsExtensions.cs L91-105.
+            var services = new ServiceCollection();
+            var chatterBuilder = CreateChatterBuilder(services);
+            Action<CommandPipelineBuilder> pipelineBuilder = b => b.WithBehavior<FakeCommandBehavior<FakeCommand>>();
+
+            // Explicit static call disambiguates from the [ExcludeFromCodeCoverage] ObsoleteCqrsExtensions shim,
+            // pinning the internal CqrsExtensions.AddCommandPipeline (L91-105) under test.
+            var returned = CqrsExtensions.AddCommandPipeline(chatterBuilder, pipelineBuilder);
+
+            returned.Should().BeSameAs(chatterBuilder);
+
+            var pipeline = services.GetServiceDescriptorByImplementationType(typeof(CommandBehaviorPipeline<>));
+            pipeline.Should().NotBeNull();
+            pipeline.ServiceType.Should().Be(typeof(ICommandBehaviorPipeline<>));
+            pipeline.ImplementationType.Should().Be(typeof(CommandBehaviorPipeline<>));
+            pipeline.Lifetime.Should().Be(ServiceLifetime.Transient);
+
+            // The supplied action actually ran: WithBehavior registered the closed command behavior.
+            var behavior = services.GetServiceDescriptorByImplementationType(typeof(FakeCommandBehavior<FakeCommand>));
+            behavior.Should().NotBeNull();
+            behavior.ServiceType.Should().Be(typeof(ICommandBehavior<FakeCommand>));
+        }
+
+        [Fact]
+        public void MustRegisterOpenGenericCommandPipelineWhenActionIsNull()
+        {
+            // AddCommandPipeline with null pipelineBuilder — CqrsExtensions.cs L102 (?.Invoke).
+            var services = new ServiceCollection();
+            var chatterBuilder = CreateChatterBuilder(services);
+            Action<CommandPipelineBuilder> pipelineBuilder = null;
+
+            // Explicit static call disambiguates from the [ExcludeFromCodeCoverage] ObsoleteCqrsExtensions shim,
+            // pinning the internal CqrsExtensions.AddCommandPipeline (L91-105) under test.
+            IChatterBuilder returned = null;
+            Action act = () => returned = CqrsExtensions.AddCommandPipeline(chatterBuilder, pipelineBuilder);
+
+            act.Should().NotThrow();
+            returned.Should().BeSameAs(chatterBuilder);
+
+            var pipeline = services.GetServiceDescriptorByImplementationType(typeof(CommandBehaviorPipeline<>));
+            pipeline.Should().NotBeNull();
+            pipeline.ServiceType.Should().Be(typeof(ICommandBehaviorPipeline<>));
+            pipeline.ImplementationType.Should().Be(typeof(CommandBehaviorPipeline<>));
+            pipeline.Lifetime.Should().Be(ServiceLifetime.Transient);
+        }
+
+        private class FakeCommand : ICommand { }
+        private class FakeCommandBehavior<TMessage> : ICommandBehavior<TMessage> where TMessage : ICommand
+        {
+            public Task Handle(TMessage message, IMessageHandlerContext messageHandlerContext, CommandHandlerDelegate next) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Chatter.CQRS/tests/DependencyInjection/UsingServiceCollectionExtensions/WhenAddingPipelineBehaviorBranches.cs
+++ b/src/Chatter.CQRS/tests/DependencyInjection/UsingServiceCollectionExtensions/WhenAddingPipelineBehaviorBranches.cs
@@ -1,0 +1,125 @@
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.CQRS.DependencyInjection;
+using Chatter.CQRS.Pipeline;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.CQRS.Tests.DependencyInjection.UsingServiceCollectionExtensions
+{
+    public class WhenAddingPipelineBehaviorBranches
+    {
+        public WhenAddingPipelineBehaviorBranches() { }
+
+        // L19: the `i.IsGenericType` predicate short-circuits to false for a non-generic
+        // implemented interface, then a later ICommandBehavior<> interface matches. Existing
+        // tests only exercise behavior types whose sole interface is ICommandBehavior<>, so the
+        // false-arm of `i.IsGenericType` for a real interface is never evaluated until now.
+        [Fact]
+        public void MustRegisterWhenBehaviorAlsoImplementsNonGenericInterface()
+        {
+            var sc = new ServiceCollection();
+
+            sc.AddPipelineBehavior(typeof(MarkedCommandBehavior<>));
+
+            sc.Should().HaveCount(1);
+            sc[0].ServiceType.Should().Be(typeof(ICommandBehavior<>));
+            sc[0].ImplementationType.Should().Be(typeof(MarkedCommandBehavior<>));
+        }
+
+        // L94 (RegisterBehaviorForAllCommands): the `t.IsGenericType` predicate short-circuits to
+        // false for the non-generic IMarker interface returned by GetInterfaces(), before the
+        // matching ICommandBehavior<> interface is found. Existing tests use either a non-matching
+        // type (throws) or a type whose only interface is ICommandBehavior<> (matches first arm).
+        [Fact]
+        public void MustRegisterForAllCommandsWhenOpenBehaviorAlsoImplementsNonGenericInterface()
+        {
+            var sc = new ServiceCollection();
+
+            sc.RegisterBehaviorForAllCommands(typeof(MarkedCommandBehavior<>));
+
+            sc.Should().HaveCount(1);
+            sc[0].ServiceType.Should().Be(typeof(ICommandBehavior<>));
+            sc[0].ImplementationType.Should().Be(typeof(MarkedCommandBehavior<>));
+        }
+
+        // L120 (RegisterBehaviorForCommand): same short-circuit-false arm of `t.IsGenericType`
+        // for the closed-generic registration path, driven by the non-generic IMarker interface.
+        [Fact]
+        public void MustRegisterForCommandWhenClosedBehaviorAlsoImplementsNonGenericInterface()
+        {
+            var sc = new ServiceCollection();
+
+            sc.RegisterBehaviorForCommand(typeof(MarkedCommandBehavior<FakeCommand>));
+
+            sc.Should().HaveCount(1);
+            sc[0].ServiceType.Should().Be(typeof(ICommandBehavior<FakeCommand>));
+            sc[0].ImplementationType.Should().Be(typeof(MarkedCommandBehavior<FakeCommand>));
+        }
+
+        // L39-41 (GetServiceDescriptorsByImplementationType): a single collection mixing an
+        // open-generic-implementation descriptor, a closed-generic-implementation descriptor, and a
+        // non-generic-implementation descriptor, so BOTH arms of the OR are evaluated within one
+        // Where pass. Existing tests place only one descriptor kind per collection, so a single
+        // evaluation only ever exercises one arm.
+        [Fact]
+        public void MustMatchOnlyOpenGenericImplementationWhenQueryingOpenGenericType()
+        {
+            var sc = BuildMixedCollection();
+
+            var foundServices = sc.GetServiceDescriptorsByImplementationType(typeof(MarkedCommandBehavior<>));
+
+            foundServices.Should().HaveCount(1);
+            foundServices.Single().ImplementationType.Should().Be(typeof(MarkedCommandBehavior<>));
+        }
+
+        [Fact]
+        public void MustMatchOnlyNonGenericImplementationWhenQueryingNonGenericType()
+        {
+            var sc = BuildMixedCollection();
+
+            var foundServices = sc.GetServiceDescriptorsByImplementationType(typeof(NonGenericService));
+
+            foundServices.Should().HaveCount(1);
+            foundServices.Single().ImplementationType.Should().Be(typeof(NonGenericService));
+        }
+
+        [Fact]
+        public void MustMatchClosedGenericImplementationViaNonGenericArmWhenQueryingClosedGenericType()
+        {
+            var sc = BuildMixedCollection();
+
+            // A closed generic (MarkedCommandBehavior<FakeCommand>) is NOT a generic type
+            // definition, so it is matched by the second (non-generic-definition) arm via an
+            // exact ImplementationType equality, not by the open-generic arm.
+            var foundServices = sc.GetServiceDescriptorsByImplementationType(typeof(MarkedCommandBehavior<FakeCommand>));
+
+            foundServices.Should().HaveCount(1);
+            foundServices.Single().ImplementationType.Should().Be(typeof(MarkedCommandBehavior<FakeCommand>));
+        }
+
+        private static IServiceCollection BuildMixedCollection()
+        {
+            var sc = new ServiceCollection();
+            sc.AddTransient(typeof(ICommandBehavior<>), typeof(MarkedCommandBehavior<>));
+            sc.AddTransient(typeof(ICommandBehavior<FakeCommand>), typeof(MarkedCommandBehavior<FakeCommand>));
+            sc.AddTransient(typeof(IMarker), typeof(NonGenericService));
+            return sc;
+        }
+
+        private interface IMarker { }
+
+        private class NonGenericService : IMarker { }
+
+        private class FakeCommand : ICommand { }
+
+        private class MarkedCommandBehavior<TMessage> : IMarker, ICommandBehavior<TMessage> where TMessage : ICommand
+        {
+            public Task Handle(TMessage message, IMessageHandlerContext messageHandlerContext, CommandHandlerDelegate next) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Chatter.CQRS/tests/DependencyInjection/UsingServiceCollectionExtensions/WhenFindingServiceDescriptorByImplementationType.cs
+++ b/src/Chatter.CQRS/tests/DependencyInjection/UsingServiceCollectionExtensions/WhenFindingServiceDescriptorByImplementationType.cs
@@ -4,6 +4,7 @@ using Chatter.CQRS.Events;
 using Chatter.CQRS.Pipeline;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
+using System.Linq;
 using Xunit;
 
 namespace Chatter.CQRS.Tests.DependencyInjection.UsingServiceCollectionExtensions
@@ -58,8 +59,29 @@ namespace Chatter.CQRS.Tests.DependencyInjection.UsingServiceCollectionExtension
             });
         }
 
+        [Fact]
+        public void MustExcludeServiceDescriptorIfImplementationTypeIsNull()
+        {
+            var sc = new ServiceCollection();
+
+            // Factory- and instance-registered descriptors leave ImplementationType null
+            // (ImplementationFactory / ImplementationInstance are set instead), so the
+            // `sd.ImplementationType != null` short-circuit must exclude them before the
+            // type-comparison arms run.
+            sc.AddTransient<ICommand>(sp => new FakeCommand());
+            sc.AddSingleton(typeof(IMessage), new FakeCommand());
+            sc.AddTransient(typeof(IEvent), typeof(FakeCommand));
+
+            var foundServices = sc.GetServiceDescriptorsByImplementationType(typeof(FakeCommand));
+
+            foundServices.Should().HaveCount(1);
+            var found = foundServices.Single();
+            found.ImplementationType.Should().Be(typeof(FakeCommand));
+            found.ServiceType.Should().Be(typeof(IEvent));
+        }
+
         private class NotACommand { }
-        private class FakeCommand : ICommand { }
+        private class FakeCommand : ICommand, IEvent { }
         private class AnotherFakeCommand : ICommand { }
     }
 }


### PR DESCRIPTION
## Summary
Raises Chatter.CQRS test coverage toward 100% within reason, under a hard guiding principle: no production logic / reachable-behavior changes. Adds behavior-pinning tests and removes only unreachable dead code.

## Changes
- **+2 tests** — `WhenAddingCommandPipeline.cs`: cover internal `AddCommandPipeline` registration behavior (open-generic `ICommandBehaviorPipeline<>` → `CommandBehaviorPipeline<>` Transient; null + non-null pipeline-builder paths).
- **+6 tests** — `WhenAddingPipelineBehaviorBranches.cs`: close residual branch arms in `ServiceCollectionExtensions` (L19 non-generic implemented-interface arm; L39-41 open-generic vs non-generic descriptor split; L94/L120 behavior-registration predicates).
- **Dead-code removal (only sanctioned source edit, behavior-preserving):**
  - `CqrsExtensions.cs` — removed dead `if (pipeline is null) return chatterBuilder;` guard in `AddCommandPipeline` (`CreatePipelineBuilder` provably never returns null).
  - `ServiceCollectionExtensions.cs` L17 — `GetTypeInfo()?.` → `GetTypeInfo().` (unreachable null-conditional sub-branch); the reachable `?? throw NullReferenceException(...)` is preserved and remains pinned by the existing `MustThrowWhenImplementedInterfacesOfCommandPipelineBehaviorTypeReturnsNull` test.

## Coverage impact
- `CqrsExtensions`: line 62→75%, branch 40→75%.
- `ServiceCollectionExtensions`: branch 89.65→98.21% (line 100%).

## Accepted scope gaps (intentional)
- Public `AddChatterCqrs` overload family left uncovered — deterministically untestable in the shared Moq test assembly: `AssemblySourceFilter.Apply()` scans the whole AppDomain and Castle/Moq proxies cause `ReflectionTypeLoadException` / duplicate `IQueryHandler<,>` registration. Closing it would require a production testability seam (out of scope per the no-source-change principle; candidate for future dotnet-uplift/testability work).
- `QueryDispatcher.cs` L37 dynamic-dispatch DLR call-site branches — would require a structural rewrite of the hot query path. Out of scope.

## Validation
`DOTNET_ROLL_FORWARD=LatestMajor dotnet test` — green 238/238 across repeated runs, no flakiness. NOTE: only the .NET 10 runtime is installed locally; the three real TFMs (netcoreapp3.1;net5.0;net6.0) are exercised via roll-forward proxy. **CI is currently RED and was not relied upon** — validated locally only.

## Versioning
No bump — test additions + unreachable-dead-code removal; no public API signature change, no observable behavior change.

Local Codex review: clean (first-pass approval, no findings).