### PR TITLE
fix(sqlservicebroker): bump System.Data.SqlClient to 4.8.6 (Dependabot #11, #1)

### DIFF
--- a/samples/CarRentalService/src/CarRental.Api/packages.lock.json
+++ b/samples/CarRentalService/src/CarRental.Api/packages.lock.json
@@ -460,8 +460,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -496,7 +496,7 @@
           "CarRental.Domain": "[1.0.0, )",
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Chatter.MessageBrokers.AzureServiceBus": "[0.8.0, )",
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Chatter.SqlChangeFeed": "[0.9.0, )",
           "Samples.SharedKernel": "[1.0.0, )"
         }
@@ -560,13 +560,13 @@
         "type": "Project",
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.sqlchangefeed": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )"
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )"
         }
       },
       "samples.sharedkernel": {
@@ -1082,8 +1082,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -1177,7 +1177,7 @@
           "CarRental.Domain": "[1.0.0, )",
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Chatter.MessageBrokers.AzureServiceBus": "[0.8.0, )",
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Chatter.SqlChangeFeed": "[0.9.0, )",
           "Samples.SharedKernel": "[1.0.0, )"
         }
@@ -1241,13 +1241,13 @@
         "type": "Project",
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.sqlchangefeed": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )"
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )"
         }
       },
       "samples.sharedkernel": {

--- a/samples/CarRentalService/src/CarRental.Application/packages.lock.json
+++ b/samples/CarRentalService/src/CarRental.Application/packages.lock.json
@@ -412,8 +412,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -471,13 +471,13 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.sqlchangefeed": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Microsoft.AspNetCore.Http.Abstractions": "[2.2.0, )"
         }
       },
@@ -898,8 +898,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -957,13 +957,13 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[8.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.sqlchangefeed": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Microsoft.AspNetCore.Http.Abstractions": "[2.2.0, )"
         }
       },

--- a/samples/CarRentalService/src/CarRental.Infrastructure/packages.lock.json
+++ b/samples/CarRentalService/src/CarRental.Infrastructure/packages.lock.json
@@ -597,8 +597,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -638,7 +638,7 @@
           "CarRental.Domain": "[1.0.0, )",
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Chatter.MessageBrokers.AzureServiceBus": "[0.8.0, )",
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Chatter.SqlChangeFeed": "[0.9.0, )",
           "Samples.SharedKernel": "[1.0.0, )"
         }
@@ -697,13 +697,13 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.sqlchangefeed": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Microsoft.AspNetCore.Http.Abstractions": "[2.2.0, )"
         }
       },
@@ -1311,8 +1311,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -1411,7 +1411,7 @@
           "CarRental.Domain": "[1.0.0, )",
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Chatter.MessageBrokers.AzureServiceBus": "[0.8.0, )",
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Chatter.SqlChangeFeed": "[0.9.0, )",
           "Samples.SharedKernel": "[1.0.0, )"
         }
@@ -1470,13 +1470,13 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[8.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.sqlchangefeed": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Microsoft.AspNetCore.Http.Abstractions": "[2.2.0, )"
         }
       },

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/CHANGELOG.md
@@ -12,6 +12,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [0.8.1] - 2026-06-06
+
+### Fixed
+
+- Upgraded `System.Data.SqlClient` 4.8.3 -> 4.8.6, resolving Dependabot alert #11 (SQL Data Provider Security Feature Bypass, high) and #1 (.NET Information Disclosure, medium).
+
 ## [0.8.0] - 2026-05-30
 
 ### Changed

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.SqlServiceBroker</PackageId>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for SQL Service Broker.</Description>

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/packages.lock.json
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/packages.lock.json
@@ -34,9 +34,9 @@
       },
       "System.Data.SqlClient": {
         "type": "Direct",
-        "requested": "[4.8.3, )",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "requested": "[4.8.6, )",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -393,9 +393,9 @@
       },
       "System.Data.SqlClient": {
         "type": "Direct",
-        "requested": "[4.8.3, )",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "requested": "[4.8.6, )",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/packages.lock.json
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/packages.lock.json
@@ -482,8 +482,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -594,7 +594,7 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.testing.core": {
@@ -1083,8 +1083,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -1195,7 +1195,7 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[8.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.testing.core": {

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/CHANGELOG.md
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/CHANGELOG.md
@@ -12,6 +12,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [0.9.1] - 2026-06-06
+
+### Fixed
+
+- Picked up `Chatter.MessageBrokers.SqlServiceBroker` 0.8.1, which upgrades the transitive `System.Data.SqlClient` 4.8.3 -> 4.8.6 (resolves Dependabot alerts #11 and #1).
+
 ## [0.9.0] - 2026-05-30
 
 ### Changed

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.SqlChangeFeed</PackageId>
-    <Version>0.9.0</Version>
+    <Version>0.9.1</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A library that leverags SQL Service Broker to send sql table changes (insert, update, delete) to a change feed queue for further processing by .NET code.</Description>

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/packages.lock.json
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/packages.lock.json
@@ -344,8 +344,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -379,7 +379,7 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       }
     },
@@ -725,8 +725,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -760,7 +760,7 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[8.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       }
     }

--- a/src/Chatter.SqlChangeFeed/tests/packages.lock.json
+++ b/src/Chatter.SqlChangeFeed/tests/packages.lock.json
@@ -498,8 +498,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -610,13 +610,13 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.sqlchangefeed": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Microsoft.AspNetCore.Http.Abstractions": "[2.2.0, )"
         }
       },
@@ -1122,8 +1122,8 @@
       },
       "System.Data.SqlClient": {
         "type": "Transitive",
-        "resolved": "4.8.3",
-        "contentHash": "yERfVLXAY0QbylAgaGLByYN0hFxX28aeEQ0hUgJO+Ntn1AfmWl5HHUoYJA0Yl9HhIUUJHVaS/Sw/RLZr5aaC+A==",
+        "resolved": "4.8.6",
+        "contentHash": "2Ij/LCaTQRyAi5lAv7UUTV9R2FobC8xN9mE0fXBZohum/xLl8IZVmE98Rq5ugQHjCgTBRKqpXRb4ORulRdA6Ig==",
         "dependencies": {
           "runtime.native.System.Data.SqlClient.sni": "4.7.0"
         }
@@ -1234,13 +1234,13 @@
         "dependencies": {
           "Chatter.MessageBrokers": "[0.9.0, )",
           "Microsoft.Extensions.Hosting": "[8.0.0, )",
-          "System.Data.SqlClient": "[4.8.3, )"
+          "System.Data.SqlClient": "[4.8.6, )"
         }
       },
       "chatter.sqlchangefeed": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.0, )",
+          "Chatter.MessageBrokers.SqlServiceBroker": "[0.8.1, )",
           "Microsoft.AspNetCore.Http.Abstractions": "[2.2.0, )"
         }
       },


### PR DESCRIPTION
## Summary

Closes 2 open Dependabot alerts for `System.Data.SqlClient`:
- **#11 (high)** — SQL Data Provider Security Feature Bypass
- **#1 (medium)** — .NET Information Disclosure Vulnerability

Both originate from a single `PackageReference` in `Chatter.MessageBrokers.SqlServiceBroker`. Bumping `4.8.3 -> 4.8.6` resolves both (4.8.6 ≥ first-patched 4.8.5 and 4.8.6).

## Changes
- `System.Data.SqlClient` `4.8.3 -> 4.8.6` in `Chatter.MessageBrokers.SqlServiceBroker` library csproj.
- All affected `packages.lock.json` regenerated via restore (`--force-evaluate`), spanning `net8.0` + `net10.0`:
  - SqlServiceBroker library + tests (direct).
  - Downstream consumers via ProjectReference: SqlChangeFeed (lib + tests), CarRental sample (Api/Application/Infrastructure) — `System.Data.SqlClient 4.8.3 -> 4.8.6` and `SqlServiceBroker 0.8.0 -> 0.8.1` propagated for lockfile consistency.
- Module version bump: `Chatter.MessageBrokers.SqlServiceBroker` `0.8.0 -> 0.8.1` (patch — security dependency upgrade, no public API change) + CHANGELOG entry.

## Validation
`dotnet test` green across all 7 modules on both TFMs (SqlServiceBroker: 156 net8.0 + 156 net10.0).

## Commits
- `942b179` dep bump + SqlServiceBroker lockfiles
- `0898b78` release 0.8.1 (version + CHANGELOG)
- `2a372d2` downstream lockfile propagation