### PR TITLE
test(messagebrokers): unblock core receive-loop coverage via in-memory infrastructure receiver

### DIFF
--- a/src/Chatter.MessageBrokers/tests/Receiving/Fakes/InMemoryMessagingInfrastructureProvider.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/Fakes/InMemoryMessagingInfrastructureProvider.cs
@@ -1,0 +1,57 @@
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Sending;
+using Moq;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.Fakes
+{
+    /// <summary>
+    /// In-memory test double for <see cref="IMessagingInfrastructureProvider"/>.
+    /// Returns the supplied <see cref="InMemoryMessagingInfrastructureReceiver"/> from
+    /// <see cref="GetReceiver"/> and provides a real <see cref="DefaultBrokeredMessagePathBuilder"/>
+    /// via <see cref="GetInfrastructure"/> so
+    /// <c>BrokeredMessageReceiver.StartReceiverImpl</c> can resolve the message receiving path.
+    /// </summary>
+    public sealed class InMemoryMessagingInfrastructureProvider : IMessagingInfrastructureProvider
+    {
+        private readonly InMemoryMessagingInfrastructureReceiver _receiver;
+        private readonly IMessagingInfrastructure _infrastructure;
+
+        public InMemoryMessagingInfrastructureProvider(InMemoryMessagingInfrastructureReceiver receiver)
+        {
+            _receiver = receiver ?? throw new System.ArgumentNullException(nameof(receiver));
+
+            // INVARIANT: MessagingInfrastructure's two-arg constructor injects DefaultBrokeredMessagePathBuilder
+            // internally; the test project has InternalsVisibleTo access so DefaultBrokeredMessagePathBuilder
+            // is resolvable, but we use the public MessagingInfrastructure ctor here to stay on the public API.
+            var dispatcherFactory = new Mock<IMessagingInfrastructureDispatcherFactory>();
+            dispatcherFactory.Setup(f => f.Create()).Returns(new Mock<IMessagingInfrastructureDispatcher>().Object);
+
+            var receiverFactory = new Mock<IMessagingInfrastructureReceiverFactory>();
+            receiverFactory.Setup(f => f.Create()).Returns(_receiver);
+
+            _infrastructure = new MessagingInfrastructure(
+                type: InfrastructureType,
+                receiveInfrastructure: receiverFactory.Object,
+                dispatchInfrastructure: dispatcherFactory.Object);
+        }
+
+        /// <summary>The infrastructure type key used for all lookups.</summary>
+        public const string InfrastructureType = "in-memory-test";
+
+        // ------------------------------------------------------------------ IMessagingInfrastructureProvider
+
+        /// <summary>Returns an <see cref="IMessagingInfrastructure"/> whose PathBuilder is the real
+        /// <see cref="DefaultBrokeredMessagePathBuilder"/> so path resolution succeeds.</summary>
+        public IMessagingInfrastructure GetInfrastructure(string type)
+            => _infrastructure;
+
+        /// <summary>Returns the <see cref="InMemoryMessagingInfrastructureReceiver"/> supplied at construction.</summary>
+        public IMessagingInfrastructureReceiver GetReceiver(string type)
+            => _receiver;
+
+        /// <summary>Not exercised by the receiver loop; throws to make unexpected calls visible.</summary>
+        public IMessagingInfrastructureDispatcher GetDispatcher(string type)
+            => throw new System.NotImplementedException(
+                $"{nameof(InMemoryMessagingInfrastructureProvider)}.{nameof(GetDispatcher)} is not used by the receiver loop.");
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Receiving/Fakes/InMemoryMessagingInfrastructureReceiver.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/Fakes/InMemoryMessagingInfrastructureReceiver.cs
@@ -1,0 +1,171 @@
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Transactions;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.Fakes
+{
+    /// <summary>
+    /// In-memory test double for <see cref="IMessagingInfrastructureReceiver"/>.
+    /// Enqueue <see cref="MessageBrokerContext"/> instances via <see cref="Enqueue"/> before
+    /// starting the receiver loop; the double drains them in order and signals
+    /// <see cref="Drained"/> when the last message has been returned.
+    /// </summary>
+    public sealed class InMemoryMessagingInfrastructureReceiver : IMessagingInfrastructureReceiver
+    {
+        private readonly ConcurrentQueue<MessageBrokerContext> _messageQueue = new ConcurrentQueue<MessageBrokerContext>();
+        private readonly List<ReceiverCall> _callLog = new List<ReceiverCall>();
+        private readonly TaskCompletionSource<bool> _drainedTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly int _expectedMessageCount;
+        private int _deliveryCount;
+        private int _receiveCallCount;
+        private bool _disposed;
+
+        /// <param name="expectedMessageCount">
+        /// Number of messages the test will enqueue; <see cref="Drained"/> completes after this
+        /// many <see cref="ReceiveMessageAsync"/> calls return a non-null context.
+        /// </param>
+        public InMemoryMessagingInfrastructureReceiver(int expectedMessageCount)
+        {
+            if (expectedMessageCount < 0)
+                throw new ArgumentOutOfRangeException(nameof(expectedMessageCount));
+            _expectedMessageCount = expectedMessageCount;
+            _deliveryCount = 1;
+
+            // INVARIANT: if zero messages are expected the queue is already drained.
+            if (_expectedMessageCount == 0)
+                _drainedTcs.TrySetResult(true);
+        }
+
+        // ------------------------------------------------------------------ public test API
+
+        /// <summary>Ordered log of calls made by the receiver loop.</summary>
+        public IReadOnlyList<ReceiverCall> CallLog => _callLog;
+
+        /// <summary>
+        /// Completes when <see cref="ReceiveMessageAsync"/> has returned the configured number
+        /// of non-null contexts. Tests await this instead of sleeping.
+        /// </summary>
+        public Task Drained => _drainedTcs.Task;
+
+        /// <summary>
+        /// Sets the value returned by <see cref="MessageDeliveryCountAsync"/> for every call.
+        /// Default is 1.
+        /// </summary>
+        public int DeliveryCount
+        {
+            get => _deliveryCount;
+            set => _deliveryCount = value;
+        }
+
+        /// <summary>Enqueues a message to be returned by the next <see cref="ReceiveMessageAsync"/> call.</summary>
+        public void Enqueue(MessageBrokerContext context)
+        {
+            if (context is null) throw new ArgumentNullException(nameof(context));
+            _messageQueue.Enqueue(context);
+        }
+
+        // ------------------------------------------------------------------ IMessagingInfrastructureReceiver
+
+        public Task InitializeAsync(ReceiverOptions options, CancellationToken cancellationToken)
+        {
+            RecordCall(ReceiverCall.Initialize);
+            return Task.CompletedTask;
+        }
+
+        public Task<MessageBrokerContext> ReceiveMessageAsync(TransactionContext transactionContext, CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            RecordCall(ReceiverCall.Receive);
+
+            if (_messageQueue.TryDequeue(out var context))
+            {
+                int callCount = Interlocked.Increment(ref _receiveCallCount);
+                if (callCount >= _expectedMessageCount)
+                    _drainedTcs.TrySetResult(true);
+
+                return Task.FromResult(context);
+            }
+
+            // Queue empty but not yet cancelled: return null so the loop idles without blocking.
+            return Task.FromResult<MessageBrokerContext>(null);
+        }
+
+        public Task<bool> AckMessageAsync(MessageBrokerContext context, TransactionContext transactionContext, CancellationToken cancellationToken)
+        {
+            RecordCall(ReceiverCall.Ack);
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> NackMessageAsync(MessageBrokerContext context, TransactionContext transactionContext, CancellationToken cancellationToken)
+        {
+            RecordCall(ReceiverCall.Nack);
+            return Task.FromResult(true);
+        }
+
+        public Task<bool> DeadletterMessageAsync(MessageBrokerContext context, TransactionContext transactionContext, string deadLetterReason, string deadLetterErrorDescription, CancellationToken cancellationToken)
+        {
+            RecordCall(ReceiverCall.Deadletter);
+            return Task.FromResult(true);
+        }
+
+        public Task StopReceiver()
+        {
+            RecordCall(ReceiverCall.Stop);
+            return Task.CompletedTask;
+        }
+
+        /// <summary>Returns <see cref="DeliveryCount"/> for every call, bypassing the default-impl read of MessageContext.</summary>
+        public Task<int> MessageDeliveryCountAsync(MessageBrokerContext context, CancellationToken cancellationToken)
+            => Task.FromResult(_deliveryCount);
+
+        /// <summary>Returns null so the loop's <c>localTransaction?.Complete()</c> is a no-op.</summary>
+        public TransactionScope CreateLocalTransaction(TransactionContext context)
+            => null;
+
+        // ------------------------------------------------------------------ IAsyncDisposable / IDisposable
+
+        public ValueTask DisposeAsync()
+        {
+            RecordCallOnce(ReceiverCall.Dispose);
+            return ValueTask.CompletedTask;
+        }
+
+        public void Dispose()
+        {
+            RecordCallOnce(ReceiverCall.Dispose);
+        }
+
+        // ------------------------------------------------------------------ helpers
+
+        private void RecordCall(ReceiverCall call)
+        {
+            lock (_callLog)
+                _callLog.Add(call);
+        }
+
+        private void RecordCallOnce(ReceiverCall call)
+        {
+            if (_disposed) return;
+            _disposed = true;
+            RecordCall(call);
+        }
+    }
+
+    /// <summary>Identifies a method call on <see cref="InMemoryMessagingInfrastructureReceiver"/>.</summary>
+    public enum ReceiverCall
+    {
+        Initialize,
+        Receive,
+        Ack,
+        Nack,
+        Deadletter,
+        Stop,
+        Dispose
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Receiving/Fakes/InMemoryMessagingInfrastructureReceiver.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/Fakes/InMemoryMessagingInfrastructureReceiver.cs
@@ -43,8 +43,19 @@ namespace Chatter.MessageBrokers.Tests.Receiving.Fakes
 
         // ------------------------------------------------------------------ public test API
 
-        /// <summary>Ordered log of calls made by the receiver loop.</summary>
-        public IReadOnlyList<ReceiverCall> CallLog => _callLog;
+        /// <summary>
+        /// Ordered log of calls made by the receiver loop. Returns a locked snapshot so test-thread
+        /// reads never touch the backing <see cref="List{T}"/> while the loop is mutating it under
+        /// <see cref="RecordCall"/>'s lock (<see cref="List{T}"/> is not safe for concurrent read/write).
+        /// </summary>
+        public IReadOnlyList<ReceiverCall> CallLog
+        {
+            get
+            {
+                lock (_callLog)
+                    return _callLog.ToArray();
+            }
+        }
 
         /// <summary>
         /// Completes when <see cref="ReceiveMessageAsync"/> has returned the configured number

--- a/src/Chatter.MessageBrokers/tests/Receiving/Fakes/InMemoryMessagingInfrastructureReceiver.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/Fakes/InMemoryMessagingInfrastructureReceiver.cs
@@ -88,23 +88,27 @@ namespace Chatter.MessageBrokers.Tests.Receiving.Fakes
             return Task.CompletedTask;
         }
 
-        public Task<MessageBrokerContext> ReceiveMessageAsync(TransactionContext transactionContext, CancellationToken cancellationToken)
+        public async Task<MessageBrokerContext> ReceiveMessageAsync(TransactionContext transactionContext, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            RecordCall(ReceiverCall.Receive);
-
             if (_messageQueue.TryDequeue(out var context))
             {
+                RecordCall(ReceiverCall.Receive);
+
                 int callCount = Interlocked.Increment(ref _receiveCallCount);
                 if (callCount >= _expectedMessageCount)
                     _drainedTcs.TrySetResult(true);
 
-                return Task.FromResult(context);
+                return context;
             }
 
-            // Queue empty but not yet cancelled: return null so the loop idles without blocking.
-            return Task.FromResult<MessageBrokerContext>(null);
+            // Queue empty: block until cancellation instead of returning null synchronously.
+            // Returning null here would let the receiver loop spin-call back into this method,
+            // pegging CPU and growing CallLog unbounded while the test winds down. Awaiting the
+            // token parks the loop until cts.Cancel(), at which point the OCE unwinds it cleanly.
+            await Task.Delay(Timeout.Infinite, cancellationToken).ConfigureAwait(false);
+            return null; // unreachable: the await above always throws on cancellation.
         }
 
         public Task<bool> AckMessageAsync(MessageBrokerContext context, TransactionContext transactionContext, CancellationToken cancellationToken)

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
@@ -1,0 +1,257 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    public class WhenReceiving : Testing.Core.Context
+    {
+        // INVARIANT: MessageBrokerOptions.TransactionMode has internal set; accessible via InternalsVisibleTo("Chatter.MessageBrokers.Tests").
+        private static MessageBrokerOptions BuildOptions(TransactionMode mode = TransactionMode.None)
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = mode;
+            return opts;
+        }
+
+        // INVARIANT: pass-through IRecoveryStrategy invokes the delegate exactly once, no retry machinery.
+        // The real RetryWithCircuitBreakerStrategy transitions are reserved for STEP-003.
+        // All TResult shapes used by the receiver loop must be covered:
+        //   Func<Task<MessageBrokerContext>> — ReceiveMessageAsync
+        //   Func<Task<bool>>                — Ack/Nack/Deadletter/DispatchReceivedMessage/FailedRecoveryAction
+        //   Func<Task<int>>                 — MessageDeliveryCountAsync
+        private static Mock<IRecoveryStrategy> PassThroughRecovery()
+        {
+            var mock = new Mock<IRecoveryStrategy>();
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+            return mock;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions(int maxReceiveAttempts = 10)
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = maxReceiveAttempts,
+            };
+
+        // INVARIANT: body must deserialise cleanly as FakeMessage for non-poison tests.
+        private static MessageBrokerContext BuildContext(byte[] body = null)
+        {
+            var converter = new JsonBodyConverter();
+            body ??= converter.Convert(new FakeMessage { Value = "hello" });
+            return new MessageBrokerContext(
+                messageId: Guid.NewGuid().ToString(),
+                body: body,
+                applicationProperties: new Dictionary<string, object>(),
+                messageReceiverPath: "test-queue",
+                receiverCancellationToken: CancellationToken.None,
+                bodyConverter: converter);
+        }
+
+        // INVARIANT: Drained fires at message dequeue, before ProcessMessageAsync runs.
+        // Asserting on the CallLog requires waiting until the expected disposition (Ack/Nack/Deadletter)
+        // actually appears — not just until the message is dequeued. This helper yields until the
+        // disposition call lands in the log, then signals the caller via the returned TCS.
+        // The watchdog CTS bounds the wait to prevent an infinite spin on unexpected code paths.
+        private static async Task WaitForDispositionAsync(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            ReceiverCall expectedDisposition,
+            CancellationToken watchdog)
+        {
+            while (!infraReceiver.CallLog.Contains(expectedDisposition))
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        private BrokeredMessageReceiver<FakeMessage> CreateSut(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            Mock<IReceivedMessageDispatcher> dispatcher,
+            Mock<IMaxReceivesExceededAction> maxReceivesAction = null,
+            Mock<ICriticalFailureNotifier> criticalNotifier = null,
+            Mock<IRecoveryStrategy> recovery = null)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+            maxReceivesAction ??= new Mock<IMaxReceivesExceededAction>();
+            criticalNotifier ??= new Mock<ICriticalFailureNotifier>();
+            recovery ??= PassThroughRecovery();
+
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: maxReceivesAction.Object,
+                criticalFailureNotifier: criticalNotifier.Object,
+                recoveryStrategy: recovery.Object,
+                receivedMessageDispatcher: dispatcher.Object);
+        }
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------ (a) successful receive → Ack
+
+        [Fact]
+        public async Task MustAckAfterSuccessfulHandlerDispatch()
+        {
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
+
+            await infraReceiver.Drained;
+
+            // Wait for the Ack to land in the log before cancelling, to avoid the race where
+            // cancellation fires before ProcessMessageAsync runs and no disposition is recorded.
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForDispositionAsync(infraReceiver, ReceiverCall.Ack, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            dispatcher.Verify(
+                d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Ack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Deadletter);
+        }
+
+        // ------------------------------------------------------------------ (b) handler failure + DeliveryCount < Max → Nack
+
+        [Fact]
+        public async Task MustNackWhenHandlerThrowsAndDeliveryCountBelowMax()
+        {
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.DeliveryCount = 1; // below MaxReceiveAttempts=10
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("handler boom"));
+
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: 10), cts.Token));
+
+            await infraReceiver.Drained;
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForDispositionAsync(infraReceiver, ReceiverCall.Nack, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Nack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Ack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Deadletter);
+        }
+
+        // ------------------------------------------------------------------ (c) poisoned message (deserialization throws) → Deadletter
+
+        [Fact]
+        public async Task MustDeadletterPoisonedMessage()
+        {
+            // Body is not valid JSON for FakeMessage; GetMessageFromBody<FakeMessage> throws → PoisonedMessageException.
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            var badBody = new JsonBodyConverter().GetBytes("not-valid-json-object");
+            infraReceiver.Enqueue(BuildContext(body: badBody));
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
+
+            await infraReceiver.Drained;
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForDispositionAsync(infraReceiver, ReceiverCall.Deadletter, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Deadletter);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Ack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack);
+            dispatcher.Verify(
+                d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        // ------------------------------------------------------------------ (d) handler failure + DeliveryCount >= Max → Deadletter + MaxReceivesExceededAction
+
+        [Fact]
+        public async Task MustDeadletterAndInvokeMaxReceivesActionWhenDeliveryCountExceedsMax()
+        {
+            const int maxAttempts = 3;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.DeliveryCount = maxAttempts; // equals Max → triggers exceeded path
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("handler boom at max"));
+
+            var maxReceivesAction = new Mock<IMaxReceivesExceededAction>();
+            maxReceivesAction
+                .Setup(a => a.ExecuteAsync(It.IsAny<FailureContext>()))
+                .Returns(Task.CompletedTask);
+
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher, maxReceivesAction: maxReceivesAction);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: maxAttempts), cts.Token));
+
+            await infraReceiver.Drained;
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForDispositionAsync(infraReceiver, ReceiverCall.Deadletter, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Deadletter);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Ack);
+            maxReceivesAction.Verify(a => a.ExecuteAsync(It.IsAny<FailureContext>()), Times.Once);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
@@ -71,6 +71,23 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
                 bodyConverter: converter);
         }
 
+        // INVARIANT: Drained completes only if the receiver loop reaches ReceiveMessageAsync.
+        // If the receiver faults during startup/initialization, StartReceiver catches and returns
+        // without faulting the loop task, so a bare `await infraReceiver.Drained` would block forever
+        // and hang the test run. Bound the wait on the same watchdog used for the disposition wait so
+        // an unreached drain fails promptly instead of hanging.
+        private static async Task AwaitDrainedAsync(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            CancellationToken watchdog)
+        {
+            var watchdogTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (watchdog.Register(() => watchdogTcs.TrySetCanceled(watchdog)))
+            {
+                var completed = await Task.WhenAny(infraReceiver.Drained, watchdogTcs.Task);
+                await completed; // surface OperationCanceledException if the watchdog fired first
+            }
+        }
+
         // INVARIANT: Drained fires at message dequeue, before ProcessMessageAsync runs.
         // Asserting on the CallLog requires waiting until the expected disposition (Ack/Nack/Deadletter)
         // actually appears — not just until the message is dequeued. This helper yields until the
@@ -129,11 +146,10 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             using var cts = new CancellationTokenSource();
             var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
 
-            await infraReceiver.Drained;
-
             // Wait for the Ack to land in the log before cancelling, to avoid the race where
             // cancellation fires before ProcessMessageAsync runs and no disposition is recorded.
             using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await AwaitDrainedAsync(infraReceiver, watchdog.Token);
             await WaitForDispositionAsync(infraReceiver, ReceiverCall.Ack, watchdog.Token);
 
             cts.Cancel();
@@ -167,9 +183,8 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             using var cts = new CancellationTokenSource();
             var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: 10), cts.Token));
 
-            await infraReceiver.Drained;
-
             using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await AwaitDrainedAsync(infraReceiver, watchdog.Token);
             await WaitForDispositionAsync(infraReceiver, ReceiverCall.Nack, watchdog.Token);
 
             cts.Cancel();
@@ -197,9 +212,8 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             using var cts = new CancellationTokenSource();
             var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
 
-            await infraReceiver.Drained;
-
             using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await AwaitDrainedAsync(infraReceiver, watchdog.Token);
             await WaitForDispositionAsync(infraReceiver, ReceiverCall.Deadletter, watchdog.Token);
 
             cts.Cancel();
@@ -240,9 +254,8 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             using var cts = new CancellationTokenSource();
             var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: maxAttempts), cts.Token));
 
-            await infraReceiver.Drained;
-
             using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await AwaitDrainedAsync(infraReceiver, watchdog.Token);
             await WaitForDispositionAsync(infraReceiver, ReceiverCall.Deadletter, watchdog.Token);
 
             cts.Cancel();

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenRecoveringThroughTheSeam.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenRecoveringThroughTheSeam.cs
@@ -160,6 +160,66 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             public string Value { get; set; }
         }
 
+        // ------------------------------------------------------------------ recording state-store decorator
+        //
+        // INVARIANT: The circuit breaker drives state transitions through ICircuitBreakerStateStore,
+        // but the store overwrites State on each transition (Open → HalfOpen → Closed), so the
+        // intermediate Open/HalfOpen states are lost by the time the test inspects the final State.
+        // This decorator delegates to the real InMemoryCircuitBreakerStateStore and records the
+        // ordered sequence of transitions actually requested, so a test can assert the circuit
+        // genuinely opened and half-opened rather than only that it ended Closed (a state it also
+        // starts in). Transitions are appended under a lock so the receiver loop's background writes
+        // never race the test thread's reads.
+        private sealed class RecordingCircuitBreakerStateStore : ICircuitBreakerStateStore
+        {
+            private readonly InMemoryCircuitBreakerStateStore _inner;
+            private readonly object _transitionsLock = new object();
+            private readonly List<CircuitBreakerState> _transitions = new List<CircuitBreakerState>();
+
+            public RecordingCircuitBreakerStateStore(InMemoryCircuitBreakerStateStore inner)
+                => _inner = inner ?? throw new ArgumentNullException(nameof(inner));
+
+            // Locked snapshot so test-thread reads never touch the backing List<T> while the
+            // receiver loop mutates it via the transition methods below.
+            public IReadOnlyList<CircuitBreakerState> ObservedTransitions
+            {
+                get { lock (_transitionsLock) { return _transitions.ToArray(); } }
+            }
+
+            private void Record(CircuitBreakerState state)
+            {
+                lock (_transitionsLock) { _transitions.Add(state); }
+            }
+
+            public Exception LastException => _inner.LastException;
+            public DateTime LastStateChangedDateUtc => _inner.LastStateChangedDateUtc;
+            public bool IsClosed => _inner.IsClosed;
+            public CircuitBreakerState State => _inner.State;
+            public int FailureCount => _inner.FailureCount;
+            public int SuccessCount => _inner.SuccessCount;
+
+            public Task OpenAsync(Exception ex)
+            {
+                Record(CircuitBreakerState.Open);
+                return _inner.OpenAsync(ex);
+            }
+
+            public Task HalfOpenAsync()
+            {
+                Record(CircuitBreakerState.HalfOpen);
+                return _inner.HalfOpenAsync();
+            }
+
+            public Task CloseAsync()
+            {
+                Record(CircuitBreakerState.Closed);
+                return _inner.CloseAsync();
+            }
+
+            public Task<int> IncrementSuccessCounterAsync() => _inner.IncrementSuccessCounterAsync();
+            public Task<int> IncrementFailureCounterAsync(Exception ex) => _inner.IncrementFailureCounterAsync(ex);
+        }
+
         // ------------------------------------------------------------------
         // Test (a): handler fails on first delivery, succeeds on second.
         //
@@ -302,7 +362,18 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             var cbEvaluator = new CircuitBreakerExceptionEvaluator(
                 new[] { new ConfigCircuitBreakerExceptionPredicatesProvider(
                     new Predicate<Exception>[] { e => e is InvalidOperationException }) });
-            var (circuitBreaker, stateStore) = BuildCircuitBreaker(cbOptions, cbEvaluator);
+
+            // Wrap the real state store in a recording decorator so the test can assert the circuit
+            // actually transitioned through Open and HalfOpen, not just that it ended Closed (which it
+            // also starts as). The CircuitBreaker is constructed directly here against the recorder.
+            var stateStore = new RecordingCircuitBreakerStateStore(
+                new InMemoryCircuitBreakerStateStore(
+                    NullLogger<InMemoryCircuitBreakerStateStore>.Instance));
+            var circuitBreaker = new CircuitBreaker(
+                stateStore,
+                cbOptions,
+                NullLogger<CircuitBreaker>.Instance,
+                cbEvaluator);
 
             // Retry: ShouldRetry=true for InvalidOperationException; MaxRetryAttempts=3 gives
             // the loop enough room to absorb the first failure and re-enter the CB.
@@ -328,6 +399,16 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             // Assert: handler was invoked at least twice (fail → CB open → half-open → succeed).
             dispatchCallCount.Should().BeGreaterThan(1,
                 because: "handler must be re-attempted after the circuit breaker transitions through half-open");
+
+            // CB must have actually opened and half-opened — not merely ended Closed (the state it
+            // also starts in). Without this, a regression where the breaker never calls
+            // OpenAsync/HalfOpenAsync would still leave the store Closed and pass the assertion below,
+            // so this test would silently stop pinning the Closed → Open → HalfOpen transition.
+            var observedTransitions = stateStore.ObservedTransitions;
+            observedTransitions.Should().Contain(CircuitBreakerState.Open,
+                because: "the qualifying failure must trip the circuit breaker to Open before recovery");
+            observedTransitions.Should().Contain(CircuitBreakerState.HalfOpen,
+                because: "the circuit breaker must transition through HalfOpen on the recovery attempt");
 
             // CB must be Closed after successful half-open recovery (NumberOfHalfOpenSuccessesToClose=1).
             stateStore.IsClosed.Should().BeTrue(

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenRecoveringThroughTheSeam.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenRecoveringThroughTheSeam.cs
@@ -121,6 +121,23 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
 
         // ------------------------------------------------------------------ determinism helper (mirrors WhenReceiving.cs)
 
+        // INVARIANT: Drained completes only if the receiver loop reaches ReceiveMessageAsync.
+        // If the receiver faults during startup/initialization, StartReceiver catches and returns
+        // without faulting the loop task, so a bare `await infraReceiver.Drained` would block forever
+        // and hang the test run. Bound the wait on the same watchdog used for the disposition wait so
+        // an unreached drain fails promptly instead of hanging.
+        private static async Task AwaitDrainedAsync(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            CancellationToken watchdog)
+        {
+            var watchdogTcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using (watchdog.Register(() => watchdogTcs.TrySetCanceled(watchdog)))
+            {
+                var completed = await Task.WhenAny(infraReceiver.Drained, watchdogTcs.Task);
+                await completed; // surface OperationCanceledException if the watchdog fired first
+            }
+        }
+
         // INVARIANT: Drained fires at message dequeue, before ProcessMessageAsync runs.
         // Poll the CallLog until the expected disposition appears, then return.
         // The watchdog CTS (10 s) bounds the wait in case of unexpected code paths.
@@ -209,9 +226,8 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             using var cts = new CancellationTokenSource();
             var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
 
-            await infraReceiver.Drained;
-
             using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await AwaitDrainedAsync(infraReceiver, watchdog.Token);
             await WaitForDispositionAsync(infraReceiver, ReceiverCall.Ack, watchdog.Token);
 
             cts.Cancel();
@@ -302,9 +318,8 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             using var cts = new CancellationTokenSource();
             var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
 
-            await infraReceiver.Drained;
-
             using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await AwaitDrainedAsync(infraReceiver, watchdog.Token);
             await WaitForDispositionAsync(infraReceiver, ReceiverCall.Ack, watchdog.Token);
 
             cts.Cancel();

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenRecoveringThroughTheSeam.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenRecoveringThroughTheSeam.cs
@@ -1,0 +1,325 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Recovery.CircuitBreaker;
+using Chatter.MessageBrokers.Recovery.Options;
+using Chatter.MessageBrokers.Recovery.Retry;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    // INVARIANT: Each test constructs a fresh SUT, receiver, and all real recovery objects.
+    // No shared mutable static state is permitted in this class. See #128.
+    public class WhenRecoveringThroughTheSeam : Testing.Core.Context
+    {
+        // ------------------------------------------------------------------ helpers: options
+
+        // INVARIANT: TransactionMode has an internal setter; accessible via InternalsVisibleTo("Chatter.MessageBrokers.Tests").
+        private static MessageBrokerOptions BuildBrokerOptions()
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = TransactionMode.None;
+            return opts;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions()
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = 10,
+            };
+
+        // INVARIANT: body must deserialise cleanly as FakeMessage for handler tests.
+        private static MessageBrokerContext BuildContext()
+        {
+            var converter = new JsonBodyConverter();
+            var body = converter.Convert(new FakeMessage { Value = "hello" });
+            return new MessageBrokerContext(
+                messageId: Guid.NewGuid().ToString(),
+                body: body,
+                applicationProperties: new Dictionary<string, object>(),
+                messageReceiverPath: "test-queue",
+                receiverCancellationToken: CancellationToken.None,
+                bodyConverter: converter);
+        }
+
+        // ------------------------------------------------------------------ helpers: recovery construction
+
+        // INVARIANT: RetryStrategy is an internal type; NullLogger is used instead of a Moq proxy because
+        // Castle.DynamicProxy cannot create a proxy for ILogger<T> when T is a non-public (internal) type.
+        private static RetryStrategy BuildRetryStrategy(
+            RecoveryOptions recoveryOptions,
+            IRetryExceptionEvaluator exceptionEvaluator)
+            => new RetryStrategy(
+                recoveryOptions,
+                NullLogger<RetryStrategy>.Instance,
+                new NoDelayRetry(),
+                exceptionEvaluator);
+
+        // INVARIANT: CircuitBreaker is public sealed; CircuitBreakerExceptionEvaluator is internal and
+        // accessible via InternalsVisibleTo. InMemoryCircuitBreakerStateStore is public — held by the
+        // test for post-run state observation.
+        private static (CircuitBreaker circuitBreaker, InMemoryCircuitBreakerStateStore stateStore)
+            BuildCircuitBreaker(
+                CircuitBreakerOptions cbOptions,
+                ICircuitBreakerExceptionEvaluator exceptionEvaluator)
+        {
+            var stateStore = new InMemoryCircuitBreakerStateStore(
+                NullLogger<InMemoryCircuitBreakerStateStore>.Instance);
+            var cb = new CircuitBreaker(
+                stateStore,
+                cbOptions,
+                NullLogger<CircuitBreaker>.Instance,
+                exceptionEvaluator);
+            return (cb, stateStore);
+        }
+
+        // INVARIANT: RetryWithCircuitBreakerStrategy is internal and accessible via InternalsVisibleTo.
+        private static RetryWithCircuitBreakerStrategy BuildStrategy(
+            RecoveryOptions recoveryOptions,
+            CircuitBreaker circuitBreaker,
+            IRetryExceptionEvaluator retryEvaluator)
+            => new RetryWithCircuitBreakerStrategy(
+                recoveryOptions,
+                circuitBreaker,
+                BuildRetryStrategy(recoveryOptions, retryEvaluator));
+
+        // ------------------------------------------------------------------ helpers: SUT construction
+
+        private static BrokeredMessageReceiver<FakeMessage> BuildSut(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            IRecoveryStrategy strategy,
+            Mock<IReceivedMessageDispatcher> dispatcher)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildBrokerOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: new Mock<IMaxReceivesExceededAction>().Object,
+                criticalFailureNotifier: new Mock<ICriticalFailureNotifier>().Object,
+                recoveryStrategy: strategy,
+                receivedMessageDispatcher: dispatcher.Object);
+        }
+
+        // ------------------------------------------------------------------ determinism helper (mirrors WhenReceiving.cs)
+
+        // INVARIANT: Drained fires at message dequeue, before ProcessMessageAsync runs.
+        // Poll the CallLog until the expected disposition appears, then return.
+        // The watchdog CTS (10 s) bounds the wait in case of unexpected code paths.
+        private static async Task WaitForDispositionAsync(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            ReceiverCall expectedDisposition,
+            CancellationToken watchdog)
+        {
+            while (!infraReceiver.CallLog.Contains(expectedDisposition))
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        // ------------------------------------------------------------------ message type
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------
+        // Test (a): handler fails on first delivery, succeeds on second.
+        //
+        // COVERAGE: RetryStrategy re-invokes the handler (retry path observed through the loop).
+        // CircuitBreaker: ShouldTrip=false (empty predicates provider list) so one handler
+        // failure increments the failure counter but never reaches NumberOfFailuresBeforeOpen=2,
+        // leaving the CB closed for the duration. The retry re-invocation is the primary
+        // assertion here; CB open/closed transition is NOT the focus of this test.
+        //
+        // DEFERRED: Asserting the CB failure-counter value directly requires reaching into
+        // InMemoryCircuitBreakerStateStore.FailureCount (public property). We deliberately
+        // do NOT assert it here because the counter may be incremented by any ExecuteAsync
+        // call (ReceiveMessageAsync, DeliveryCountAsync, Ack, etc.) that happens to throw —
+        // not only the handler call — making the exact count fragile to assert through the
+        // loop seam. Deferred to a dedicated unit test if exact failure-count sequencing
+        // must be pinned.
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task MustRetryHandlerAndAckOnEventualSuccess()
+        {
+            // Arrange
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.Enqueue(BuildContext());
+
+            var dispatchCallCount = 0;
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(
+                    It.IsAny<FakeMessage>(),
+                    It.IsAny<MessageBrokerContext>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    dispatchCallCount++;
+                    if (dispatchCallCount == 1)
+                        throw new InvalidOperationException("transient failure on first attempt");
+                    return Task.CompletedTask;
+                });
+
+            // CB: ShouldTrip=false for all exceptions (empty predicates list → ShouldTrip always false).
+            // This ensures one handler failure does not open the circuit breaker.
+            var cbOptions = new CircuitBreakerOptions
+            {
+                OpenToHalfOpenWaitTimeInSeconds = 0,
+                ConcurrentHalfOpenAttempts = 1,
+                NumberOfFailuresBeforeOpen = 2,
+                NumberOfHalfOpenSuccessesToClose = 1,
+                SecondsOpenBeforeCriticalFailureNotification = 0,
+            };
+            var cbEvaluator = new CircuitBreakerExceptionEvaluator(
+                Array.Empty<ICircuitBreakerExceptionPredicatesProvider>());
+            var (circuitBreaker, _) = BuildCircuitBreaker(cbOptions, cbEvaluator);
+
+            // Retry: ShouldRetry=true for InvalidOperationException; MaxRetryAttempts=3 covers two attempts.
+            var recoveryOptions = new RecoveryOptions { MaxRetryAttempts = 3 };
+            var retryEvaluator = new RetryExceptionEvaluator(
+                new[] { new ConfigRetryExceptionPredicatesProvider(
+                    new Predicate<Exception>[] { e => e is InvalidOperationException }) });
+            var strategy = BuildStrategy(recoveryOptions, circuitBreaker, retryEvaluator);
+
+            var sut = BuildSut(infraReceiver, strategy, dispatcher);
+
+            // Act
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
+
+            await infraReceiver.Drained;
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForDispositionAsync(infraReceiver, ReceiverCall.Ack, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            // Assert: handler was invoked more than once (retry path), and the message was Ack'd.
+            dispatchCallCount.Should().BeGreaterThan(1,
+                because: "RetryStrategy must re-invoke the handler after the first failure");
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Ack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Deadletter);
+        }
+
+        // ------------------------------------------------------------------
+        // Test (b): enough failures to open the circuit breaker, then handler succeeds
+        //           via the half-open recovery path.
+        //
+        // COVERAGE:
+        //   - CB Closed → Open transition: first handler failure increments the counter
+        //     to NumberOfFailuresBeforeOpen=1 → CB opens.
+        //   - CB Open → HalfOpen: CircuitBreaker.ExecuteAsync waits Task.Delay(0 s) and
+        //     transitions to HalfOpen on the next retry attempt.
+        //   - CB HalfOpen → Closed: handler succeeds in HalfOpen; one success reaches
+        //     NumberOfHalfOpenSuccessesToClose=1 → CB closes.
+        //   - The CB state transitions are observed via InMemoryCircuitBreakerStateStore.State
+        //     after the loop completes, and via the final Ack in the receiver's CallLog.
+        //
+        // DEFERRED: The precise moment the CB enters Open (between which two loop iterations)
+        //   is not pinned here because it depends on the interleaving of ExecuteAsync calls
+        //   (ReceiveMessageAsync vs. DispatchAsync vs. DeliveryCountAsync). What IS pinned:
+        //   given exactly one qualifying failure and NumberOfFailuresBeforeOpen=1, the CB
+        //   MUST have been Open at some point before the final Ack, and MUST be Closed after it.
+        //
+        // NOTE: ShouldTrip predicate matches InvalidOperationException (thrown by the handler).
+        //   ShouldRetry also matches InvalidOperationException so the retry wrapper re-attempts
+        //   after the CB opens. Because openToHalfOpenWaitTime=0 s, the half-open transition
+        //   is immediate; no real wall-clock delay occurs.
+        // ------------------------------------------------------------------
+        [Fact]
+        public async Task MustOpenCircuitBreakerOnFailureThenRecoverViaHalfOpen()
+        {
+            // Arrange
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.Enqueue(BuildContext());
+
+            var dispatchCallCount = 0;
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(
+                    It.IsAny<FakeMessage>(),
+                    It.IsAny<MessageBrokerContext>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    dispatchCallCount++;
+                    if (dispatchCallCount == 1)
+                        throw new InvalidOperationException("failure that trips the circuit");
+                    return Task.CompletedTask;
+                });
+
+            // CB: ShouldTrip=true for InvalidOperationException; threshold=1 so the first
+            // handler failure opens the circuit immediately. openToHalfOpenWaitTime=0 so no
+            // real wall-clock delay in the half-open transition.
+            var cbOptions = new CircuitBreakerOptions
+            {
+                OpenToHalfOpenWaitTimeInSeconds = 0,
+                ConcurrentHalfOpenAttempts = 1,
+                NumberOfFailuresBeforeOpen = 1,
+                NumberOfHalfOpenSuccessesToClose = 1,
+                SecondsOpenBeforeCriticalFailureNotification = 0,
+            };
+            var cbEvaluator = new CircuitBreakerExceptionEvaluator(
+                new[] { new ConfigCircuitBreakerExceptionPredicatesProvider(
+                    new Predicate<Exception>[] { e => e is InvalidOperationException }) });
+            var (circuitBreaker, stateStore) = BuildCircuitBreaker(cbOptions, cbEvaluator);
+
+            // Retry: ShouldRetry=true for InvalidOperationException; MaxRetryAttempts=3 gives
+            // the loop enough room to absorb the first failure and re-enter the CB.
+            var recoveryOptions = new RecoveryOptions { MaxRetryAttempts = 3 };
+            var retryEvaluator = new RetryExceptionEvaluator(
+                new[] { new ConfigRetryExceptionPredicatesProvider(
+                    new Predicate<Exception>[] { e => e is InvalidOperationException }) });
+            var strategy = BuildStrategy(recoveryOptions, circuitBreaker, retryEvaluator);
+
+            var sut = BuildSut(infraReceiver, strategy, dispatcher);
+
+            // Act
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
+
+            await infraReceiver.Drained;
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await WaitForDispositionAsync(infraReceiver, ReceiverCall.Ack, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            // Assert: handler was invoked at least twice (fail → CB open → half-open → succeed).
+            dispatchCallCount.Should().BeGreaterThan(1,
+                because: "handler must be re-attempted after the circuit breaker transitions through half-open");
+
+            // CB must be Closed after successful half-open recovery (NumberOfHalfOpenSuccessesToClose=1).
+            stateStore.IsClosed.Should().BeTrue(
+                because: "one successful half-open attempt must close the circuit breaker");
+
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Ack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Deadletter);
+        }
+    }
+}


### PR DESCRIPTION
Closes #121. Part of #120.

## What
Unblocks 0%-coverage of the already-deep core receive loop. The core abstraction (`BrokeredMessageReceiver<T>` + `RetryWithCircuitBreakerStrategy`) is **deep, not shallow** — its 0% coverage was a *reachability* symptom (every production `IMessagingInfrastructureReceiver` baked in a live SDK/ADO.NET client). This PR authors a fresh in-memory core-seam double so the loop can be driven from unit tests. **No core interface change. Test-only.**

> Note: #121's text said "consume the in-memory double from #122." That was inaccurate — #122/#123 produced *adapter-internal SDK port* doubles (`IServiceBusMessageReceiver`/`ISqlConnectionSource`, both `internal`), the wrong layer. No in-memory `IMessagingInfrastructureReceiver` existed. This PR authors one fresh in the core test project.

## Changes (3 commits, characterization-first)
- **STEP-001** `tests/Receiving/Fakes/` — hand-rolled `InMemoryMessagingInfrastructureReceiver` (records ordered ack/nack/deadletter/init/stop/dispose calls, enqueue, test-controlled delivery count, deterministic `Drained` signal) + backing `InMemoryMessagingInfrastructureProvider`.
- **STEP-002** `WhenReceiving.cs` — pins loop ordering: success→ack, failure(<max)→nack, poisoned→deadletter, failure(≥max)→deadletter + `IMaxReceivesExceededAction`.
- **STEP-003** `WhenRecoveringThroughTheSeam.cs` — exercises real `RetryWithCircuitBreakerStrategy` transitions through the loop (retry re-invocation, CB Closed→Open→HalfOpen→Closed).

## Honest coverage boundary
Genuinely unit-covered through the seam: retry re-invocation, CB state transitions, all four disposition paths. Deferred-with-inline-note: exact CB failure-counter sequencing through the seam (fragile — any `ExecuteAsync` throw increments it) and the `CircuitBreakerOpenException` swallow path (already covered by existing isolated retry tests).

## Determinism
No `Task.Delay`/`Thread.Sleep` — deterministic `TaskCompletionSource` + `WaitForDispositionAsync` poll, cancel-after-assert. Fresh SUT per test (mind net10.0 AppDomain ordering, ref #128).

## Out of scope
Candidate 4 (fold per-broker infra factory pass-throughs into core `Func<>` registration) deferred to a follow-up PR — it touches core + both broker public surfaces and would version-bump; #121's acceptance stands alone without it.

## Validation
`dotnet test` (Chatter.sln). `Chatter.MessageBrokers.Tests` **359/359** green on net8.0 + net10.0 (was 353; +6 new). Full-solution run surfaced one CQRS net10.0 failure = known flaky #128 (AppDomain order-dependent); CQRS passes 239/239 on isolated re-run. Unrelated to this module.

## Versioning
None — pure test additions, no public surface change, no CHANGELOG entry required.