### PR TITLE
test(azureservicebus.auth): pin token-provider DI wiring (#124)

### DIFF
--- a/src/Chatter.MessageBrokers.AzureServiceBus.Auth/tests/UsingServiceBusOptionsBuilderExtensions/WhenWiringTokenProvider.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus.Auth/tests/UsingServiceBusOptionsBuilderExtensions/WhenWiringTokenProvider.cs
@@ -1,0 +1,87 @@
+using System.Collections.Generic;
+using Chatter.MessageBrokers.AzureServiceBus.Options;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Auth.Tests.UsingServiceBusOptionsBuilderExtensions
+{
+    public class WhenWiringTokenProvider : global::Chatter.Testing.Core.Context
+    {
+        private const string ClientId = "client-id";
+        private const string Secret = "secret";
+        private const string Thumbprint = "THUMBPRINT";
+        private const string Authority = "https://login.microsoftonline.com/tenant/";
+        private const string RedirectUri = "https://localhost/redirect";
+
+        // INVARIANT: the end-to-end ServiceBusOptions.TokenProvider round-trip is intentionally
+        // NOT re-asserted here because ServiceBusOptionsBuilder.Build() is internal to
+        // Chatter.MessageBrokers.AzureServiceBus and not visible to this assembly; that round-trip
+        // is owned by the ASB module test WhenBuilding.cs. These tests characterize ONLY the
+        // public extension surface: that registration invokes the eager Func building an
+        // AzureActiveDirectoryTokenProvider WITHOUT firing the MSAL/DefaultAzureCredential callback,
+        // and that the fluent contract returns the same builder instance.
+        private static ServiceBusOptionsBuilder CreateBuilder()
+            => ServiceBusOptionsBuilder.Create(
+                new ServiceCollection(),
+                new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()).Build());
+
+        [Fact]
+        public void MustNotThrowAtRegistrationFromUseAadTokenProviderWithSecret()
+        {
+            var builder = CreateBuilder();
+
+            builder.Invoking(b => b.UseAadTokenProviderWithSecret(ClientId, Secret, Authority))
+                .Should().NotThrow();
+        }
+
+        [Fact]
+        public void MustReturnSameBuilderFromUseAadTokenProviderWithSecret()
+        {
+            var builder = CreateBuilder();
+
+            var result = builder.UseAadTokenProviderWithSecret(ClientId, Secret, Authority);
+
+            result.Should().BeSameAs(builder);
+        }
+
+        [Fact]
+        public void MustNotThrowAtRegistrationFromUseAadTokenProviderWithCert()
+        {
+            var builder = CreateBuilder();
+
+            builder.Invoking(b => b.UseAadTokenProviderWithCert(ClientId, Thumbprint, Authority, validCertsOnly: true))
+                .Should().NotThrow();
+        }
+
+        [Fact]
+        public void MustReturnSameBuilderFromUseAadTokenProviderWithCert()
+        {
+            var builder = CreateBuilder();
+
+            var result = builder.UseAadTokenProviderWithCert(ClientId, Thumbprint, Authority, validCertsOnly: true);
+
+            result.Should().BeSameAs(builder);
+        }
+
+        [Fact]
+        public void MustNotThrowAtRegistrationFromUseAadTokenProviderInteractively()
+        {
+            var builder = CreateBuilder();
+
+            builder.Invoking(b => b.UseAadTokenProviderInteractively(ClientId, RedirectUri))
+                .Should().NotThrow();
+        }
+
+        [Fact]
+        public void MustReturnSameBuilderFromUseAadTokenProviderInteractively()
+        {
+            var builder = CreateBuilder();
+
+            var result = builder.UseAadTokenProviderInteractively(ClientId, RedirectUri);
+
+            result.Should().BeSameAs(builder);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Light characterization coverage for `Chatter.MessageBrokers.AzureServiceBus.Auth` (issue #124, epic #120). Test-only — no structural refactor, no public-surface change, no version bump.

Pins the genuine 0% surface: `ServiceBusOptionsBuilderExtensions` DI/auth wiring. The module's `AadTokenProviderFactory` wraps a true-external boundary (MSAL / `DefaultAzureCredential`) and is intentionally NOT ported.

## Tests added

`WhenWiringTokenProvider` — 6 facts (2 per extension) over `UseAadTokenProviderWithSecret`, `UseAadTokenProviderWithCert`, `UseAadTokenProviderInteractively`:

- **No-throw at registration** — characterizes that the `AddTokenProvider(Func<ITokenProvider>)` overload eagerly builds the `AzureActiveDirectoryTokenProvider` without firing the MSAL/`DefaultAzureCredential` callback.
- **Fluent same-instance** — each extension returns the same `ServiceBusOptionsBuilder`.

Public surface only — real `ServiceCollection` + in-memory `IConfiguration`, no `Build()`, no reflection, no internals, no Moq. An invariant comment notes the end-to-end `ServiceBusOptions.TokenProvider` round-trip stays owned by the ASB module test (`Build()` is internal to that assembly).

## Versioning

None — test-only.

## Validation

`dotnet test Chatter.sln` — all green on net8.0 + net10.0 (Auth 22, +6 new).

Closes #124.