### PR TITLE
ci: scope ci.yml push trigger to master to stop PR double-runs (#129)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,17 +9,7 @@ on:
       - 'tests/**'
       - '.github/workflows/ci.yml'
   push:
-    branches:
-      - 'feature/**'
-      - 'bugfix/**'
-      - 'hotfix/**'
-      - 'refactor/**'
-      - 'chore/**'
-      - 'docs/**'
-      - 'test/**'
-      - 'ci/**'
-      - 'release/**'
-      - master
+    branches: [master]
     paths:
       - 'src/**'
       - 'tests/**'


### PR DESCRIPTION
## Summary
Scopes `.github/workflows/ci.yml` so each commit is validated **once**, fixing the double CI runs / duplicate `build` contexts / split verdicts described in #129.

## Root cause
The `push:` trigger still enumerated feature-branch prefixes (`feature/**`, `bugfix/**`, `hotfix/**`, `refactor/**`, `chore/**`, `docs/**`, `test/**`, `ci/**`, `release/**`, `master`). With an open PR, a push to a feature branch fired **both** the `push` event and `pull_request: synchronize` on the same SHA. The existing `concurrency` block can't dedupe them — `push` (`refs/heads/...`) and `pull_request` (`refs/pull/N/merge`) carry different `github.ref`, so they land in different concurrency groups.

## Fix (Option A)
- `push:` trigger narrowed to `branches: [master]` only (post-merge trunk validation), retaining its existing `paths:` filter.
- `pull_request` trigger (the PR merge gate), `workflow_dispatch`, `permissions`, and the `concurrency` block left unchanged.
- `build` job id/name **unchanged** — branch-protection required-status-check stays satisfied.

Result: a push to a PR branch → exactly one CI run via `pull_request`; no duplicate `build` contexts; pushes to master still validated.

## Tradeoff
Pushes to a feature branch with **no open PR** no longer trigger CI (validation happens at the PR gate). Intended per Option A.

## Validation
CI-YAML-only change; YAML parses valid; no source/test impact (diff vs master = `ci.yml` only). The reworked workflow runs on this PR as live validation.

## ⚠️ Pre-merge check
Confirm the branch-protection **required status check** is named `build` (Settings → Branches). Name is preserved, so this should remain satisfied.

Closes #129.