### PR TITLE
fix(azureservicebus): cap deadletter error description to ASB 4096 limit (#92)

### DIFF
--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -12,6 +12,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+- Cap the Azure Service Bus deadletter error description to the SDK's 4096-character limit, preventing `System.ArgumentOutOfRangeException` on `OnDeadLetterAsync` (#92).
+
 ## [0.10.1] - 2026-06-07
 
 ### Changed

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.AzureServiceBus</PackageId>
-    <Version>0.10.1</Version>
+    <Version>0.10.2</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for Azure Service Bus.</Description>

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
@@ -14,6 +14,12 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
 {
     internal class ServiceBusReceiver : IMessagingInfrastructureReceiver
     {
+        // INVARIANT: the Azure Service Bus SDK rejects a deadletter error description longer than 4096
+        // UTF-16 chars with ArgumentOutOfRangeException (Parameter 'deadLetterErrorDescription'), so the
+        // description is capped at this length (matching the SDK's char-based validation) before dispatch.
+        private const int MaxDeadLetterErrorDescriptionLength = 4096;
+        private const string DeadLetterErrorDescriptionTruncationMarker = "…[truncated]";
+
         readonly object _syncLock;
         private readonly ILogger<ServiceBusReceiver> _logger;
         private readonly InboundBrokeredMessageFactory _inboundFactory;
@@ -212,9 +218,25 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                 return false;
             }
 
-            await this.InnerReceiver.DeadLetterAsync(msg.SystemProperties.LockToken, deadLetterReason, deadLetterErrorDescription);
+            await this.InnerReceiver.DeadLetterAsync(msg.SystemProperties.LockToken, deadLetterReason, CapDeadLetterErrorDescription(deadLetterErrorDescription));
             _logger.LogTrace($"Message '{msg.MessageId}' sucessfully deadlettered");
             return true;
+        }
+
+        // Caps the deadletter error description at the SDK's MaxDeadLetterErrorDescriptionLength UTF-16
+        // chars. A null/empty or already-fitting description is returned unchanged; an over-limit
+        // description preserves its diagnostic head and appends a truncation marker, reserving the
+        // marker's length inside the budget so the result never exceeds the limit.
+        private static string CapDeadLetterErrorDescription(string deadLetterErrorDescription)
+        {
+            if (string.IsNullOrEmpty(deadLetterErrorDescription)
+                || deadLetterErrorDescription.Length <= MaxDeadLetterErrorDescriptionLength)
+            {
+                return deadLetterErrorDescription;
+            }
+
+            var headLength = MaxDeadLetterErrorDescriptionLength - DeadLetterErrorDescriptionTruncationMarker.Length;
+            return deadLetterErrorDescription.Substring(0, headLength) + DeadLetterErrorDescriptionTruncationMarker;
         }
 
         public TransactionScope CreateLocalTransaction(TransactionContext context)

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenAcknowledgingMessage.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenAcknowledgingMessage.cs
@@ -1,5 +1,6 @@
 using Chatter.MessageBrokers.AzureServiceBus.Options;
 using Chatter.MessageBrokers.AzureServiceBus.Receiving;
+using Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving;
 using Chatter.MessageBrokers.Configuration;
 using Chatter.MessageBrokers.Context;
 using Chatter.MessageBrokers.Receiving;
@@ -49,6 +50,34 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
             return sut;
         }
 
+        // Drives the deadletter path through the in-memory IServiceBusMessageReceiver double so the
+        // capped description handed to DeadLetterAsync is captured via DeadLetteredLockTokens.
+        private static ServiceBusReceiver CreateInMemorySut(InMemoryServiceBusMessageReceiver inMemory)
+        {
+            var serviceBusOptions = new ServiceBusOptions
+            {
+                ConnectionString = "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=secret",
+                TokenProvider = new NullTokenProvider(),
+            };
+            var logger = new Mock<ILogger<ServiceBusReceiver>>();
+            var factory = new Mock<IBodyConverterFactory>();
+            factory.Setup(f => f.CreateBodyConverter(It.IsAny<string>())).Returns(new JsonBodyConverter());
+            var inboundFactory = new InboundBrokeredMessageFactory(factory.Object, Mock.Of<ILogger>());
+            return new ServiceBusReceiver(serviceBusOptions, new MessageBrokerOptions(), logger.Object, inboundFactory, (_, __) => inMemory);
+        }
+
+        private static async Task<(ServiceBusReceiver sut, MessageBrokerContext context, TransactionContext transactionContext)> ReceivedPeekLockMessageAsync(InMemoryServiceBusMessageReceiver inMemory)
+        {
+            inMemory.EnqueueMessage(ServiceBusMessageFactory.ReceivedMessage());
+            var sut = CreateInMemorySut(inMemory);
+            await sut.InitializeAsync(new ReceiverOptions { MessageReceiverPath = "receiver", TransactionMode = TransactionMode.ReceiveOnly }, CancellationToken.None);
+            var transactionContext = new TransactionContext("receiver");
+            var context = await sut.ReceiveMessageAsync(transactionContext, CancellationToken.None);
+            return (sut, context, transactionContext);
+        }
+
+        private const int MaxDeadLetterErrorDescriptionLength = 4096;
+
         [Fact]
         public async Task MustReturnFalseFromAckWhenNotPeekLock()
         {
@@ -95,6 +124,49 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
             var sut = await CreatePeekLockSutAsync();
             var result = await sut.DeadletterMessageAsync(CreateEmptyContext(), new TransactionContext("receiver"), "reason", "description", CancellationToken.None);
             result.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task MustForwardSubLimitDeadletterDescriptionUnchanged()
+        {
+            var inMemory = new InMemoryServiceBusMessageReceiver();
+            var (sut, context, transactionContext) = await ReceivedPeekLockMessageAsync(inMemory);
+            var description = new string('a', MaxDeadLetterErrorDescriptionLength - 1);
+
+            var result = await sut.DeadletterMessageAsync(context, transactionContext, "reason", description, CancellationToken.None);
+
+            result.Should().BeTrue();
+            inMemory.DeadLetteredLockTokens.Should().ContainSingle()
+                .Which.description.Should().Be(description);
+        }
+
+        [Fact]
+        public async Task MustForwardExactlyLimitDeadletterDescriptionUnchanged()
+        {
+            var inMemory = new InMemoryServiceBusMessageReceiver();
+            var (sut, context, transactionContext) = await ReceivedPeekLockMessageAsync(inMemory);
+            var description = new string('a', MaxDeadLetterErrorDescriptionLength);
+
+            var result = await sut.DeadletterMessageAsync(context, transactionContext, "reason", description, CancellationToken.None);
+
+            result.Should().BeTrue();
+            inMemory.DeadLetteredLockTokens.Should().ContainSingle()
+                .Which.description.Should().Be(description);
+        }
+
+        [Fact]
+        public async Task MustCapOverLimitDeadletterDescriptionWithoutThrowing()
+        {
+            var inMemory = new InMemoryServiceBusMessageReceiver();
+            var (sut, context, transactionContext) = await ReceivedPeekLockMessageAsync(inMemory);
+            var description = new string('a', MaxDeadLetterErrorDescriptionLength + 100);
+
+            var result = await sut.DeadletterMessageAsync(context, transactionContext, "reason", description, CancellationToken.None);
+
+            result.Should().BeTrue();
+            var captured = inMemory.DeadLetteredLockTokens.Should().ContainSingle().Subject.description;
+            captured.Length.Should().BeLessThanOrEqualTo(MaxDeadLetterErrorDescriptionLength);
+            captured.Should().StartWith(new string('a', 10));
         }
     }
 }


### PR DESCRIPTION
## Summary
Caps the Azure Service Bus deadletter error description to the SDK's **4096-character** limit at the ASB adapter boundary (`ServiceBusReceiver.DeadletterMessageAsync`), fixing `System.ArgumentOutOfRangeException` ("Maximum permitted length is 4096 (Parameter 'deadLetterErrorDescription')") raised on `OnDeadLetterAsync` when `Exception.ToString()` exceeds the limit.

## Approach
- Cap applied at the **ASB adapter** — the only layer that enforces the 4096 limit. Core `BrokeredMessageReceiver` is left untouched, so non-ASB brokers (e.g. SqlServiceBroker, which has no such limit) keep full descriptions.
- **Head-preserving truncation**: exception type + message + top frames retained; a `…[truncated]` marker is appended with its length reserved inside the 4096 budget (result length ≤ 4096, never 4096 + marker).
- Sub-limit and exactly-4096 descriptions pass through byte-for-byte unchanged. Null/empty forwarded as-is.
- Cap on UTF-16 `.Length` (matches how the SDK validates).

## Tests
3 characterization tests via the existing in-memory ASB receiver double (`InMemoryServiceBusMessageReceiver.DeadLetteredLockTokens`):
- sub-limit forwarded unchanged
- exactly-4096 boundary unchanged
- over-limit capped to ≤4096, no throw

## Versioning
PATCH bump `Chatter.MessageBrokers.AzureServiceBus` 0.10.1 → 0.10.2 + CHANGELOG `Fixed` entry.

## Validation
`dotnet test Chatter.sln` — green, 0 failures on net8.0 + net10.0.

Closes #92.