### PR TITLE
test(messagebrokers): characterize serialization paths before Newtonsoft→STJ port

### DIFF
--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/UsingBrokeredMessageOutbox/WhenSendingToOutbox.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/UsingBrokeredMessageOutbox/WhenSendingToOutbox.cs
@@ -5,7 +5,6 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
-using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -34,8 +33,11 @@ namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.UsingBrokered
             _sut = new BrokeredMessageOutbox<DbContext>(_context, _loggerFactory.Object);
         }
 
+        private const string FixedCorrelationId = "fixed-correlation-id";
+
         private OutboundBrokeredMessage CreateOutbound(string messageId = "msg-1", string destination = "test-destination")
-            => new OutboundBrokeredMessage(messageId, new byte[] { 1, 2, 3 }, new Dictionary<string, object>(), destination, _bodyConverter.Object);
+            => new OutboundBrokeredMessage(messageId, new byte[] { 1, 2, 3 }, new Dictionary<string, object>(), destination, _bodyConverter.Object)
+                .WithCorrelationId(FixedCorrelationId);
 
         [Fact]
         public async Task MustPersistOneOutboxMessagePerOutboundMessage()
@@ -69,7 +71,13 @@ namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.UsingBrokered
             await _sut.SendToOutbox(new[] { outbound }, null);
 
             var persisted = (await _dbContext.Set<OutboxMessage>().ToListAsync()).Single();
-            persisted.MessageContext.Should().Be(JsonConvert.SerializeObject(outbound.MessageContext));
+            // This literal pins the CURRENT Newtonsoft wire form of the persisted MessageContext.
+            // The OutboundBrokeredMessage ctor injects two headers in this order: ContentType
+            // (from the body converter) then CorrelationId (pinned via WithCorrelationId so the
+            // wire form is deterministic). MUST be updated when the Phase-2 STJ port intentionally
+            // changes the serialized form.
+            var expectedWire = $"{{\"{MessageContext.ContentType}\":\"application/json\",\"{MessageContext.CorrelationId}\":\"{FixedCorrelationId}\"}}";
+            persisted.MessageContext.Should().Be(expectedWire);
         }
 
         [Fact]

--- a/src/Chatter.MessageBrokers/tests/Reliability/Outbox/UsingInMemoryBrokeredMessageOutbox/WhenManagingOutbox.cs
+++ b/src/Chatter.MessageBrokers/tests/Reliability/Outbox/UsingInMemoryBrokeredMessageOutbox/WhenManagingOutbox.cs
@@ -63,6 +63,23 @@ namespace Chatter.MessageBrokers.Tests.Reliability.Outbox.UsingInMemoryBrokeredM
         }
 
         [Fact]
+        public async Task MustStoreNewtonsoftSerializedMessageContextWireString()
+        {
+            // This literal pins the CURRENT Newtonsoft wire form of the stored MessageContext.
+            // The OutboundBrokeredMessage ctor injects two headers in this order: ContentType
+            // (from the body converter) then CorrelationId (pinned via WithCorrelationId so the
+            // wire form is deterministic). MUST be updated when the Phase-2 STJ port intentionally
+            // changes the serialized form.
+            var outbound = CreateOutbound("id-1", "queue/path").WithCorrelationId("fixed-correlation-id");
+
+            await _sut.SendToOutbox(outbound, new TransactionContext());
+
+            var stored = (await _sut.GetUnprocessedMessagesFromOutbox()).Single();
+            var expectedWire = $"{{\"{MessageContext.ContentType}\":\"application/json\",\"{MessageContext.CorrelationId}\":\"fixed-correlation-id\"}}";
+            stored.MessageContext.Should().Be(expectedWire);
+        }
+
+        [Fact]
         public async Task MustThrowInvalidOperationWhenAddingDuplicateMessageId()
         {
             await _sut.SendToOutbox(CreateOutbound("id-1"), new TransactionContext());

--- a/src/Chatter.MessageBrokers/tests/Reliability/Outbox/UsingOutboxProcessor/WhenProcessingOutboxMessage.cs
+++ b/src/Chatter.MessageBrokers/tests/Reliability/Outbox/UsingOutboxProcessor/WhenProcessingOutboxMessage.cs
@@ -1,0 +1,102 @@
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Reliability;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Reliability.Outbox.UsingOutboxProcessor
+{
+    public class WhenProcessingOutboxMessage : Testing.Core.Context
+    {
+        private const string Infra = "test-infrastructure";
+        private const string ContentType = "application/json";
+
+        private readonly Mock<IMessagingInfrastructureProvider> _infrastructureProvider = new Mock<IMessagingInfrastructureProvider>();
+        private readonly Mock<IMessagingInfrastructureDispatcher> _dispatcher = new Mock<IMessagingInfrastructureDispatcher>();
+        private readonly Mock<ILogger<OutboxProcessor>> _logger = new Mock<ILogger<OutboxProcessor>>();
+        private readonly Mock<IBodyConverterFactory> _bodyConverterFactory = new Mock<IBodyConverterFactory>();
+        private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+        private readonly Mock<IBrokeredMessageOutbox> _outbox = new Mock<IBrokeredMessageOutbox>();
+        private readonly OutboxProcessor _sut;
+
+        public WhenProcessingOutboxMessage()
+        {
+            _infrastructureProvider.Setup(p => p.GetDispatcher(It.IsAny<string>())).Returns(_dispatcher.Object);
+            _bodyConverter.SetupGet(c => c.ContentType).Returns(ContentType);
+            _bodyConverter.Setup(c => c.GetBytes(It.IsAny<string>())).Returns(new byte[] { 1, 2, 3 });
+            _bodyConverterFactory.Setup(f => f.CreateBodyConverter(It.IsAny<string>())).Returns(_bodyConverter.Object);
+
+            // INVARIANT: OutboxProcessor.Process casts the outbox to IUnitOfWork and dispatches
+            // inside ExecuteAsync's callback; the mock MUST invoke that callback or dispatch never fires.
+            _outbox.As<IUnitOfWork>()
+                   .Setup(u => u.ExecuteAsync(It.IsAny<Func<CancellationToken, Task>>(), It.IsAny<TransactionContext>(), It.IsAny<CancellationToken>()))
+                   .Returns<Func<CancellationToken, Task>, TransactionContext, CancellationToken>((operation, _, ct) => operation(ct));
+
+            _sut = new OutboxProcessor(_infrastructureProvider.Object, _logger.Object, _bodyConverterFactory.Object, _outbox.Object);
+        }
+
+        // The MessageContext column persists a Newtonsoft-serialized IDictionary<string, object> as a
+        // JSON object string. Process deserializes it via JsonConvert.DeserializeObject and then performs
+        // hard (string) casts on the ContentType (:43) and InfrastructureType (:48) values. Under Newtonsoft
+        // those values deserialize to System.String, so the casts succeed.
+        //
+        // ORACLE: under System.Text.Json, DeserializeObject<IDictionary<string, object>> yields JsonElement
+        // values, and the (string) casts at :43 and :48 throw InvalidCastException. Process swallows that
+        // into _logger.LogError, so dispatch would silently never fire. These positive-dispatch assertions
+        // are what make that future break visible — a "does not throw" assertion alone would still pass.
+        private static string NewtonsoftSerializedContext()
+            => $"{{\"{MessageContext.ContentType}\":\"{ContentType}\",\"{MessageContext.InfrastructureType}\":\"{Infra}\"}}";
+
+        private static OutboxMessage CreateOutboxMessage()
+            => new OutboxMessage
+            {
+                Id = 1,
+                MessageId = "message-id",
+                Destination = "destination",
+                // Left empty so Process falls through to the (string) cast on messageContext[ContentType] at :43.
+                MessageContentType = null,
+                MessageContext = NewtonsoftSerializedContext(),
+                MessageBody = "message-body",
+            };
+
+        [Fact]
+        public async Task MustResolveDispatcherUsingInfrastructureTypeFromDeserializedContext()
+        {
+            await _sut.Process(CreateOutboxMessage());
+
+            _infrastructureProvider.Verify(p => p.GetDispatcher(Infra), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustResolveBodyConverterUsingContentTypeFromDeserializedContext()
+        {
+            await _sut.Process(CreateOutboxMessage());
+
+            _bodyConverterFactory.Verify(f => f.CreateBodyConverter(ContentType), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustDispatchOutboundMessageToInfrastructure()
+        {
+            await _sut.Process(CreateOutboxMessage());
+
+            _dispatcher.Verify(d => d.Dispatch(It.IsAny<OutboundBrokeredMessage>(), null), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustMarkOutboxMessageProcessed()
+        {
+            var message = CreateOutboxMessage();
+
+            await _sut.Process(message);
+
+            _outbox.Verify(o => o.UpdateProcessedDate(message, It.IsAny<CancellationToken>()), Times.Once);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingRoutingSlipSerialization/WhenRoundTrippingThroughJson.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingRoutingSlipSerialization/WhenRoundTrippingThroughJson.cs
@@ -1,0 +1,75 @@
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Routing.Slips;
+using FluentAssertions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingRoutingSlipSerialization
+{
+    // CHARACTERIZATION TEST: pins the CURRENT Newtonsoft.Json round-trip behavior of RoutingSlip
+    // through the real production seams (InboundBrokeredMessage.WithRoutingSlip serialize +
+    // MessageBrokerContext.TryGetRoutingSlip deserialize). It exists so the planned
+    // Newtonsoft -> System.Text.Json port can be verified to preserve observable round-trip behavior.
+    //
+    // INVARIANT: assertions pin round-trip FIDELITY (Id, Route count, ordered DestinationPath),
+    // NOT the exact JSON wire bytes. The wire format is a serializer-internal detail that the STJ
+    // port is permitted to change, so asserting exact bytes here would falsely fail the port.
+    public class WhenRoundTrippingThroughJson : Testing.Core.Context
+    {
+        private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+
+        public WhenRoundTrippingThroughJson()
+            => _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+
+        private MessageBrokerContext CreateContext(IDictionary<string, object> messageContext)
+            => new MessageBrokerContext("message-id", new byte[] { 1 }, messageContext, "receiver-path", CancellationToken.None, _bodyConverter.Object);
+
+        [Fact]
+        public void MustRoundTripRoutingSlipThroughProductionSeams()
+        {
+            var id = Guid.NewGuid();
+
+            // Use a NON-EMPTY Route so that RoutingStep's private parameterless [JsonConstructor]
+            // is the load-bearing deserialize mechanism on the way back. The Phase-2 STJ port MUST
+            // preserve binding to this non-public constructor or this round-trip breaks.
+            var slip = RoutingSlipBuilder.NewRoutingSlip(id)
+                .WithRoute("a")
+                .WithRoute("b")
+                .Build();
+
+            // SERIALIZE seam: the dictionary instance handed to the context is the same instance the
+            // InboundBrokeredMessage wraps, so WithRoutingSlip writes the serialized slip string into it
+            // under MessageContext.RoutingSlip.
+            var serializeContext = new Dictionary<string, object>();
+            var serializeSut = CreateContext(serializeContext);
+            serializeSut.BrokeredMessage.WithRoutingSlip(slip);
+
+            serializeContext.Should().ContainKey(MessageContext.RoutingSlip);
+            var serializedSlip = serializeContext[MessageContext.RoutingSlip];
+
+            // DESERIALIZE seam: seed the serialized slip string into a fresh context's message-context
+            // dictionary, then deserialize through TryGetRoutingSlip.
+            var deserializeContext = new Dictionary<string, object>
+            {
+                [MessageContext.RoutingSlip] = serializedSlip
+            };
+            var deserializeSut = CreateContext(deserializeContext);
+
+            var found = deserializeSut.TryGetRoutingSlip(out var roundTrippedSlip);
+
+            found.Should().BeTrue();
+            roundTrippedSlip.Id.Should().Be(id);
+            roundTrippedSlip.Route.Should().HaveCount(2);
+            roundTrippedSlip.Route[0].DestinationPath.Should().Be("a");
+            roundTrippedSlip.Route[1].DestinationPath.Should().Be("b");
+
+            // KNOWN UNTESTED SUB-SURFACE: RoutingSlip.Attachments (IDictionary<string, object>) is left
+            // empty here on purpose. Its object-boxing round-trip is serializer-dependent (Newtonsoft
+            // boxes to JObject; STJ would box to JsonElement), so it is an STJ-changeable surface that is
+            // intentionally NOT pinned by this characterization test.
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Phase 1 of the Newtonsoft.Json → System.Text.Json migration: **characterization tests only** — pins currently-unguarded serialization behavior in `Chatter.MessageBrokers` so the future STJ port is verifiable. No production change, no version bump.

A read-only readiness assessment found the body-converter seam already well-covered (wire-format-pinned), but three higher-risk paths unguarded. This PR closes those gaps.

## Tests added / fixed
1. **RoutingSlip JSON round-trip** (new `WhenRoundTrippingThroughJson.cs`) — serialize via `WithRoutingSlip` → deserialize via `TryGetRoutingSlip`; asserts round-trip **fidelity** (Id, Route order, DestinationPath). Exercises `RoutingStep`'s **private `[JsonConstructor]`** as the load-bearing deserialize mechanism the STJ port must preserve. (Attachments boxing intentionally left unpinned — STJ-changeable.)
2. **OutboxProcessor** (new `WhenProcessingOutboxMessage.cs` — no test existed) — pins `DeserializeObject<IDictionary<string,object>>` + the downstream `(string)` casts. Asserts dispatch **positively occurred** (not just "no throw") because `Process` swallows exceptions — so a future STJ `JsonElement`-cast break is caught.
3. **De-tautologized outbox assertions** — EF `WhenSendingToOutbox.cs` L72 previously asserted `output == JsonConvert.SerializeObject(output)` (pinned nothing). Now asserts an **expected literal wire string** built from `MessageContext` key constants. Added the missing parallel `[Fact]` for `InMemoryBrokeredMessageOutbox`. Discovered the ctor auto-injects a random `CorrelationId` → pinned deterministically so the literal is stable.

## Wire format pinned (Newtonsoft, today)
`{"Chatter.ContentType":"application/json","Chatter.CorrelationId":"<id>"}` — comments mark these literals as **must-update** when the STJ port intentionally changes the wire format.

## Validation
`dotnet test Chatter.sln` — green, 0 failures, net8.0 + net10.0 (MessageBrokers 371/371, EF 58/58).

## Next (Phase 2, not in this PR)
The STJ port itself. Oracles in place: the `JsonElement`-cast break in OutboxProcessor and the non-public-ctor slip binding are now both visible. Note: a shared characterization helper (deterministic CorrelationId + literal builder from key constants) may be worth extracting in Phase 2 — flagged during implementation.