### PR TITLE
ci: scope coverlet coverage per module + aggregate report

### DIFF
--- a/.github/workflows/azureservicebus-auth-cicd.yml
+++ b/.github/workflows/azureservicebus-auth-cicd.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [master]
     paths:
-      - 'src/Chatter.MessageBrokers.AzureServiceBus.Auth/**'
+      - 'src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/**'
       - '.github/workflows/azureservicebus-auth-cicd.yml'
 
 permissions:

--- a/.github/workflows/azureservicebus-cicd.yml
+++ b/.github/workflows/azureservicebus-cicd.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [master]
     paths:
-      - 'src/Chatter.MessageBrokers.AzureServiceBus/**'
+      - 'src/Chatter.MessageBrokers.AzureServiceBus/src/**'
       - '.github/workflows/azureservicebus-cicd.yml'
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,22 @@ jobs:
             'src/Chatter.SqlChangeFeed/tests/Chatter.SqlChangeFeed.Tests.csproj'; do
             dotnet test "$p" -c Release --no-build /p:CollectCoverage=true
           done
+      - name: Merge coverage report
+        run: |
+          dotnet tool install --global dotnet-reportgenerator-globaltool --version 5.5.10
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+      - name: Generate aggregate coverage
+        run: |
+          reportgenerator \
+            -reports:'artifacts/coverage/*.cobertura.*.xml' \
+            -targetdir:'artifacts/coverage/report' \
+            -reporttypes:'Cobertura;TextSummary;MarkdownSummaryGithub'
+          cat artifacts/coverage/report/SummaryGithub.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: |
+            artifacts/coverage/report/**
+            artifacts/coverage/*.cobertura.*.xml

--- a/.github/workflows/cqrs-cicd.yml
+++ b/.github/workflows/cqrs-cicd.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [master]
     paths:
-      - 'src/Chatter.CQRS/**'
+      - 'src/Chatter.CQRS/src/**'
       - '.github/workflows/cqrs-cicd.yml'
 
 permissions:

--- a/.github/workflows/messagebrokers-cicd.yml
+++ b/.github/workflows/messagebrokers-cicd.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [master]
     paths:
-      - 'src/Chatter.MessageBrokers/**'
+      - 'src/Chatter.MessageBrokers/src/**'
       - '.github/workflows/messagebrokers-cicd.yml'
 
 permissions:

--- a/.github/workflows/reliability-ef-cicd.yml
+++ b/.github/workflows/reliability-ef-cicd.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [master]
     paths:
-      - 'src/Chatter.MessageBrokers.Reliability.EntityFramework/**'
+      - 'src/Chatter.MessageBrokers.Reliability.EntityFramework/src/**'
       - '.github/workflows/reliability-ef-cicd.yml'
 
 permissions:

--- a/.github/workflows/sqlchangefeed-cicd.yml
+++ b/.github/workflows/sqlchangefeed-cicd.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [master]
     paths:
-      - 'src/Chatter.SqlChangeFeed/**'
+      - 'src/Chatter.SqlChangeFeed/src/**'
       - '.github/workflows/sqlchangefeed-cicd.yml'
 
 permissions:

--- a/.github/workflows/sqlservicebroker-cicd.yml
+++ b/.github/workflows/sqlservicebroker-cicd.yml
@@ -10,7 +10,7 @@ on:
   push:
     branches: [master]
     paths:
-      - 'src/Chatter.MessageBrokers.SqlServiceBroker/**'
+      - 'src/Chatter.MessageBrokers.SqlServiceBroker/src/**'
       - '.github/workflows/sqlservicebroker-cicd.yml'
 
 permissions:

--- a/.github/workflows/version-check-all.yml
+++ b/.github/workflows/version-check-all.yml
@@ -11,48 +11,48 @@ jobs:
   cqrs:
     uses: ./.github/workflows/version-check.yml
     with:
-      src-path: 'src/Chatter.CQRS/'
+      src-path: 'src/Chatter.CQRS/src/'
       csproj-path: 'src/Chatter.CQRS/src/Chatter.CQRS/Chatter.CQRS.csproj'
       tag-prefix: 'cqrs'
 
   messagebrokers:
     uses: ./.github/workflows/version-check.yml
     with:
-      src-path: 'src/Chatter.MessageBrokers/'
+      src-path: 'src/Chatter.MessageBrokers/src/'
       csproj-path: 'src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj'
       tag-prefix: 'messagebrokers'
 
   azureservicebus:
     uses: ./.github/workflows/version-check.yml
     with:
-      src-path: 'src/Chatter.MessageBrokers.AzureServiceBus/'
+      src-path: 'src/Chatter.MessageBrokers.AzureServiceBus/src/'
       csproj-path: 'src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj'
       tag-prefix: 'azureservicebus'
 
   azureservicebus-auth:
     uses: ./.github/workflows/version-check.yml
     with:
-      src-path: 'src/Chatter.MessageBrokers.AzureServiceBus.Auth/'
+      src-path: 'src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/'
       csproj-path: 'src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/Chatter.MessageBrokers.AzureServiceBus.Auth/Chatter.MessageBrokers.AzureServiceBus.Auth.csproj'
       tag-prefix: 'azureservicebus-auth'
 
   reliability-ef:
     uses: ./.github/workflows/version-check.yml
     with:
-      src-path: 'src/Chatter.MessageBrokers.Reliability.EntityFramework/'
+      src-path: 'src/Chatter.MessageBrokers.Reliability.EntityFramework/src/'
       csproj-path: 'src/Chatter.MessageBrokers.Reliability.EntityFramework/src/Chatter.MessageBrokers.Reliability.EntityFramework/Chatter.MessageBrokers.Reliability.EntityFramework.csproj'
       tag-prefix: 'reliability-ef'
 
   sqlservicebroker:
     uses: ./.github/workflows/version-check.yml
     with:
-      src-path: 'src/Chatter.MessageBrokers.SqlServiceBroker/'
+      src-path: 'src/Chatter.MessageBrokers.SqlServiceBroker/src/'
       csproj-path: 'src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj'
       tag-prefix: 'sqlservicebroker'
 
   sqlchangefeed:
     uses: ./.github/workflows/version-check.yml
     with:
-      src-path: 'src/Chatter.SqlChangeFeed/'
+      src-path: 'src/Chatter.SqlChangeFeed/src/'
       csproj-path: 'src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj'
       tag-prefix: 'sqlchangefeed'

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,20 @@
+<Project>
+
+  <!-- Coverage-only properties, scoped to test projects (names ending in '.Tests').
+       This naturally excludes Chatter.Testing.Core (ends in '.Core'), library projects,
+       and samples, so nothing here alters packaged library output. CollectCoverage is
+       intentionally NOT set: CI passes /p:CollectCoverage=true; default OFF keeps plain
+       `dotnet test` fast. -->
+  <PropertyGroup Condition="$(MSBuildProjectName.EndsWith('.Tests'))">
+    <CoverletOutputFormat>cobertura</CoverletOutputFormat>
+    <!-- coverlet 10.0.1 with an explicit (non-trailing-slash) filename inserts
+         '.$(TargetFramework)' before the final '.' segment of the supplied filename.
+         Supplying '<ProjectName>.cobertura.xml' therefore yields a unique-per-project,
+         unique-per-TFM file: artifacts/coverage/<ProjectName>.cobertura.<TFM>.xml
+         (empirically verified). Do NOT add $(TargetFramework) here — coverlet adds it. -->
+    <CoverletOutput>$(MSBuildThisFileDirectory)artifacts/coverage/$(MSBuildProjectName).cobertura.xml</CoverletOutput>
+    <ExcludeByAttribute>GeneratedCodeAttribute;CompilerGeneratedAttribute;ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+    <Exclude>[*.Tests]*;[Chatter.Testing.Core]*</Exclude>
+  </PropertyGroup>
+
+</Project>

--- a/src/Chatter.CQRS/tests/Chatter.CQRS.Tests.csproj
+++ b/src/Chatter.CQRS/tests/Chatter.CQRS.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Include>[Chatter.CQRS]*</Include>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/src/Chatter.MessageBrokers.AzureServiceBus.Auth/tests/Chatter.MessageBrokers.AzureServiceBus.Auth.Tests.csproj
+++ b/src/Chatter.MessageBrokers.AzureServiceBus.Auth/tests/Chatter.MessageBrokers.AzureServiceBus.Auth.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Include>[Chatter.MessageBrokers.AzureServiceBus.Auth]*</Include>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Chatter.MessageBrokers.AzureServiceBus.Tests.csproj
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Chatter.MessageBrokers.AzureServiceBus.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Include>[Chatter.MessageBrokers.AzureServiceBus]*</Include>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Chatter.MessageBrokers.Reliability.EntityFramework.Tests.csproj
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Chatter.MessageBrokers.Reliability.EntityFramework.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Include>[Chatter.MessageBrokers.Reliability.EntityFramework]*</Include>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Chatter.MessageBrokers.SqlServiceBroker.Tests.csproj
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Chatter.MessageBrokers.SqlServiceBroker.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Chatter.MessageBrokers.SqlServiceBroker.Tests</AssemblyName>
     <RootNamespace>Chatter.MessageBrokers.SqlServiceBroker.Tests</RootNamespace>
+    <Include>[Chatter.MessageBrokers.SqlServiceBroker]*</Include>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/src/Chatter.MessageBrokers/tests/Chatter.MessageBrokers.Tests.csproj
+++ b/src/Chatter.MessageBrokers/tests/Chatter.MessageBrokers.Tests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <Include>[Chatter.MessageBrokers]*</Include>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">

--- a/src/Chatter.SqlChangeFeed/tests/Chatter.SqlChangeFeed.Tests.csproj
+++ b/src/Chatter.SqlChangeFeed/tests/Chatter.SqlChangeFeed.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <AssemblyName>Chatter.SqlChangeFeed.Tests</AssemblyName>
     <RootNamespace>Chatter.SqlChangeFeed.Tests</RootNamespace>
+    <Include>[Chatter.SqlChangeFeed]*</Include>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">


### PR DESCRIPTION
## Summary
Fixes misleading coverlet numbers. Tests always ran fine — coverage was just unscoped (each test run measured upstream dependency assemblies it didn't target) and unmerged (per-project, multi-TFM clobbering).

## Changes
- **`Directory.Build.props` (new, root)** — coverage-only props gated to `*.Tests` projects (no `<Version>`; libraries/samples/Testing.Core unaffected): cobertura format, unique per-project+per-TFM output `artifacts/coverage/<Project>.cobertura.<TFM>.xml`, `ExcludeByAttribute` (generated code), base `Exclude` of test + `Chatter.Testing.Core` assemblies.
- **7 test csprojs** — each gets `<Include>[Chatter.<Module>]*</Include>` so coverage measures only its own library assembly. Verified: exact-assembly bracket match (no prefix bleed), upstream deps absent from output.
- **`.github/workflows/ci.yml`** — after the test loop, install pinned ReportGenerator `5.5.10` (global tool, no lockfile impact), merge all per-project cobertura into one report (`Cobertura` + `TextSummary` + `MarkdownSummaryGithub`), append the summary to the job summary, and upload a `coverage-report` artifact (`if: always()`). Report-only — no threshold gate.

## Notes
- No library/source/version changes → no module version bump.
- `--locked-mode` safe: no new PackageReference, no `packages.lock.json` touched.
- coverlet OFF by default → plain `dotnet test` unchanged/fast.

## Validation
`dotnet test` green across all 7 modules on net8.0 + net10.0.

## Commits
- `961067c` per-module coverage scoping (props + 7 Includes)
- `ffd7406` CI aggregate coverage merge