### PR TITLE
ci: install .NET 8 and 10 SDKs for retargeted build pipeline

### DIFF
--- a/eng/pipelines/stages/ci.yml
+++ b/eng/pipelines/stages/ci.yml
@@ -14,22 +14,16 @@ stages:
         vmImage: 'ubuntu-latest'
       steps:
       - task: UseDotNet@2
-        displayName: 'Use .NET 3 Core sdk'
+        displayName: 'Use .NET 8 sdk'
         inputs:
           packageType: 'sdk'
-          version: '3.x'
+          version: '8.x'
 
       - task: UseDotNet@2
-        displayName: 'Use .NET 5 Core sdk'
+        displayName: 'Use .NET 10 sdk'
         inputs:
           packageType: 'sdk'
-          version: '5.x'
-
-      - task: UseDotNet@2
-        displayName: 'Use .NET 6 Core sdk'
-        inputs:
-          packageType: 'sdk'
-          version: '6.x'
+          version: '10.x'
           
       - task: DotNetCoreCLI@2
         displayName: 'Dotnet Restore ${{parameters.ProjectName}}'


### PR DESCRIPTION
## Summary

Follow-up to #115 (TFM uplift to `net8.0;net10.0`). The shared Azure Pipelines build template `eng/pipelines/stages/ci.yml` still installed the .NET **3.x/5.x/6.x** SDKs, which no longer match any project's target frameworks — CI restore/build/test/pack would fail.

## Change

- `eng/pipelines/stages/ci.yml`: replace the three `UseDotNet@2` tasks (3.x, 5.x, 6.x) with two installing **8.x** and **10.x**. All other steps (restore/build/test/pack/publish), parameters, and pool unchanged.

## Out of scope (verified, no change needed)

- Per-module `src/<Module>/src/ci.yml` (×7): trigger/`extends` config only, no SDK pin.
- `chatter-ci-cd.yml`: orchestration only.
- `nuget-cd.yml`: `NuGetToolInstaller 5.8` for push — format-agnostic, unaffected.

## Validation

Azure Pipelines YAML — not runnable in this environment. YAML well-formedness confirmed locally (`yaml.safe_load`). No version bump (CI-only change; no packaged-output impact).