### PR TITLE
fix(azureservicebus): make cross-entity transactions opt-in (multi-receiver regression)

### DIFF
--- a/src/Chatter.CQRS/src/Chatter.CQRS/CHANGELOG.md
+++ b/src/Chatter.CQRS/src/Chatter.CQRS/CHANGELOG.md
@@ -12,6 +12,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [0.8.1] - 2026-06-08
+
+### Fixed
+
+- Assembly-source scan no longer throws `ReflectionTypeLoadException` when a loaded assembly (e.g. a dynamic-proxy/mock assembly) contains unloadable types; it now uses the loadable types.
+
 ## [0.8.0] - 2026-05-30
 
 ### Changed

--- a/src/Chatter.CQRS/src/Chatter.CQRS/CHANGELOG.md
+++ b/src/Chatter.CQRS/src/Chatter.CQRS/CHANGELOG.md
@@ -16,7 +16,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
-- Assembly-source scan no longer throws `ReflectionTypeLoadException` when a loaded assembly (e.g. a dynamic-proxy/mock assembly) contains unloadable types; it now uses the loadable types.
+- Assembly-source scan no longer throws `ReflectionTypeLoadException` when a loaded assembly (e.g. a dynamic-proxy/mock assembly) contains unloadable types; it now uses the loadable types. Dynamic assemblies (e.g. `DynamicProxyGenAssembly2`) are now also excluded from the scan source, so they never reach the underlying type enumeration that throws on them.
 
 ## [0.8.0] - 2026-05-30
 

--- a/src/Chatter.CQRS/src/Chatter.CQRS/Chatter.CQRS.csproj
+++ b/src/Chatter.CQRS/src/Chatter.CQRS/Chatter.CQRS.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.CQRS</PackageId>
-    <Version>0.8.0</Version>
+    <Version>0.8.1</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An extensible CQRS library that supports passing of context to message handlers.</Description>

--- a/src/Chatter.CQRS/src/Chatter.CQRS/DependencyInjection/AssemblySourceFilter.cs
+++ b/src/Chatter.CQRS/src/Chatter.CQRS/DependencyInjection/AssemblySourceFilter.cs
@@ -51,8 +51,26 @@ namespace Chatter.CQRS.DependencyInjection
             => ExplictAssemblies.Union(GetAssembliesThatMatchNamespaceSelector());
 
         private IEnumerable<Assembly> GetAssembliesThatMatchNamespaceSelector()
-            => AssemblySourceProvider.GetSourceAssemblies().Where(assembly => assembly.GetTypes()
+            => AssemblySourceProvider.GetSourceAssemblies().Where(assembly => SafeGetLoadableTypes(assembly)
                 .Any(type => IsMatchingNamespaceSelector(type.Namespace)) || IsMatchingNamespaceSelector(assembly.FullName));
+
+        /// <summary>
+        /// Returns the types defined in <paramref name="assembly"/>, falling back to the loadable subset when the
+        /// assembly contains unloadable types. A loaded assembly with unloadable types (e.g. a dynamic-proxy/mock
+        /// assembly such as DynamicProxyGenAssembly2) would otherwise cause <see cref="Assembly.GetTypes"/> to throw
+        /// <see cref="ReflectionTypeLoadException"/> and abort the entire assembly-source scan.
+        /// </summary>
+        internal static IEnumerable<Type> SafeGetLoadableTypes(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.Where(type => type is not null)!;
+            }
+        }
 
         private bool IsMatchingNamespaceSelector(string comparator)
             => string.IsNullOrWhiteSpace(NamespaceSelector)

--- a/src/Chatter.CQRS/src/Chatter.CQRS/DependencyInjection/CurrentAppDomainAssemblyProvider.cs
+++ b/src/Chatter.CQRS/src/Chatter.CQRS/DependencyInjection/CurrentAppDomainAssemblyProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 
 namespace Chatter.CQRS.DependencyInjection
@@ -10,6 +11,9 @@ namespace Chatter.CQRS.DependencyInjection
 
         internal static CurrentAppDomainAssemblyProvider Default => new CurrentAppDomainAssemblyProvider();
 
-        public IEnumerable<Assembly> GetSourceAssemblies() => AppDomain.CurrentDomain.GetAssemblies();
+        // INVARIANT: dynamic assemblies (e.g. mock/dynamic-proxy assemblies like DynamicProxyGenAssembly2)
+        // can never contain Chatter handlers/behaviors and are inherently unscannable; excluding them here
+        // stops them from reaching Scrutor's FromAssemblies type enumeration, which throws on dynamic assemblies.
+        public IEnumerable<Assembly> GetSourceAssemblies() => AppDomain.CurrentDomain.GetAssemblies().Where(assembly => !assembly.IsDynamic);
     }
 }

--- a/src/Chatter.CQRS/tests/DependencyInjection/UsingAssemblySourceFilter/WhenApplyingFilter.cs
+++ b/src/Chatter.CQRS/tests/DependencyInjection/UsingAssemblySourceFilter/WhenApplyingFilter.cs
@@ -2,6 +2,8 @@
 using Chatter.Testing.Core.Creators.Common;
 using Chatter.Testing.Core.Creators.CQRS;
 using FluentAssertions;
+using Moq;
+using System;
 using System.Linq;
 using System.Reflection;
 using Xunit;
@@ -255,6 +257,59 @@ namespace Chatter.CQRS.Tests.DependencyInjection.UsingAssemblySourceFilter
             var result = filter.Apply();
 
             result.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void MustTolerateAssemblyWhoseGetTypesThrowsReflectionTypeLoadExceptionAndStillDiscoverMatchingAssemblies()
+        {
+            var throwingAssemblyMock = new Mock<Assembly>();
+            throwingAssemblyMock.SetupGet(a => a.FullName).Returns("DynamicProxyGenAssembly2");
+            throwingAssemblyMock.Setup(a => a.GetTypes())
+                                .Throws(new ReflectionTypeLoadException(new Type[] { null }, new Exception[] { new Exception() }));
+
+            var @namespace = "This.is.a.Namespace";
+            var type = New.Common().Type
+                .WithNamespace(@namespace)
+                .Creation;
+            var matchingAssembly = New.Common().Assembly
+                .WithTypes(type)
+                .Creation;
+
+            var assemblyFilterSourceProvider = New.Cqrs().AssemblyFilterSourceProvider
+                .WithSourceAssemblies(throwingAssemblyMock.Object, matchingAssembly)
+                .Creation;
+
+            var filter = new AssemblySourceFilter(assemblyFilterSourceProvider, @namespace.ToUpper(), null);
+            var result = filter.Apply();
+
+            result.Should().HaveCount(1);
+            result.Should().Contain(matchingAssembly);
+        }
+
+        [Fact]
+        public void MustReturnNonNullLoadableTypesWhenGetTypesThrowsReflectionTypeLoadException()
+        {
+            var loadableType = New.Common().Type.Creation;
+            var assemblyMock = new Mock<Assembly>();
+            assemblyMock.Setup(a => a.GetTypes())
+                        .Throws(new ReflectionTypeLoadException(new Type[] { loadableType, null }, new Exception[] { new Exception() }));
+
+            var result = AssemblySourceFilter.SafeGetLoadableTypes(assemblyMock.Object);
+
+            result.Should().ContainSingle().Which.Should().BeSameAs(loadableType);
+        }
+
+        [Fact]
+        public void MustReturnAllTypesWhenGetTypesDoesNotThrow()
+        {
+            var type = New.Common().Type.Creation;
+            var assembly = New.Common().Assembly
+                .WithTypes(type)
+                .Creation;
+
+            var result = AssemblySourceFilter.SafeGetLoadableTypes(assembly);
+
+            result.Should().ContainSingle().Which.Should().BeSameAs(type);
         }
     }
 }

--- a/src/Chatter.CQRS/tests/DependencyInjection/UsingCurrentAppDomainAssemblyProvider/WhenGettingSourceAssemblies.cs
+++ b/src/Chatter.CQRS/tests/DependencyInjection/UsingCurrentAppDomainAssemblyProvider/WhenGettingSourceAssemblies.cs
@@ -2,6 +2,8 @@
 using FluentAssertions;
 using System;
 using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
 using Xunit;
 
 namespace Chatter.CQRS.Tests.DependencyInjection.UsingAssemblySourceProvider
@@ -15,7 +17,9 @@ namespace Chatter.CQRS.Tests.DependencyInjection.UsingAssemblySourceProvider
             // least this snapshot. Asserting a superset (rather than exact-set equality) keeps
             // the test order-independent and tolerant of assemblies loaded between the two
             // calls, while still failing if the provider drops currently-loaded assemblies.
-            var snapshot = AppDomain.CurrentDomain.GetAssemblies();
+            // Dynamic assemblies are excluded from the snapshot because the provider intentionally
+            // filters them out (they are inherently unscannable).
+            var snapshot = AppDomain.CurrentDomain.GetAssemblies().Where(assembly => !assembly.IsDynamic).ToArray();
 
             var actual = CurrentAppDomainAssemblyProvider.Default.GetSourceAssemblies().ToList();
 
@@ -23,6 +27,25 @@ namespace Chatter.CQRS.Tests.DependencyInjection.UsingAssemblySourceProvider
             actual.Should().Contain(snapshot);
             actual.Should().Contain(typeof(CurrentAppDomainAssemblyProvider).Assembly);
             actual.Should().Contain(typeof(WhenGettingSourceAssemblies).Assembly);
+        }
+
+        [Fact]
+        public void MustExcludeDynamicAssemblies()
+        {
+            // Emit a dynamic assembly so it is present in the current AppDomain. Dynamic assemblies
+            // (e.g. mock/dynamic-proxy assemblies like DynamicProxyGenAssembly2) are inherently
+            // unscannable and would throw when handed to Scrutor's type enumeration, so the provider
+            // must exclude them at the source.
+            var dynamicAssembly = AssemblyBuilder.DefineDynamicAssembly(
+                new AssemblyName($"Chatter.Tests.Dynamic.{Guid.NewGuid():N}"),
+                AssemblyBuilderAccess.Run);
+            dynamicAssembly.IsDynamic.Should().BeTrue();
+
+            var actual = CurrentAppDomainAssemblyProvider.Default.GetSourceAssemblies().ToList();
+
+            actual.Should().NotContain(assembly => assembly.IsDynamic);
+            actual.Should().NotContain(dynamicAssembly);
+            actual.Should().Contain(typeof(CurrentAppDomainAssemblyProvider).Assembly);
         }
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -12,6 +12,22 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [1.1.0] - 2026-06-09
+
+### Added
+
+- `ServiceBusOptions.EnableCrossEntityTransactions` (default `false`) and `ServiceBusOptionsBuilder.WithCrossEntityTransactions()` opt-in for explicitly enabling cross-entity transaction support.
+- Startup guard that fails fast with a clear error when cross-entity transactions are enabled alongside more than one distinct top-level receiver entity.
+
+### Changed
+
+- `EnableCrossEntityTransactions` now defaults to `false` and is auto-enabled only when a `FullAtomicityViaInfrastructure` receiver is registered (previously always on).
+
+### Fixed
+
+- Cross-entity transactions are no longer forced on, so a host can run multiple queue receivers on distinct entities again (regression introduced in 1.0.0 by the Azure.Messaging.ServiceBus migration).
+- The fatal cross-entity rejection now surfaces as a `CriticalReceiverException` instead of hanging silently.
+
 ## [1.0.0] - 2026-06-08
 
 ### Changed

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -29,6 +29,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 - The fatal cross-entity rejection now surfaces as a `CriticalReceiverException` instead of hanging silently.
 - A global `WithTransactionMode(FullAtomicityViaInfrastructure)` now correctly auto-enables cross-entity transactions on the shared client; previously only per-receiver transaction modes were honored, so receivers inheriting the global atomicity mode silently lost the cross-entity guarantee.
 - `ServiceBusOptions.EnableCrossEntityTransactions` now has a public setter so the cross-entity opt-in binds from configuration (`Chatter:Infrastructure:AzureServiceBus:EnableCrossEntityTransactions`); previously the `internal` setter meant `ConfigurationBinder` silently skipped it and config-only opt-in was ignored.
+- An explicit `WithCrossEntityTransactions(false)` now overrides a config-bound `EnableCrossEntityTransactions = true`; previously the fluent value was applied only when it differed from the default, so an explicit disable was silently ignored when configuration enabled it.
 
 ## [1.0.0] - 2026-06-08
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -28,6 +28,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 - Cross-entity transactions are no longer forced on, so a host can run multiple queue receivers on distinct entities again (regression introduced in 1.0.0 by the Azure.Messaging.ServiceBus migration).
 - The fatal cross-entity rejection now surfaces as a `CriticalReceiverException` instead of hanging silently.
 - A global `WithTransactionMode(FullAtomicityViaInfrastructure)` now correctly auto-enables cross-entity transactions on the shared client; previously only per-receiver transaction modes were honored, so receivers inheriting the global atomicity mode silently lost the cross-entity guarantee.
+- `ServiceBusOptions.EnableCrossEntityTransactions` now has a public setter so the cross-entity opt-in binds from configuration (`Chatter:Infrastructure:AzureServiceBus:EnableCrossEntityTransactions`); previously the `internal` setter meant `ConfigurationBinder` silently skipped it and config-only opt-in was ignored.
 
 ## [1.0.0] - 2026-06-08
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -27,6 +27,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 - Cross-entity transactions are no longer forced on, so a host can run multiple queue receivers on distinct entities again (regression introduced in 1.0.0 by the Azure.Messaging.ServiceBus migration).
 - The fatal cross-entity rejection now surfaces as a `CriticalReceiverException` instead of hanging silently.
+- A global `WithTransactionMode(FullAtomicityViaInfrastructure)` now correctly auto-enables cross-entity transactions on the shared client; previously only per-receiver transaction modes were honored, so receivers inheriting the global atomicity mode silently lost the cross-entity guarantee.
 
 ## [1.0.0] - 2026-06-08
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.AzureServiceBus</PackageId>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for Azure Service Bus.</Description>

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
@@ -9,6 +9,7 @@ using Chatter.MessageBrokers.AzureServiceBus.Receiving;
 using Chatter.MessageBrokers.AzureServiceBus.Receiving.CircuitBreaker;
 using Chatter.MessageBrokers.AzureServiceBus.Receiving.Retry;
 using Chatter.MessageBrokers.AzureServiceBus.Sending;
+using Chatter.MessageBrokers.Configuration;
 using Chatter.MessageBrokers.Receiving;
 using Chatter.MessageBrokers.Recovery.CircuitBreaker;
 using Chatter.MessageBrokers.Recovery.Retry;
@@ -62,7 +63,8 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddSingleton(sp =>
             {
                 var registry = sp.GetRequiredService<ServiceBusReceiverRegistry>();
-                var enableCrossEntityTransactions = ResolveEffectiveCrossEntityTransactions(options, registry);
+                var globalTransactionMode = sp.GetRequiredService<MessageBrokerOptions>().TransactionMode;
+                var enableCrossEntityTransactions = ResolveEffectiveCrossEntityTransactions(options, registry, globalTransactionMode);
                 return CreateSharedClient(options, enableCrossEntityTransactions);
             });
             builder.Services.AddSingleton<IServiceBusMessageSenderFactory>(sp =>
@@ -101,14 +103,16 @@ namespace Microsoft.Extensions.DependencyInjection
 
         // Computes the EFFECTIVE cross-entity-transactions flag for the shared client and enforces the
         // single-top-level-entity startup guard. Cross-entity is ON when explicitly opted in via
-        // ServiceBusOptions OR when any registered receiver requested FullAtomicityViaInfrastructure (which
-        // depends on it). When ON, Azure Service Bus pins the client to ONE top-level entity, so registering
-        // more than one distinct top-level receiver entity (queue name / topic name; subscriptions on the
-        // same topic count once) is unsupportable — fail fast and loud at startup rather than letting the SDK
-        // silently fail the second receiver.
-        private static bool ResolveEffectiveCrossEntityTransactions(ServiceBusOptions options, ServiceBusReceiverRegistry registry)
+        // ServiceBusOptions OR when any registered receiver's EFFECTIVE transaction mode is
+        // FullAtomicityViaInfrastructure (which depends on it). A receiver with no per-call mode inherits the
+        // global MessageBrokerOptions.TransactionMode, so globalTransactionMode is folded into that
+        // per-receiver effective-mode computation. When ON, Azure Service Bus pins the client to ONE
+        // top-level entity, so registering more than one distinct top-level receiver entity (queue name /
+        // topic name; subscriptions on the same topic count once) is unsupportable — fail fast and loud at
+        // startup rather than letting the SDK silently fail the second receiver.
+        private static bool ResolveEffectiveCrossEntityTransactions(ServiceBusOptions options, ServiceBusReceiverRegistry registry, TransactionMode globalTransactionMode)
         {
-            var effective = options.EnableCrossEntityTransactions || registry.AnyRequiresCrossEntityTransactions();
+            var effective = options.EnableCrossEntityTransactions || registry.AnyRequiresCrossEntityTransactions(globalTransactionMode);
             if (!effective)
             {
                 return false;

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
@@ -3,6 +3,7 @@ using Chatter.CQRS.DependencyInjection;
 using Chatter.CQRS.Events;
 using Chatter.MessageBrokers;
 using Chatter.MessageBrokers.AzureServiceBus;
+using Chatter.MessageBrokers.AzureServiceBus.DependencyInjection;
 using Chatter.MessageBrokers.AzureServiceBus.Options;
 using Chatter.MessageBrokers.AzureServiceBus.Receiving;
 using Chatter.MessageBrokers.AzureServiceBus.Receiving.CircuitBreaker;
@@ -12,6 +13,8 @@ using Chatter.MessageBrokers.Receiving;
 using Chatter.MessageBrokers.Recovery.CircuitBreaker;
 using Chatter.MessageBrokers.Recovery.Retry;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using ServiceBusClient = Azure.Messaging.ServiceBus.ServiceBusClient;
 using ServiceBusClientOptions = Azure.Messaging.ServiceBus.ServiceBusClientOptions;
 using ServiceBusConnectionStringProperties = Azure.Messaging.ServiceBus.ServiceBusConnectionStringProperties;
@@ -39,14 +42,29 @@ namespace Microsoft.Extensions.DependencyInjection
             builder.Services.AddScoped<ServiceBusReceiver>();
             builder.Services.AddScoped<ServiceBusMessageSender>();
 
-            // INVARIANT: a single shared ServiceBusClient per namespace. Cross-entity transactions require
-            // one client per namespace, so the client is a singleton built once from ServiceBusOptions with
-            // EnableCrossEntityTransactions enabled; receivers and senders are created off this one client.
-            // The client is registered via a factory delegate (not as a pre-built implementation instance) so
-            // the container OWNS it: Microsoft DI disposes only the singletons it creates, so factory
-            // registration ensures the client — and the senders cached off it — are disposed on provider
-            // teardown (e.g. when apps/tests dispose and rebuild the service provider).
-            builder.Services.AddSingleton(_ => CreateSharedClient(options));
+            // Ensure the receiver registry exists even when no receivers were configured (e.g. a send-only
+            // host), so the shared-client factory can always resolve it. AddQueueReceiver/AddTopicSubscription
+            // run before this (the options delegate completes before AddAzureServiceBus(builder, options)),
+            // so any populated registry is reused here rather than replaced.
+            GetOrAddReceiverRegistry(builder.Services);
+
+            // INVARIANT: a single shared ServiceBusClient per namespace. The client is a singleton built once
+            // from ServiceBusOptions; receivers and senders are created off this one client. The client is
+            // registered via a factory delegate (not as a pre-built implementation instance) so the container
+            // OWNS it: Microsoft DI disposes only the singletons it creates, so factory registration ensures
+            // the client — and the senders cached off it — are disposed on provider teardown (e.g. when
+            // apps/tests dispose and rebuild the service provider).
+            //
+            // The factory reads the receiver registry at lazy build-time (after all AddQueueReceiver/
+            // AddTopicSubscription calls have run, before the first hosted-service pump starts) to compute the
+            // effective cross-entity-transactions flag and to enforce the single-top-level-entity guard. It
+            // reads ReceiverOptions FROM THE REGISTRY, never re-entering DI to resolve receivers.
+            builder.Services.AddSingleton(sp =>
+            {
+                var registry = sp.GetRequiredService<ServiceBusReceiverRegistry>();
+                var enableCrossEntityTransactions = ResolveEffectiveCrossEntityTransactions(options, registry);
+                return CreateSharedClient(options, enableCrossEntityTransactions);
+            });
             builder.Services.AddSingleton<IServiceBusMessageSenderFactory>(sp =>
                 new AzureSdkMessageSenderFactory(sp.GetRequiredService<ServiceBusClient>()));
             builder.Services.AddSingleton<AzureServiceBusEntityPathBuilder>();
@@ -81,16 +99,43 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
+        // Computes the EFFECTIVE cross-entity-transactions flag for the shared client and enforces the
+        // single-top-level-entity startup guard. Cross-entity is ON when explicitly opted in via
+        // ServiceBusOptions OR when any registered receiver requested FullAtomicityViaInfrastructure (which
+        // depends on it). When ON, Azure Service Bus pins the client to ONE top-level entity, so registering
+        // more than one distinct top-level receiver entity (queue name / topic name; subscriptions on the
+        // same topic count once) is unsupportable — fail fast and loud at startup rather than letting the SDK
+        // silently fail the second receiver.
+        private static bool ResolveEffectiveCrossEntityTransactions(ServiceBusOptions options, ServiceBusReceiverRegistry registry)
+        {
+            var effective = options.EnableCrossEntityTransactions || registry.AnyRequiresCrossEntityTransactions();
+            if (!effective)
+            {
+                return false;
+            }
+
+            var distinctTopLevelEntities = registry.DistinctTopLevelEntities();
+            if (distinctTopLevelEntities.Count > 1)
+            {
+                var entityList = string.Join(", ", distinctTopLevelEntities);
+                throw new InvalidOperationException(
+                    $"Azure Service Bus cross-entity transactions support only a single top-level receiver entity per host; found: {entityList}. Disable cross-entity (default) or consolidate receivers.");
+            }
+
+            return true;
+        }
+
         // Builds the single shared ServiceBusClient for the namespace from ServiceBusOptions. A null
         // TokenCredential means SAS auth via the connection string; a non-null TokenCredential authenticates
         // against the fully-qualified namespace derived from the connection string's Endpoint. Cross-entity
-        // transactions are enabled on the client so the send + the receiver's settle enlist in one
-        // transaction, and the configured RetryOptions (when present) are carried onto the client.
-        private static ServiceBusClient CreateSharedClient(ServiceBusOptions options)
+        // transactions are enabled on the client (per the resolved effective flag) so the send + the
+        // receiver's settle enlist in one transaction, and the configured RetryOptions (when present) are
+        // carried onto the client.
+        private static ServiceBusClient CreateSharedClient(ServiceBusOptions options, bool enableCrossEntityTransactions)
         {
             var clientOptions = new ServiceBusClientOptions
             {
-                EnableCrossEntityTransactions = true,
+                EnableCrossEntityTransactions = enableCrossEntityTransactions,
             };
             if (options.RetryOptions != null)
             {
@@ -115,6 +160,9 @@ namespace Microsoft.Extensions.DependencyInjection
                                                                               int maxReceiveAttempts = 10)
             where TMessage : class, IEvent
         {
+            // The TOPIC is the top-level entity Azure Service Bus pins a cross-entity transaction to; two
+            // subscriptions on the same topic share one top-level entity.
+            GetOrAddReceiverRegistry(builder.Services).Register(topicName, transactionMode);
             builder.Services.AddReceiver<TMessage>(subscriptionName, errorQueuePath, description, topicName, transactionMode, ASBMessageContext.InfrastructureType, maxReceiveAttempts: maxReceiveAttempts);
             return builder;
         }
@@ -127,8 +175,27 @@ namespace Microsoft.Extensions.DependencyInjection
                                                                           int maxReceiveAttempts = 10)
             where TMessage : class, ICommand
         {
+            // The QUEUE is itself the top-level entity Azure Service Bus pins a cross-entity transaction to.
+            GetOrAddReceiverRegistry(builder.Services).Register(queueName, transactionMode);
             builder.Services.AddReceiver<TMessage>(queueName, errorQueuePath, description, queueName, transactionMode, ASBMessageContext.InfrastructureType, maxReceiveAttempts: maxReceiveAttempts);
             return builder;
+        }
+
+        // Resolves the single ServiceBusReceiverRegistry instance shared across all AddQueueReceiver/
+        // AddTopicSubscription calls and the shared-client factory, registering it on first use. The instance
+        // is captured directly into the singleton descriptor so the same object is both written here (at
+        // registration) and read by the client factory (at lazy resolve).
+        private static ServiceBusReceiverRegistry GetOrAddReceiverRegistry(IServiceCollection services)
+        {
+            var existing = services.FirstOrDefault(d => d.ServiceType == typeof(ServiceBusReceiverRegistry));
+            if (existing?.ImplementationInstance is ServiceBusReceiverRegistry registry)
+            {
+                return registry;
+            }
+
+            registry = new ServiceBusReceiverRegistry();
+            services.AddSingleton(registry);
+            return registry;
         }
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
@@ -1,0 +1,53 @@
+using Chatter.MessageBrokers.Receiving;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
+{
+    // INVARIANT: a write-at-registration, read-at-client-build registry of the Azure Service Bus receivers
+    // configured on a host. AddQueueReceiver/AddTopicSubscription append to it as they run (all complete
+    // before the shared ServiceBusClient is first resolved), and the client factory reads it to compute the
+    // effective cross-entity-transactions flag and to enforce the single-top-level-entity startup guard.
+    // ReceiverOptions are captured here (not resolved from the container) so the singleton client factory
+    // never re-enters DI to inspect receivers.
+    internal sealed class ServiceBusReceiverRegistry
+    {
+        private readonly List<RegisteredReceiver> _receivers = new List<RegisteredReceiver>();
+
+        // Records a configured receiver. topLevelEntity is the queue name for a queue receiver or the TOPIC
+        // name for a subscription — the unit Azure Service Bus pins a cross-entity transaction to. Two
+        // subscriptions on the same topic share one top-level entity and so do not count as distinct.
+        public void Register(string topLevelEntity, TransactionMode? transactionMode)
+        {
+            _receivers.Add(new RegisteredReceiver(topLevelEntity, transactionMode));
+        }
+
+        // True when any configured receiver requested FullAtomicityViaInfrastructure, which requires
+        // cross-entity transactions on the shared client.
+        public bool AnyRequiresCrossEntityTransactions()
+            => _receivers.Any(r => r.TransactionMode == TransactionMode.FullAtomicityViaInfrastructure);
+
+        // The set of DISTINCT top-level receiver entities (queue names / topic names), case-insensitive to
+        // match Azure Service Bus entity-name semantics. Used by the startup guard to detect the
+        // unsupportable cross-entity + multiple-top-level-entity combination.
+        public IReadOnlyCollection<string> DistinctTopLevelEntities()
+            => _receivers
+                .Where(r => !string.IsNullOrWhiteSpace(r.TopLevelEntity))
+                .Select(r => r.TopLevelEntity)
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToList();
+
+        private readonly struct RegisteredReceiver
+        {
+            public RegisteredReceiver(string topLevelEntity, TransactionMode? transactionMode)
+            {
+                TopLevelEntity = topLevelEntity;
+                TransactionMode = transactionMode;
+            }
+
+            public string TopLevelEntity { get; }
+            public TransactionMode? TransactionMode { get; }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
@@ -23,10 +23,13 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
             _receivers.Add(new RegisteredReceiver(topLevelEntity, transactionMode));
         }
 
-        // True when any configured receiver requested FullAtomicityViaInfrastructure, which requires
-        // cross-entity transactions on the shared client.
-        public bool AnyRequiresCrossEntityTransactions()
-            => _receivers.Any(r => r.TransactionMode == TransactionMode.FullAtomicityViaInfrastructure);
+        // True when any configured receiver's EFFECTIVE transaction mode is FullAtomicityViaInfrastructure,
+        // which requires cross-entity transactions on the shared client. A receiver registered with no
+        // per-call mode (null) inherits the global MessageBrokerOptions.TransactionMode at runtime (mirroring
+        // BrokeredMessageReceiver's `options.TransactionMode ??= _messageBrokerOptions.TransactionMode`), so
+        // the effective mode folds the global mode in: per-call ?? global.
+        public bool AnyRequiresCrossEntityTransactions(TransactionMode globalTransactionMode)
+            => _receivers.Any(r => (r.TransactionMode ?? globalTransactionMode) == TransactionMode.FullAtomicityViaInfrastructure);
 
         // The set of DISTINCT top-level receiver entities (queue names / topic names), case-insensitive to
         // match Azure Service Bus entity-name semantics. Used by the startup guard to detect the

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptions.cs
@@ -19,7 +19,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         // top-level entity throws "Local transactions cannot span multiple top-level entities". This is
         // auto-enabled when a FullAtomicityViaInfrastructure receiver is registered; opt in explicitly here
         // only when a single-entity host needs cross-entity send+settle atomicity.
-        public bool EnableCrossEntityTransactions { get; internal set; }
+        public bool EnableCrossEntityTransactions { get; set; }
         internal RetryPolicyConfiguation RetryPolicy { get; set; }
         [JsonIgnore]
         public ServiceBusRetryOptions RetryOptions { get; internal set; }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptions.cs
@@ -14,6 +14,12 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         public string ConnectionString { get; set; }
         public int MaxConcurrentCalls { get; set; } = 1;
         public int PrefetchCount { get; set; } = 0;
+        // INVARIANT: cross-entity transactions are OFF by default. Enabling them pins the shared
+        // ServiceBusClient to the first top-level entity it touches, so a second receiver on a different
+        // top-level entity throws "Local transactions cannot span multiple top-level entities". This is
+        // auto-enabled when a FullAtomicityViaInfrastructure receiver is registered; opt in explicitly here
+        // only when a single-entity host needs cross-entity send+settle atomicity.
+        public bool EnableCrossEntityTransactions { get; internal set; }
         internal RetryPolicyConfiguation RetryPolicy { get; set; }
         [JsonIgnore]
         public ServiceBusRetryOptions RetryOptions { get; internal set; }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptionsBuilder.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptionsBuilder.cs
@@ -18,9 +18,11 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         private int _prefetchCount = _defaultPrefetchCount;
         private ServiceBusRetryOptions _retryOptions = null;
         private IConfigurationSection _serviceBusOptionsSection = null;
+        private bool _enableCrossEntityTransactions = _defaultEnableCrossEntityTransactions;
 
         private const int _defaultMaxConcurrentCalls = 1;
         private const int _defaultPrefetchCount = 0;
+        private const bool _defaultEnableCrossEntityTransactions = false;
 
         public static ServiceBusOptionsBuilder Create(IServiceCollection services, IConfiguration configuration)
             => new ServiceBusOptionsBuilder(services, configuration);
@@ -67,6 +69,16 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         public ServiceBusOptionsBuilder WithPrefetchCount(int count)
         {
             _prefetchCount = count;
+            return this;
+        }
+
+        // Opts the shared ServiceBusClient into cross-entity transactions. Default is OFF: enabling this pins
+        // the client to a single top-level entity, so a host configured this way may register only one
+        // top-level receiver entity (enforced by a startup guard). A FullAtomicityViaInfrastructure receiver
+        // turns this on automatically; call this only to force it on for an explicitly single-entity host.
+        public ServiceBusOptionsBuilder WithCrossEntityTransactions(bool enabled = true)
+        {
+            _enableCrossEntityTransactions = enabled;
             return this;
         }
 
@@ -192,6 +204,11 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
             if (_prefetchCount != _defaultPrefetchCount)
             {
                 options.PrefetchCount = _prefetchCount;
+            }
+
+            if (_enableCrossEntityTransactions != _defaultEnableCrossEntityTransactions)
+            {
+                options.EnableCrossEntityTransactions = _enableCrossEntityTransactions;
             }
 
             Services.AddSingleton(options);

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptionsBuilder.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptionsBuilder.cs
@@ -18,11 +18,16 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         private int _prefetchCount = _defaultPrefetchCount;
         private ServiceBusRetryOptions _retryOptions = null;
         private IConfigurationSection _serviceBusOptionsSection = null;
-        private bool _enableCrossEntityTransactions = _defaultEnableCrossEntityTransactions;
+        // INVARIANT: null means WithCrossEntityTransactions was never called, so the config-bound value is
+        // left untouched. A non-null value means the fluent method was called and its value overrides any
+        // config-bound value in EITHER direction (explicit false overrides config true, explicit true
+        // overrides config false). This distinguishes "fluent method not called" from "called with the
+        // default value" — a plain bool defaulting to false could not tell those apart, which silently
+        // dropped an explicit WithCrossEntityTransactions(false) when config bound true.
+        private bool? _enableCrossEntityTransactions = null;
 
         private const int _defaultMaxConcurrentCalls = 1;
         private const int _defaultPrefetchCount = 0;
-        private const bool _defaultEnableCrossEntityTransactions = false;
 
         public static ServiceBusOptionsBuilder Create(IServiceCollection services, IConfiguration configuration)
             => new ServiceBusOptionsBuilder(services, configuration);
@@ -206,9 +211,12 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
                 options.PrefetchCount = _prefetchCount;
             }
 
-            if (_enableCrossEntityTransactions != _defaultEnableCrossEntityTransactions)
+            // Explicit fluent call wins over configuration: apply the fluent value only when
+            // WithCrossEntityTransactions was actually called, leaving the config-bound value untouched
+            // otherwise.
+            if (_enableCrossEntityTransactions.HasValue)
             {
-                options.EnableCrossEntityTransactions = _enableCrossEntityTransactions;
+                options.EnableCrossEntityTransactions = _enableCrossEntityTransactions.Value;
             }
 
             Services.AddSingleton(options);

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
@@ -1,6 +1,7 @@
 using Chatter.MessageBrokers.AzureServiceBus.Options;
 using Chatter.MessageBrokers.Configuration;
 using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Exceptions;
 using Chatter.MessageBrokers.Receiving;
 using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Logging;
@@ -19,6 +20,11 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
         // description is capped at this length (matching the SDK's char-based validation) before dispatch.
         private const int MaxDeadLetterErrorDescriptionLength = 4096;
         private const string DeadLetterErrorDescriptionTruncationMarker = "…[truncated]";
+        // The AMQP-level signal Azure Service Bus returns when a cross-entity-transaction client touches a
+        // second top-level entity. The SDK surfaces this as a non-transient ServiceBusException (or an
+        // InvalidOperationException from the client-side enlistment guard); the message text is the stable
+        // discriminator across SDK versions and exception shapes.
+        private const string CrossEntityTransactionRejectionMarker = "multiple top-level entities";
 
         readonly object _syncLock;
         private readonly ILogger<ServiceBusReceiver> _logger;
@@ -142,6 +148,16 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
 
                 return null;
             }
+            catch (Exception e) when (IsCrossEntityTransactionRejection(e))
+            {
+                // Defense-in-depth behind the DI-time startup guard: when cross-entity transactions are on,
+                // Azure Service Bus pins the shared client to the first top-level entity it touches and
+                // rejects a second receiver on a different top-level entity ("cannot span multiple top-level
+                // entities"). This is fatal and non-recoverable, so it is rethrown as CriticalReceiverException
+                // to stop the core receive loop loudly instead of being retried as a transient failure.
+                _logger.LogCritical(e, "Azure Service Bus rejected the receiver because cross-entity transactions cannot span multiple top-level entities");
+                throw new CriticalReceiverException(e);
+            }
             catch (Exception e)
             {
                 _logger.LogError(e, "Failure to receive message from Azure Serivce Bus");
@@ -236,6 +252,22 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
 
             var headLength = MaxDeadLetterErrorDescriptionLength - DeadLetterErrorDescriptionTruncationMarker.Length;
             return deadLetterErrorDescription.Substring(0, headLength) + DeadLetterErrorDescriptionTruncationMarker;
+        }
+
+        // Classifies a receive-path exception as the fatal cross-entity-transaction rejection. Matches both
+        // the non-transient ServiceBusException and the InvalidOperationException shapes the SDK may raise, on
+        // the stable "multiple top-level entities" message marker. A transient ServiceBusException is NOT
+        // matched here — it is handled by the dedicated transient branch above.
+        private static bool IsCrossEntityTransactionRejection(Exception exception)
+        {
+            if (exception is ServiceBusException sbe && sbe.IsTransient)
+            {
+                return false;
+            }
+
+            return (exception is ServiceBusException || exception is InvalidOperationException)
+                && exception.Message != null
+                && exception.Message.IndexOf(CrossEntityTransactionRejectionMarker, StringComparison.OrdinalIgnoreCase) >= 0;
         }
 
         public TransactionScope CreateLocalTransaction(TransactionContext context)

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
@@ -28,6 +28,34 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
         private static IConfiguration EmptyConfig()
             => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()).Build();
 
+        // Builds a configuration whose Chatter:Infrastructure:AzureServiceBus section carries the connection
+        // string plus the supplied EnableCrossEntityTransactions value, so the opt-in is exercised purely via
+        // config binding (ServiceBusOptionsBuilder.UseConfig -> section.Get<ServiceBusOptions>()), with NO
+        // fluent WithCrossEntityTransactions() call.
+        private static IConfiguration CrossEntityConfig(bool enableCrossEntityTransactions)
+            => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["Chatter:Infrastructure:AzureServiceBus:ConnectionString"] = _connectionString,
+                ["Chatter:Infrastructure:AzureServiceBus:EnableCrossEntityTransactions"] =
+                    enableCrossEntityTransactions.ToString(),
+            }).Build();
+
+        // Builds services where the ASB opt-in comes ONLY from configuration binding (no fluent
+        // WithConnectionString / WithCrossEntityTransactions): the section is bound by the options builder.
+        private static ServiceCollection BuildServicesFromConfig(
+            IConfiguration configuration,
+            Action<ServiceBusOptionsBuilder> configure)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddChatterCqrs(configuration, typeof(WhenConfiguringCrossEntityTransactions))
+                    .AddMessageBrokers()
+                    .AddAzureServiceBus(sb => configure(sb));
+
+            return services;
+        }
+
         private static ServiceCollection BuildServices(Action<ServiceBusOptionsBuilder> configure)
             => BuildServices(configure, null);
 
@@ -196,6 +224,51 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
                 },
                 mb => mb.WithTransactionMode(TransactionMode.ReceiveOnly))
                 .BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustBindCrossEntityOptInFromConfigurationAndTripGuardForMultipleTopLevelEntities()
+        {
+            // Config-only opt-in: EnableCrossEntityTransactions = true is set purely via configuration binding
+            // (no fluent WithCrossEntityTransactions()). The flag must bind from the section, so pairing it with
+            // two distinct top-level entities trips the single-top-level-entity guard exactly as the fluent
+            // opt-in does. Regression guard for the internal-setter binding gap (config opt-in was silently
+            // ignored because ConfigurationBinder skips non-public setters).
+            await using var provider = BuildServicesFromConfig(
+                CrossEntityConfig(enableCrossEntityTransactions: true),
+                sb =>
+                {
+                    sb.AddQueueReceiver<FirstCommand>("queue-a");
+                    sb.AddQueueReceiver<SecondCommand>("queue-b");
+                }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*single top-level receiver entity*")
+                .WithMessage("*queue-a*")
+                .WithMessage("*queue-b*");
+        }
+
+        [Fact]
+        public async Task MustNotEnableCrossEntityWhenConfigOptInAbsentForMultipleTopLevelEntities()
+        {
+            // Config binds EnableCrossEntityTransactions = false (the default): cross-entity stays OFF, so two
+            // distinct non-atomic top-level entities are allowed and the guard does not trip — the config-bound
+            // flag is genuinely honored in both directions.
+            await using var provider = BuildServicesFromConfig(
+                CrossEntityConfig(enableCrossEntityTransactions: false),
+                sb =>
+                {
+                    sb.AddQueueReceiver<FirstCommand>("queue-a");
+                    sb.AddQueueReceiver<SecondCommand>("queue-b");
+                }).BuildServiceProvider();
 
             var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
@@ -1,5 +1,6 @@
 using Chatter.CQRS.Commands;
 using Chatter.MessageBrokers.AzureServiceBus.Options;
+using Chatter.MessageBrokers.Configuration;
 using Chatter.MessageBrokers.Receiving;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
@@ -28,12 +29,17 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
             => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()).Build();
 
         private static ServiceCollection BuildServices(Action<ServiceBusOptionsBuilder> configure)
+            => BuildServices(configure, null);
+
+        private static ServiceCollection BuildServices(
+            Action<ServiceBusOptionsBuilder> configure,
+            Action<MessageBrokerOptionsBuilder> configureMessageBrokers)
         {
             var services = new ServiceCollection();
             services.AddLogging();
 
             services.AddChatterCqrs(EmptyConfig(), typeof(WhenConfiguringCrossEntityTransactions))
-                    .AddMessageBrokers()
+                    .AddMessageBrokers(configureMessageBrokers)
                     .AddAzureServiceBus(sb =>
                     {
                         sb.WithConnectionString(_connectionString);
@@ -127,6 +133,69 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
                 sb.AddTopicSubscription<FirstEvent>("shared-topic", "sub-1");
                 sb.AddTopicSubscription<SecondEvent>("shared-topic", "sub-2");
             }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustConstructSharedClientWhenGlobalFullAtomicityWithSingleReceiverWithoutPerCallMode()
+        {
+            // Regression guard for the bug: a GLOBAL WithTransactionMode(FullAtomicityViaInfrastructure) set on
+            // MessageBrokerOptions, with a single queue receiver carrying NO per-call mode, must auto-enable
+            // cross-entity transactions via the inherited global mode. With one top-level entity the guard does
+            // not trip and the client is constructed.
+            await using var provider = BuildServices(
+                sb => sb.AddQueueReceiver<FirstCommand>("queue-a"),
+                mb => mb.WithTransactionMode(TransactionMode.FullAtomicityViaInfrastructure))
+                .BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustThrowConfigurationGuardWhenGlobalFullAtomicitySpansMultipleTopLevelEntities()
+        {
+            // Global WithTransactionMode(FullAtomicityViaInfrastructure) folds into each receiver's effective
+            // mode, so two distinct top-level queue entities (neither with a per-call mode) trip the
+            // single-top-level-entity guard exactly as per-call atomicity would.
+            await using var provider = BuildServices(
+                sb =>
+                {
+                    sb.AddQueueReceiver<FirstCommand>("queue-a");
+                    sb.AddQueueReceiver<SecondCommand>("queue-b");
+                },
+                mb => mb.WithTransactionMode(TransactionMode.FullAtomicityViaInfrastructure))
+                .BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*single top-level receiver entity*")
+                .WithMessage("*queue-a*")
+                .WithMessage("*queue-b*");
+        }
+
+        [Fact]
+        public async Task MustConstructSharedClientWhenGlobalReceiveOnlyWithTwoNonAtomicReceivers()
+        {
+            // Global ReceiveOnly (the default global mode) keeps cross-entity OFF, so two distinct non-atomic
+            // top-level entities are allowed and the guard does not trip — existing multi-receiver hosts are
+            // unaffected by the global-mode fold-in.
+            await using var provider = BuildServices(
+                sb =>
+                {
+                    sb.AddQueueReceiver<FirstCommand>("queue-a");
+                    sb.AddQueueReceiver<SecondCommand>("queue-b");
+                },
+                mb => mb.WithTransactionMode(TransactionMode.ReceiveOnly))
+                .BuildServiceProvider();
 
             var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
@@ -276,6 +276,60 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
             resolveClient().Should().NotBeNull();
         }
 
+        [Fact]
+        public async Task MustHonorExplicitFluentDisableOverConfigEnabled()
+        {
+            // Regression guard (Codex P2): config binds EnableCrossEntityTransactions = true, but the app
+            // explicitly calls WithCrossEntityTransactions(false) to force it off. The explicit fluent value
+            // must win over the config-bound value, so the resolved option is false.
+            await using var provider = BuildServicesFromConfig(
+                CrossEntityConfig(enableCrossEntityTransactions: true),
+                sb => sb.WithCrossEntityTransactions(false)).BuildServiceProvider();
+
+            var options = provider.GetRequiredService<ServiceBusOptions>();
+
+            options.EnableCrossEntityTransactions.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task MustKeepConfigEnabledWhenNoFluentCall()
+        {
+            // Config binds EnableCrossEntityTransactions = true and no fluent WithCrossEntityTransactions()
+            // call is made: the config-bound value is left untouched, so the resolved option stays true.
+            await using var provider = BuildServicesFromConfig(
+                CrossEntityConfig(enableCrossEntityTransactions: true),
+                sb => { }).BuildServiceProvider();
+
+            var options = provider.GetRequiredService<ServiceBusOptions>();
+
+            options.EnableCrossEntityTransactions.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task MustEnableViaFluentWhenNoConfig()
+        {
+            // No config opt-in, but the app explicitly calls WithCrossEntityTransactions(true): the explicit
+            // fluent value applies, so the resolved option is true.
+            await using var provider = BuildServices(
+                sb => sb.WithCrossEntityTransactions(true)).BuildServiceProvider();
+
+            var options = provider.GetRequiredService<ServiceBusOptions>();
+
+            options.EnableCrossEntityTransactions.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task MustDefaultToDisabledWhenNoConfigAndNoFluentCall()
+        {
+            // Neither config opt-in nor a fluent WithCrossEntityTransactions() call: the option falls back to
+            // its default of false.
+            await using var provider = BuildServices(sb => { }).BuildServiceProvider();
+
+            var options = provider.GetRequiredService<ServiceBusOptions>();
+
+            options.EnableCrossEntityTransactions.Should().BeFalse();
+        }
+
         private sealed class FirstEvent : CQRS.Events.IEvent { }
         private sealed class SecondEvent : CQRS.Events.IEvent { }
     }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
@@ -1,0 +1,140 @@
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.AzureServiceBus.Options;
+using Chatter.MessageBrokers.Receiving;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+using ServiceBusClient = Azure.Messaging.ServiceBus.ServiceBusClient;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.UsingChatterAzureServiceBusExtensions
+{
+    // Verifies the DI-time cross-entity-transactions opt-in, effective-flag computation, and single-top-level
+    // -entity startup guard WITHOUT a live broker. The shared ServiceBusClient is constructed (and the guard
+    // runs) at first resolve of ServiceBusClient — no Azure connection is made — so a placeholder SAS
+    // connection string is sufficient and these are fast unit [Fact]s, not Docker-gated integration tests.
+    public class WhenConfiguringCrossEntityTransactions : Testing.Core.Context
+    {
+        private const string _connectionString =
+            "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=secret";
+
+        private sealed class FirstCommand : ICommand { }
+        private sealed class SecondCommand : ICommand { }
+
+        private static IConfiguration EmptyConfig()
+            => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string>()).Build();
+
+        private static ServiceCollection BuildServices(Action<ServiceBusOptionsBuilder> configure)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddChatterCqrs(EmptyConfig(), typeof(WhenConfiguringCrossEntityTransactions))
+                    .AddMessageBrokers()
+                    .AddAzureServiceBus(sb =>
+                    {
+                        sb.WithConnectionString(_connectionString);
+                        configure(sb);
+                    });
+
+            return services;
+        }
+
+        [Fact]
+        public async Task MustConstructSharedClientWithoutTrippingGuardForTwoNonAtomicQueueReceivers()
+        {
+            // (a) Default (no opt-in, two distinct non-atomic queue receivers): cross-entity is OFF, so the
+            // shared client is constructed and the guard does NOT throw — both receivers can run.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.AddQueueReceiver<FirstCommand>("queue-a");
+                sb.AddQueueReceiver<SecondCommand>("queue-b");
+            }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustThrowConfigurationGuardWhenCrossEntityEnabledWithMultipleTopLevelEntities()
+        {
+            // (b) Explicit WithCrossEntityTransactions() + two distinct top-level entities: the unsupportable
+            // combination fails fast and loud at client build with a clear configuration exception naming the
+            // conflicting entities.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.WithCrossEntityTransactions();
+                sb.AddQueueReceiver<FirstCommand>("queue-a");
+                sb.AddQueueReceiver<SecondCommand>("queue-b");
+            }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*single top-level receiver entity*")
+                .WithMessage("*queue-a*")
+                .WithMessage("*queue-b*");
+        }
+
+        [Fact]
+        public async Task MustConstructSharedClientForSingleFullAtomicityReceiver()
+        {
+            // (c) A single FullAtomicityViaInfrastructure receiver auto-enables cross-entity transactions; with
+            // only one top-level entity the guard does not trip and the client is constructed.
+            await using var provider = BuildServices(sb =>
+                sb.AddQueueReceiver<FirstCommand>("queue-a", transactionMode: TransactionMode.FullAtomicityViaInfrastructure))
+                .BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustThrowConfigurationGuardWhenFullAtomicitySpansMultipleTopLevelEntities()
+        {
+            // A FullAtomicityViaInfrastructure receiver auto-enables cross-entity transactions; pairing it with
+            // a second distinct top-level entity is the silent-hang scenario the guard converts into a loud
+            // startup failure.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.AddQueueReceiver<FirstCommand>("queue-a", transactionMode: TransactionMode.FullAtomicityViaInfrastructure);
+                sb.AddQueueReceiver<SecondCommand>("queue-b");
+            }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*single top-level receiver entity*");
+        }
+
+        [Fact]
+        public async Task MustNotTripGuardForTwoSubscriptionsOnSameTopic()
+        {
+            // Two subscriptions on the SAME topic share one top-level entity, so even with cross-entity on they
+            // do not count as distinct entities and the guard does not trip.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.WithCrossEntityTransactions();
+                sb.AddTopicSubscription<FirstEvent>("shared-topic", "sub-1");
+                sb.AddTopicSubscription<SecondEvent>("shared-topic", "sub-2");
+            }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        private sealed class FirstEvent : CQRS.Events.IEvent { }
+        private sealed class SecondEvent : CQRS.Events.IEvent { }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/Config.json
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/Config.json
@@ -102,6 +102,17 @@
               "RequiresDuplicateDetection": false,
               "RequiresSession": false
             }
+          },
+          {
+            "Name": "chatter.attempts",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
           }
         ],
         "Topics": [

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineComplexPayloadTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineComplexPayloadTests.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.AzureServiceBus.Options;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
+{
+    // End-to-end coverage of Chatter's System.Text.Json body path against a real Azure Service Bus round trip,
+    // guarding the Newtonsoft -> STJ migration where it matters most: NON-flat payloads (the other pipeline
+    // tests cover only flat scalars). The SYSTEM UNDER TEST is Chatter's send + receive serialization:
+    //
+    //   Test A: a command carrying a nested object, a List<T>, a Dictionary<string,object>, a by-name enum, a
+    //     bool and a numeric field is dispatched ONLY through Chatter's IBrokeredMessageDispatcher.Send,
+    //     delivered by Chatter's pump to a Chatter-resolved RecordingMessageHandler, and EVERY field is
+    //     asserted to round-trip exactly. This proves the STJ Convert (send) and GetMessageFromBody (receive)
+    //     agree on nested/collection/enum/dictionary shapes over the wire, not just flat scalars.
+    //
+    //   Test B (read-leniency): a RAW message body with QUOTED scalars ({"Flag":"true","Count":"3"}) is
+    //     injected via a raw-SDK edge SEND — Chatter's own send never emits quoted scalars, so a raw edge-send
+    //     is the only way to exercise the Newtonsoft read-leniency the converters restore (this mirrors the
+    //     existing edge-only SDK usage in PipelineDeadLetterTests/PipelineTransactionModeTests). A Chatter
+    //     receiver + handler then reads it, and the assertion is that Chatter's lenient deserialization coerced
+    //     the quoted "true" to a CLR bool and the quoted "3" to a CLR int.
+    //
+    // All facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green; the emulator CI lane (`--filter Category=Integration`) runs them for real.
+    [Trait("Category", "Integration")]
+    [Collection(ServiceBusEmulatorCollection.Name)]
+    public class PipelineComplexPayloadTests
+    {
+        private const string ComplexQueue = "chatter.roundtrip";
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
+
+        private readonly ServiceBusEmulatorFixture _emulator;
+
+        public PipelineComplexPayloadTests(ServiceBusEmulatorFixture emulator)
+            => _emulator = emulator;
+
+        public enum PayloadKind
+        {
+            Unspecified = 0,
+            Booked = 1,
+            Cancelled = 2,
+        }
+
+        public sealed class NestedDetail
+        {
+            public string Label { get; set; }
+            public int Score { get; set; }
+        }
+
+        // A command whose shape spans every non-flat STJ path the migration must preserve: a nested object, a
+        // List<T>, a Dictionary<string,object>, a by-name enum, a bool and a numeric field. Each is asserted
+        // independently after the round trip.
+        public sealed class ComplexCommand : ICommand
+        {
+            public NestedDetail Nested { get; set; }
+            public List<string> Tags { get; set; }
+            public Dictionary<string, object> Attributes { get; set; }
+            public PayloadKind Kind { get; set; }
+            public bool Enabled { get; set; }
+            public decimal Amount { get; set; }
+        }
+
+        // The DTO the raw-SDK edge-send targets. Flag/Count are strongly-typed bool/int so the QUOTED scalars in
+        // the raw body exercise Chatter's read-leniency converters (NewtonsoftLenientBooleanConverter +
+        // AllowReadingFromString) rather than the strict STJ defaults.
+        public sealed class LenientScalarCommand : ICommand
+        {
+            public bool Flag { get; set; }
+            public int Count { get; set; }
+        }
+
+        // Test A: a non-flat payload sent through Chatter's dispatcher is delivered by Chatter's pump to the
+        // handler with every member — nested object, list, dictionary, by-name enum, bool, numeric — restored
+        // exactly. Asserts purely on the payload Chatter handed the handler, proving the STJ body path survives a
+        // real Azure Service Bus round trip for non-scalar shapes.
+        [RequiresDockerFact]
+        public async Task ComplexPayloadRoundTripsEveryFieldThroughChatterSerializer()
+        {
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb => sb.AddQueueReceiver<ComplexCommand>(ComplexQueue),
+                typeof(ComplexCommand));
+            await harness.StartAsync();
+
+            var sent = new ComplexCommand
+            {
+                Nested = new NestedDetail { Label = "inner", Score = 99 },
+                Tags = new List<string> { "first", "second", "third" },
+                Attributes = new Dictionary<string, object>
+                {
+                    ["region"] = "us-east",
+                    ["priority"] = 7L,
+                    ["urgent"] = true,
+                },
+                Kind = PayloadKind.Cancelled,
+                Enabled = true,
+                Amount = 123.45m,
+            };
+
+            var dispatcher = harness.CreateDispatcher(out var scope);
+            using (scope)
+            {
+                await dispatcher.Send(sent, ComplexQueue);
+            }
+
+            var handled = await harness.WaitForHandledAsync<ComplexCommand>(HandlerWait);
+
+            handled.Message.Should().NotBeNull("Chatter's pipeline must deliver the complex command to the handler");
+
+            // Nested object survives verbatim.
+            handled.Message.Nested.Should().NotBeNull("a nested object must round-trip through STJ");
+            handled.Message.Nested.Label.Should().Be("inner");
+            handled.Message.Nested.Score.Should().Be(99);
+
+            // List<T> preserves contents AND order.
+            handled.Message.Tags.Should().Equal("first", "second", "third");
+
+            // Dictionary<string,object> values materialize back to CLR types (string/long/bool) — the untyped
+            // read path Chatter's MaterializingObjectConverter restores.
+            handled.Message.Attributes.Should().ContainKey("region").WhoseValue.Should().Be("us-east");
+            handled.Message.Attributes.Should().ContainKey("priority").WhoseValue.Should().Be(7L);
+            handled.Message.Attributes.Should().ContainKey("urgent").WhoseValue.Should().Be(true);
+
+            // Enum round-trips to the exact value.
+            handled.Message.Kind.Should().Be(PayloadKind.Cancelled);
+
+            // Bool and numeric fields survive exactly.
+            handled.Message.Enabled.Should().BeTrue();
+            handled.Message.Amount.Should().Be(123.45m);
+        }
+
+        // Edge-only raw-SDK send: writes a JSON body with QUOTED scalars directly to the queue, the one form
+        // Chatter's own send never emits. Mirrors the existing edge-only SDK usage in the deadletter/transaction
+        // tests — the SDK appears solely to seed the body, never as the system under test.
+        private async Task RawSendQuotedScalarBodyAsync(string queue, string jsonBody)
+        {
+            await using var client = new ServiceBusClient(_emulator.GetConnectionString());
+            var sender = client.CreateSender(queue);
+            var message = new ServiceBusMessage(BinaryData.FromBytes(Encoding.UTF8.GetBytes(jsonBody)))
+            {
+                ContentType = "application/json",
+            };
+            await sender.SendMessageAsync(message);
+        }
+
+        // Test B: a raw message body with QUOTED scalars ({"Flag":"true","Count":"3"}) is read by a Chatter
+        // receiver + handler; Chatter's lenient deserialization coerces Flag to the CLR bool true and Count to
+        // the CLR int 3. Proves the read-leniency converters (restoring Newtonsoft parity) work across a real
+        // Azure Service Bus receive, not just in isolation.
+        [RequiresDockerFact]
+        public async Task QuotedScalarBodyIsCoercedByChatterLenientDeserialization()
+        {
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb => sb.AddQueueReceiver<LenientScalarCommand>(ComplexQueue),
+                typeof(LenientScalarCommand));
+            await harness.StartAsync();
+
+            // PascalCase member names so the body binds regardless of case-insensitivity, with the scalars
+            // QUOTED to exercise read-leniency. Chatter's send would emit `"Flag":true,"Count":3`.
+            await RawSendQuotedScalarBodyAsync(ComplexQueue, "{\"Flag\":\"true\",\"Count\":\"3\"}");
+
+            var handled = await harness.WaitForHandledAsync<LenientScalarCommand>(HandlerWait);
+
+            handled.Message.Should().NotBeNull("Chatter must deserialize the raw quoted-scalar body and deliver it");
+            handled.Message.Flag.Should().BeTrue(
+                "Chatter's NewtonsoftLenientBooleanConverter coerces a quoted \"true\" to the CLR bool true");
+            handled.Message.Count.Should().Be(
+                3,
+                "Chatter's AllowReadingFromString coerces a quoted \"3\" to the CLR int 3");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineDeadLetterTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineDeadLetterTests.cs
@@ -35,7 +35,18 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
     public class PipelineDeadLetterTests
     {
         private const string DeadLetterQueue = "chatter.deadletter";
+        // A dedicated queue (MaxDeliveryCount 10, so the broker does NOT deadletter before Chatter does) for the
+        // exact-attempts boundary test: Chatter's maxReceiveAttempts (small N) governs deadlettering, and the
+        // queue is isolated so its $DeadLetterQueue peek is not polluted by other tests' poisoned messages.
+        private const string AttemptsQueue = "chatter.attempts";
+        // The exact number of handler invocations expected on the attempts boundary test before Chatter
+        // deadletters: Chatter deadletters when deliveryCount >= MaxReceiveAttempts, so with N attempts the
+        // PeekLock handler is invoked exactly N times.
+        private const int MaxReceiveAttemptsForBoundary = 2;
         private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
+        // A window long enough that any further (over-N) redelivery would have landed, used to assert the handler
+        // is NOT invoked beyond the exact attempt count.
+        private static readonly TimeSpan NoFurtherInvocationWindow = TimeSpan.FromSeconds(15);
         // A window long enough for Chatter to settle the deadletter after the handler throws, before the
         // edge-only peek of the $DeadLetterQueue sub-queue.
         private static readonly TimeSpan DeadLetterPeekWait = TimeSpan.FromSeconds(20);
@@ -59,11 +70,11 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
         // Edge-only raw-SDK read of the entity's dead-letter sub-queue. Chatter exposes no DLQ read, so the
         // Azure SDK is used here purely to observe the message Chatter's deadletter path produced. PeekLock +
         // explicit Complete drains it so a leftover cannot leak into a later run on the shared emulator.
-        private async Task<ServiceBusReceivedMessage> ReceiveDeadLetteredAsync(TimeSpan timeout)
+        private async Task<ServiceBusReceivedMessage> ReceiveDeadLetteredAsync(TimeSpan timeout, string queue = DeadLetterQueue)
         {
             await using var client = new ServiceBusClient(_emulator.GetConnectionString());
             var receiver = client.CreateReceiver(
-                DeadLetterQueue,
+                queue,
                 new ServiceBusReceiverOptions
                 {
                     SubQueue = SubQueue.DeadLetter,
@@ -165,6 +176,60 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
             deadLettered.DeadLetterErrorDescription.Should().EndWith(
                 DeadLetterErrorDescriptionTruncationMarker,
                 "the capped description preserves its diagnostic head and appends Chatter's truncation marker");
+        }
+
+        // Exact attempts -> deadletter boundary: with a throwing handler on a PeekLock receiver configured for
+        // maxReceiveAttempts: N (on a queue whose own MaxDeliveryCount is higher, so the BROKER does not
+        // deadletter first), Chatter invokes the handler EXACTLY N times — it redelivers on each abandoned lock
+        // and deadletters only once deliveryCount >= N — and then the message lands on the entity's
+        // $DeadLetterQueue. This pins the attempts->deadletter boundary precisely (the existing tests assert only
+        // >= 2 redelivery); both the exact invocation count and the resulting DLQ landing are proven through
+        // Chatter, with the raw SDK used only at the edge to peek the DLQ.
+        [RequiresDockerFact]
+        public async Task ThrowingHandlerIsInvokedExactlyMaxAttemptsThenDeadletters()
+        {
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb => sb.AddQueueReceiver<DeadLetterCommand>(
+                    AttemptsQueue,
+                    transactionMode: TransactionMode.ReceiveOnly,
+                    maxReceiveAttempts: MaxReceiveAttemptsForBoundary),
+                typeof(DeadLetterCommand));
+            await harness.StartAsync();
+
+            harness.GetSignal<DeadLetterCommand>().ThrowOnHandle =
+                () => new InvalidOperationException("force exact-attempts deadletter through Chatter's pipeline");
+
+            var dispatcher = harness.CreateDispatcher(out var scope);
+            using (scope)
+            {
+                await dispatcher.Send(new DeadLetterCommand { Value = "exact-attempts" }, AttemptsQueue);
+            }
+
+            // Chatter invokes the handler on each PeekLock delivery until it deadletters at deliveryCount >= N,
+            // so the handler is invoked exactly N times: first reach N...
+            var reached = await harness.WaitForInvocationCountAsync<DeadLetterCommand>(
+                MaxReceiveAttemptsForBoundary, HandlerWait);
+            reached.Should().Be(
+                MaxReceiveAttemptsForBoundary,
+                "Chatter redelivers an abandoned PeekLock message and deadletters at deliveryCount >= maxReceiveAttempts, so the handler is invoked exactly that many times");
+
+            // ...then confirm it does NOT exceed N within a margin (no further redelivery after deadlettering).
+            var afterDeadletter = await harness.WaitForInvocationCountAsync<DeadLetterCommand>(
+                MaxReceiveAttemptsForBoundary + 1, NoFurtherInvocationWindow);
+            afterDeadletter.Should().Be(
+                MaxReceiveAttemptsForBoundary,
+                "once Chatter deadletters at max attempts the message is gone, so the handler is not invoked again");
+
+            // The message then lands on the entity's $DeadLetterQueue — the attempts boundary terminated in a
+            // deadletter, not an endless redelivery. This DLQ read is the only raw-SDK usage and drains the
+            // message so it cannot leak into a later run on the shared emulator.
+            var deadLettered = await ReceiveDeadLetteredAsync(DeadLetterPeekWait, AttemptsQueue);
+            deadLettered.Should().NotBeNull(
+                "after exactly maxReceiveAttempts failed deliveries Chatter must move the message to the entity's $DeadLetterQueue");
+            deadLettered.DeadLetterReason.Should().Be(
+                "Poisoned message received",
+                "Chatter stamps this literal reason when it deadletters at the attempts boundary");
         }
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineForwardingTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineForwardingTests.cs
@@ -1,13 +1,12 @@
 using System;
-using System.Text;
 using System.Threading.Tasks;
-using Azure.Messaging.ServiceBus;
 using Chatter.CQRS;
 using Chatter.CQRS.Commands;
 using Chatter.CQRS.Context;
 using Chatter.CQRS.Events;
 using Chatter.MessageBrokers.AzureServiceBus.Options;
 using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
 using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -19,31 +18,28 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
     //
     //   Forwarding: a command is sent via IBrokeredMessageDispatcher.Send to chatter.forward.source. A handler
     //     on that queue (resolved by Chatter on the receive path) forwards a follow-up to chatter.forward.dest
-    //     via the broker context's Send (IMessageBrokerContext.Send). The forwarded message is then observed on
-    //     chatter.forward.dest by an edge-only raw-SDK receive, proving the forward routed through Chatter's
-    //     send path with its payload intact.
+    //     via the broker context's Send (IMessageBrokerContext.Send). A SECOND in-process Chatter receiver on
+    //     chatter.forward.dest then delivers the forwarded command to its RecordingMessageHandler, proving the
+    //     forward routed through Chatter's send path with its payload intact — end to end, with no raw-SDK edge.
     //
-    //     TOPOLOGY CONSTRAINT (why the dest is read at the edge, not via a second Chatter receiver): the
-    //     production ServiceBusClient is built with EnableCrossEntityTransactions = true
-    //     (ChatterAzureServiceBusExtensions.CreateSharedClient) and ALL receivers/senders are created off that
-    //     one shared client. With cross-entity transactions enabled, the Azure SDK pins the first entity the
-    //     client touches as the transaction "via" entity and REJECTS a second receiver bound to a different
-    //     top-level entity on the same client — "Local transactions cannot span multiple top-level entities
-    //     such as queue or topic" (Azure/azure-sdk-for-net#34997). So a second in-process Chatter receiver on
-    //     chatter.forward.dest cannot run alongside the chatter.forward.source receiver; its receive throws and
-    //     BrokeredMessageReceiver.StartReceiver swallows the failure (logs LogCritical, does not rethrow), so
-    //     the handler is simply never invoked. The forward itself succeeds (Chatter's send path runs under a
-    //     ReceiveOnly Suppress scope), so the delivered message is observed at the dest with a raw-SDK edge
-    //     receive instead of a second Chatter pump. See the suspected-production-concern note in the worker
-    //     report.
+    //     TOPOLOGY NOTE (why a second Chatter receiver on the dest now works): EnableCrossEntityTransactions is
+    //     opt-in and defaults OFF (ChatterAzureServiceBusExtensions auto-enables it only when a
+    //     FullAtomicityViaInfrastructure receiver is registered). Both receivers here are ReceiveOnly, so
+    //     cross-entity transactions stay OFF and the shared ServiceBusClient does NOT pin a single "via" entity
+    //     — a second receiver on a different top-level entity (chatter.forward.dest) coexists with the
+    //     chatter.forward.source receiver in one host. (When cross-entity transactions ARE on, the Azure SDK
+    //     still rejects receivers spanning multiple top-level entities — "Local transactions cannot span
+    //     multiple top-level entities such as queue or topic", Azure/azure-sdk-for-net#34997 — which the
+    //     DI-time startup guard now converts into a loud configuration failure; see
+    //     WhenConfiguringCrossEntityTransactions.)
     //
     //   Topic: an event is published via IBrokeredMessageDispatcher.Publish to chatter.topic. A receiver
     //     registered with AddTopicSubscription<TEvt>("chatter.topic","chatter.sub") delivers it to a
     //     RecordingMessageHandler, proving Chatter's topic publish + subscription receive path.
     //
-    // Raw Azure.Messaging.ServiceBus appears ONLY at the test EDGE to receive the forwarded message from
-    // chatter.forward.dest (mirroring the deadletter tests' edge peek of $DeadLetterQueue) — never as the
-    // system under test. The send/forward/publish are all Chatter calls.
+    // The send/forward/publish are all Chatter calls, and the forwarded message is observed via a second
+    // Chatter receiver (RecordingMessageHandler) rather than a raw-SDK edge receive — the whole path is
+    // Chatter's.
     //
     // All facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
     // `dotnet test` stays green; the emulator CI lane (`--filter Category=Integration`) runs them for real.
@@ -73,8 +69,9 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
             public string Value { get; set; }
         }
 
-        // The command the source handler forwards to chatter.forward.dest. An edge-only raw-SDK receive on the
-        // dest queue captures it, proving the forward landed through Chatter's send path.
+        // The command the source handler forwards to chatter.forward.dest. A second in-process Chatter receiver
+        // on the dest delivers it to a RecordingMessageHandler, proving the forward landed through Chatter's
+        // send path.
         public sealed class ForwardedCommand : ICommand
         {
             public string Value { get; set; }
@@ -104,36 +101,12 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
             }
         }
 
-        // Edge-only raw-SDK receive of the forwarded message from chatter.forward.dest. Chatter cannot run a
-        // second in-process receiver on this entity alongside the chatter.forward.source receiver (the shared
-        // EnableCrossEntityTransactions client rejects a second receiver on a different top-level entity — see
-        // the class-level TOPOLOGY CONSTRAINT note), so the Azure SDK is used here purely to observe the message
-        // Chatter's forward produced. PeekLock + explicit Complete drains it so a leftover cannot leak into a
-        // later run on the shared emulator. The body is the UTF-8 JSON Chatter's JsonBodyConverter wrote, so the
-        // forwarded payload is asserted by decoding the raw body rather than re-running Chatter's deserializer.
-        private async Task<string> ReceiveForwardedBodyAsync(TimeSpan timeout)
-        {
-            await using var client = new ServiceBusClient(_emulator.GetConnectionString());
-            var receiver = client.CreateReceiver(
-                ForwardDestQueue,
-                new ServiceBusReceiverOptions { ReceiveMode = ServiceBusReceiveMode.PeekLock });
-
-            var forwarded = await receiver.ReceiveMessageAsync(timeout);
-            if (forwarded is null)
-            {
-                return null;
-            }
-
-            await receiver.CompleteMessageAsync(forwarded);
-            return Encoding.UTF8.GetString(forwarded.Body.ToArray());
-        }
-
         // Forwarding through Chatter: a command sent to chatter.forward.source is consumed by a handler that
-        // forwards a follow-up to chatter.forward.dest via the broker context's Send. The forwarded message is
-        // observed on chatter.forward.dest by an edge-only raw-SDK receive, proving the forward routed through
-        // Chatter's send path with the payload intact. Only the source receiver runs in-process; the dest is
-        // read at the edge because the shared cross-entity-transaction client cannot host a second receiver on a
-        // different top-level entity (class-level TOPOLOGY CONSTRAINT note).
+        // forwards a follow-up to chatter.forward.dest via the broker context's Send. A SECOND in-process
+        // Chatter receiver on chatter.forward.dest delivers the forwarded command to its RecordingMessageHandler,
+        // proving the forward routed through Chatter's send path with the payload intact — end to end. Both
+        // receivers are ReceiveOnly, so cross-entity transactions stay OFF and both can run on the shared client
+        // (class-level TOPOLOGY NOTE).
         [RequiresDockerFact]
         public async Task HandlerForwardsToDestinationQueueThroughChatterSendPath()
         {
@@ -143,11 +116,16 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
                 {
                     // Receiver on the source queue, whose handler forwards via the broker context. Register the
                     // forwarding handler explicitly so Chatter resolves it (instead of a RecordingMessageHandler)
-                    // for SourceCommand on the receive path. NO dest receiver: a second receiver on
-                    // chatter.forward.dest would be rejected by the shared EnableCrossEntityTransactions client.
-                    sb.AddQueueReceiver<SourceCommand>(ForwardSourceQueue);
+                    // for SourceCommand on the receive path.
+                    sb.AddQueueReceiver<SourceCommand>(ForwardSourceQueue, transactionMode: TransactionMode.ReceiveOnly);
                     sb.Services.AddTransient<IMessageHandler<SourceCommand>, ForwardingSourceHandler>();
-                });
+
+                    // A second receiver on the dest queue: with cross-entity transactions OFF (both ReceiveOnly),
+                    // it coexists with the source receiver in one host and delivers the forwarded command to its
+                    // RecordingMessageHandler.
+                    sb.AddQueueReceiver<ForwardedCommand>(ForwardDestQueue, transactionMode: TransactionMode.ReceiveOnly);
+                },
+                typeof(ForwardedCommand));
             await harness.StartAsync();
 
             var dispatcher = harness.CreateDispatcher(out var scope);
@@ -157,15 +135,16 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
             }
 
             // The source handler's forward (Chatter's send path) must land the ForwardedCommand on
-            // chatter.forward.dest; observe it at the edge. The wait is generous because the emulator must
-            // deliver the source message, run the handler, complete the forward send, then enqueue on the dest.
-            var forwardedBody = await ReceiveForwardedBodyAsync(HandlerWait);
+            // chatter.forward.dest, where the second Chatter receiver delivers it to its handler. The wait is
+            // generous because the emulator must deliver the source message, run the handler, complete the
+            // forward send, then deliver on the dest.
+            var handled = await harness.WaitForHandledAsync<ForwardedCommand>(HandlerWait);
 
-            forwardedBody.Should().NotBeNull(
+            handled.Message.Should().NotBeNull(
                 "the forwarded command must be delivered to chatter.forward.dest through Chatter's send path");
-            forwardedBody.Should().Contain(
+            handled.Message.Value.Should().Be(
                 "origin-forwarded",
-                "the dest queue must hold the exact payload the source handler forwarded");
+                "the dest receiver's handler must receive the exact payload the source handler forwarded");
         }
 
         // Topic publish/subscribe through Chatter: an event published to chatter.topic via Chatter's

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineMultiReceiverTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineMultiReceiverTests.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.AzureServiceBus.Options;
+using Chatter.MessageBrokers.Receiving;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
+{
+    // Multi-receiver host coverage: TWO queue receivers bound to DISTINCT top-level entities run in ONE
+    // in-process host through Chatter's real DI graph and receiver pump, and BOTH handlers are invoked. This
+    // is the EXACT scenario that hung on v1.0.0 — the shared ServiceBusClient was always built with
+    // EnableCrossEntityTransactions, so the Azure SDK pinned the first entity the client touched as the
+    // transaction "via" entity and rejected a second receiver on a different top-level entity, which
+    // BrokeredMessageReceiver.StartReceiver swallowed (the handler was simply never invoked).
+    //
+    // After the opt-in fix (cross-entity transactions default OFF, auto-enabled only when a
+    // FullAtomicityViaInfrastructure receiver is registered) a host with multiple non-atomic receivers on
+    // distinct entities no longer trips the SDK's single-via-entity rule, so both pumps deliver. Both
+    // receivers here use TransactionMode.ReceiveOnly (NOT FullAtomicity), so cross-entity stays OFF and each
+    // handled message is settled (Complete) and does not leak onto the shared emulator's queues.
+    //
+    // The DI-time startup guard (cross-entity ON + multiple distinct top-level entities throws at client
+    // build) is exercised WITHOUT a broker by the WhenConfiguringCrossEntityTransactions unit facts, so it is
+    // deliberately NOT re-covered here as a Docker-gated test.
+    //
+    // All facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green; the emulator CI lane (`--filter Category=Integration`) runs them for real.
+    [Trait("Category", "Integration")]
+    [Collection(ServiceBusEmulatorCollection.Name)]
+    public class PipelineMultiReceiverTests
+    {
+        // Two DISTINCT top-level queue entities, reused from the existing emulator Config.json (no new
+        // entities). xUnit runs classes within a collection serially, so reusing these queues cannot collide
+        // with the round-trip / transaction-mode classes that also reference them.
+        private const string QueueA = "chatter.roundtrip";
+        private const string QueueB = "chatter.receiveonly";
+
+        // Generous on purpose: two receivers must each deliver against the slow emulator, where a full
+        // integration run takes minutes. 90s per handler gives headroom without masking a real wiring failure
+        // (the multi-receiver hang is the scenario under test, so a stall must fail fast via TimeoutException
+        // rather than hang CI).
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(90);
+
+        private readonly ServiceBusEmulatorFixture _emulator;
+
+        public PipelineMultiReceiverTests(ServiceBusEmulatorFixture emulator)
+            => _emulator = emulator;
+
+        public sealed class AlphaCommand : ICommand
+        {
+            public string Value { get; set; }
+        }
+
+        public sealed class BetaCommand : ICommand
+        {
+            public string Value { get; set; }
+        }
+
+        // Two queue receivers on distinct top-level entities, registered in ONE host via two AddQueueReceiver
+        // calls in the same configure delegate. A message sent to each must reach its own handler with the
+        // exact payload — proving multiple receivers on distinct entities now coexist in one host (the prior
+        // cross-entity-transaction hang is gone).
+        [RequiresDockerFact]
+        public async Task MultipleReceiversOnDistinctEntitiesEachDeliverToTheirHandler()
+        {
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb =>
+                {
+                    sb.AddQueueReceiver<AlphaCommand>(QueueA, transactionMode: TransactionMode.ReceiveOnly);
+                    sb.AddQueueReceiver<BetaCommand>(QueueB, transactionMode: TransactionMode.ReceiveOnly);
+                },
+                typeof(AlphaCommand),
+                typeof(BetaCommand));
+            await harness.StartAsync();
+
+            var dispatcher = harness.CreateDispatcher(out var scope);
+            using (scope)
+            {
+                await dispatcher.Send(new AlphaCommand { Value = "alpha" }, QueueA);
+                await dispatcher.Send(new BetaCommand { Value = "beta" }, QueueB);
+            }
+
+            var alphaHandled = await harness.WaitForHandledAsync<AlphaCommand>(HandlerWait);
+            var betaHandled = await harness.WaitForHandledAsync<BetaCommand>(HandlerWait);
+
+            alphaHandled.Message.Should().NotBeNull(
+                "the receiver on the first entity must deliver its command to its handler");
+            alphaHandled.Message.Value.Should().Be(
+                "alpha",
+                "the first handler must receive the exact payload sent to the first entity");
+
+            betaHandled.Message.Should().NotBeNull(
+                "the receiver on the second entity must deliver its command to its handler in the same host");
+            betaHandled.Message.Value.Should().Be(
+                "beta",
+                "the second handler must receive the exact payload sent to the second entity");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineScheduledDeliveryTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineScheduledDeliveryTests.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.AzureServiceBus;
+using Chatter.MessageBrokers.AzureServiceBus.Options;
+using Chatter.MessageBrokers.Routing.Options;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
+{
+    // Scheduled-delivery coverage driven THROUGH Chatter. The SYSTEM UNDER TEST is Chatter's outbound
+    // scheduled-enqueue path: a command is dispatched via IBrokeredMessageDispatcher.Send with the
+    // ASBMessageContext.ScheduledEnqueueTimeUtc header set on SendOptions. Chatter's
+    // OutboundBrokeredMessageExtensions.AsAzureServiceBusMessage reads that header and stamps
+    // ServiceBusMessage.ScheduledEnqueueTime, so the broker holds the message until the scheduled time before
+    // delivering it to Chatter's pump and the RecordingMessageHandler.
+    //
+    // The proof is purely through Chatter: the handler is NOT invoked before the scheduled time (a short-timeout
+    // WaitForHandledAsync times out) and IS invoked after it (a second wait with margin succeeds). Timings are
+    // tolerant for the slow emulator.
+    //
+    // All facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green; the emulator CI lane (`--filter Category=Integration`) runs them for real.
+    [Trait("Category", "Integration")]
+    [Collection(ServiceBusEmulatorCollection.Name)]
+    public class PipelineScheduledDeliveryTests
+    {
+        private const string ScheduledQueue = "chatter.roundtrip";
+        // How far in the future the message is scheduled. Long enough that the "not yet" assertion is meaningful
+        // against the slow emulator, short enough to keep the test quick.
+        private static readonly TimeSpan ScheduleDelay = TimeSpan.FromSeconds(10);
+        // A wait that must EXPIRE before the scheduled time elapses — kept comfortably under ScheduleDelay so a
+        // premature delivery (the failure this guards) would be observed.
+        private static readonly TimeSpan BeforeScheduleWait = TimeSpan.FromSeconds(4);
+        // A wait that starts at/after the scheduled time, with generous margin for the emulator to deliver.
+        private static readonly TimeSpan AfterScheduleWait = TimeSpan.FromSeconds(45);
+
+        private readonly ServiceBusEmulatorFixture _emulator;
+
+        public PipelineScheduledDeliveryTests(ServiceBusEmulatorFixture emulator)
+            => _emulator = emulator;
+
+        public sealed class ScheduledCommand : ICommand
+        {
+            public string Value { get; set; }
+        }
+
+        // A command dispatched with a future ScheduledEnqueueTimeUtc is held by the broker until that time:
+        // Chatter's pump does NOT deliver it before the scheduled time (the bounded wait times out), then DOES
+        // deliver it after, proving Chatter's scheduled-enqueue header reached the broker and was honored.
+        [RequiresDockerFact]
+        public async Task ScheduledCommandIsNotDeliveredBeforeItsScheduledTimeThenIsDeliveredAfter()
+        {
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb => sb.AddQueueReceiver<ScheduledCommand>(ScheduledQueue),
+                typeof(ScheduledCommand));
+            await harness.StartAsync();
+
+            // Chatter's scheduled-enqueue is set via the ASB-specific header on SendOptions; the outbound mapper
+            // (AsAzureServiceBusMessage) reads ASBMessageContext.ScheduledEnqueueTimeUtc and stamps
+            // ServiceBusMessage.ScheduledEnqueueTime. The value must be a DateTime (GetScheduledEnqueueTimeUtc
+            // casts to DateTime?).
+            var scheduledTimeUtc = DateTime.UtcNow + ScheduleDelay;
+            var options = new SendOptions();
+            options.WithMessageContext(ASBMessageContext.ScheduledEnqueueTimeUtc, scheduledTimeUtc);
+
+            var dispatcher = harness.CreateDispatcher(out var scope);
+            using (scope)
+            {
+                await dispatcher.Send(new ScheduledCommand { Value = "scheduled" }, ScheduledQueue, options: options);
+            }
+
+            // Before the scheduled time: the handler must NOT have been invoked. A bounded wait that expires
+            // before ScheduleDelay proves the broker is holding the message.
+            Func<Task> prematureWait = () => harness.WaitForHandledAsync<ScheduledCommand>(BeforeScheduleWait);
+            await prematureWait.Should().ThrowAsync<TimeoutException>(
+                "a scheduled message must not be delivered before its ScheduledEnqueueTimeUtc");
+
+            // After the scheduled time: the handler IS invoked. The wait margin covers the remaining schedule
+            // delay plus the emulator's delivery latency.
+            var handled = await harness.WaitForHandledAsync<ScheduledCommand>(AfterScheduleWait);
+            handled.Message.Should().NotBeNull(
+                "the scheduled message must be delivered once its ScheduledEnqueueTimeUtc has elapsed");
+            handled.Message.Value.Should().Be("scheduled");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineSingleEntityAtomicityTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineSingleEntityAtomicityTests.cs
@@ -76,6 +76,60 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
             }
         }
 
+        // Records, across all invocations, whether the handler was ever invoked for a FOLLOW-UP message — the
+        // HandlerSignal only retains the LAST record, so a dedicated flag is needed to prove the follow-up was
+        // NEVER delivered over the whole (redelivered) lifetime, not merely on the last poll. Registered as a
+        // singleton so the test and the DI-resolved handler share one instance.
+        private sealed class FollowUpObserver
+        {
+            private int _followUpHandledCount;
+
+            public int FollowUpHandledCount => Volatile.Read(ref _followUpHandledCount);
+
+            public void RecordFollowUp() => Interlocked.Increment(ref _followUpHandledCount);
+        }
+
+        // The rollback counterpart of ForwardingAtomicHandler: on the ORIGINAL message it sends a follow-up to
+        // the SAME entity within the receiver's atomic scope and THEN THROWS before returning, so the
+        // TransactionScope never completes and the enlisted follow-up send is rolled back (never delivered). It
+        // records every invocation (via the signal registry, so the test can observe redelivery) and flags any
+        // follow-up sighting on the shared FollowUpObserver so the test can prove no follow-up is ever handled.
+        private sealed class RollbackAtomicHandler : IMessageHandler<AtomicCommand>
+        {
+            private readonly HandlerSignalRegistry _registry;
+            private readonly FollowUpObserver _followUpObserver;
+
+            public RollbackAtomicHandler(HandlerSignalRegistry registry, FollowUpObserver followUpObserver)
+            {
+                _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+                _followUpObserver = followUpObserver ?? throw new ArgumentNullException(nameof(followUpObserver));
+            }
+
+            public async Task Handle(AtomicCommand message, IMessageHandlerContext context)
+            {
+                _registry.GetOrAdd<AtomicCommand>().Record(
+                    new HandledRecord<AtomicCommand>(message, context as IMessageBrokerContext));
+
+                if (message.IsFollowUp)
+                {
+                    // A follow-up reaching the handler would mean the rolled-back send was delivered — the
+                    // failure this test guards against. Flag it and stop (no further send) so the test can assert
+                    // it never happens.
+                    _followUpObserver.RecordFollowUp();
+                    return;
+                }
+
+                // Send the follow-up to the SAME entity so it enlists in the receiver's atomic scope, then throw
+                // BEFORE returning so the scope never completes — the follow-up send must roll back with it.
+                await context.Send(
+                    new AtomicCommand { Value = message.Value + "-followup", IsFollowUp = true },
+                    AtomicQueue);
+
+                throw new InvalidOperationException(
+                    "force the atomic scope to roll back after enlisting the follow-up send");
+            }
+        }
+
         // FullAtomicityViaInfrastructure on a single entity: the original is consumed and the follow-up it
         // sends (within the atomic scope) is delivered back to the same handler. Observing the follow-up
         // handling proves the send committed atomically with the original's settle.
@@ -122,6 +176,57 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
                     r => r.Message.IsFollowUp && r.Message.Value == "atomic-followup",
                     "the committed atomic scope must deliver the follow-up payload to the same entity, not just " +
                     "redeliver the original");
+        }
+
+        // FullAtomicityViaInfrastructure rollback (the commit test's counterpart): the handler sends a follow-up
+        // to the SAME entity within the atomic scope and then THROWS, so the TransactionScope never completes.
+        // The enlisted follow-up send must roll back (the follow-up is NEVER delivered) AND the original is
+        // abandoned on the PeekLock and REDELIVERED to the handler. This is the rollback half of the atomicity
+        // guarantee — the original's settle and the follow-up send fail together. maxReceiveAttempts bounds the
+        // redelivery so the original eventually deadletters instead of looping forever.
+        [RequiresDockerFact]
+        public async Task FullAtomicityRollsBackFollowUpWhenHandlerThrowsAndRedeliversOriginal()
+        {
+            var followUpObserver = new FollowUpObserver();
+
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb =>
+                {
+                    sb.AddQueueReceiver<AtomicCommand>(
+                        AtomicQueue,
+                        transactionMode: TransactionMode.FullAtomicityViaInfrastructure,
+                        maxReceiveAttempts: 3);
+                    // The shared observer the test reads to prove no follow-up ever reaches the handler.
+                    sb.Services.AddSingleton(followUpObserver);
+                    // The rollback handler sends the follow-up then throws, so the atomic scope never completes.
+                    sb.Services.AddTransient<IMessageHandler<AtomicCommand>, RollbackAtomicHandler>();
+                });
+            await harness.StartAsync();
+
+            var dispatcher = harness.CreateDispatcher(out var scope);
+            using (scope)
+            {
+                await dispatcher.Send(new AtomicCommand { Value = "rollback" }, AtomicQueue);
+            }
+
+            // First handling: the original message (which sends the follow-up, then throws).
+            var firstHandling = await harness.WaitForHandledAsync<AtomicCommand>(HandlerWait);
+            firstHandling.Message.Value.Should().Be("rollback");
+            firstHandling.Message.IsFollowUp.Should().BeFalse("the original message is consumed first");
+
+            // The original is abandoned on the thrown handler and REDELIVERED (PeekLock), so the handler is
+            // invoked again — proving the original's settle rolled back with the scope.
+            var observed = await harness.WaitForInvocationCountAsync<AtomicCommand>(2, HandlerWait);
+            observed.Should().BeGreaterThanOrEqualTo(2,
+                "the original is abandoned when the handler throws and must be redelivered (the settle rolled back)");
+
+            // The follow-up send enlisted in the never-completed scope must have rolled back: across the entire
+            // redelivered lifetime the handler is NEVER invoked for a follow-up. The window is generous enough
+            // that a delivered follow-up (if the rollback were broken) would have landed within it.
+            followUpObserver.FollowUpHandledCount.Should().Be(
+                0,
+                "the follow-up sent inside the never-completed atomic scope must roll back and never be delivered");
         }
     }
 }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
@@ -6,11 +6,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
-### Added
+## [0.11.1] - 2026-06-09
 
 ### Changed
 
-### Fixed
+- Re-released to pull in Chatter.CQRS 0.8.1 (assembly-source scan no longer throws `ReflectionTypeLoadException` on dynamic/unloadable assemblies); no functional change to Chatter.MessageBrokers itself.
 
 ## [0.11.0] - 2026-06-07
 

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
@@ -7,7 +7,7 @@
          TryEncodeUnicodeScalar) is char*-pointer based, so the overrides must be unsafe. -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Chatter.MessageBrokers</PackageId>
-    <Version>0.11.0</Version>
+    <Version>0.11.1</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A message broker adapter library built on top of Chatter.CQRS.</Description>


### PR DESCRIPTION
## Summary

Fixes a **regression shipped in `Chatter.MessageBrokers.AzureServiceBus` 1.0.0** (the Azure.Messaging.ServiceBus migration) that the new integration tests surfaced: the shared `ServiceBusClient` was built with `EnableCrossEntityTransactions = true` **unconditionally**, so a single host **could not run more than one queue receiver** — the second top-level entity throws *"Local transactions cannot span multiple top-level entities"*, and the receive loop **swallowed** it into a silent 30s hang.

**Bumps `Chatter.MessageBrokers.AzureServiceBus` 1.0.0 → 1.1.0.** Core `Chatter.MessageBrokers` is intentionally untouched.

> Stacked on #144 (the integration-test PR, which provides the test harness). **Base = #144**; retarget to `master` after #144 merges.

## Fix

- **Cross-entity transactions are now OFF by default.** Auto-enabled only when a receiver uses `TransactionMode.FullAtomicityViaInfrastructure`, or via the new explicit opt-in.
- **New API:** `ServiceBusOptions.EnableCrossEntityTransactions` (config-bindable, default false) + `ServiceBusOptionsBuilder.WithCrossEntityTransactions()`.
- **Startup guard:** when cross-entity is effective *and* more than one distinct top-level receiver entity is registered, fail fast with a clear configuration error naming the conflicting entities — instead of the SDK silently failing the second receiver.
- **Loud failure:** the fatal cross-entity rejection is reclassified as `CriticalReceiverException` so it surfaces via the existing receiver seam instead of hanging — **no core module change** (keeps blast radius off the other brokers).

Net effect: multi-queue-receiver hosts (the common case) work out of the box; atomicity users get cross-entity when they ask for it.

## Tests

- **5 DI guard unit tests** (`WhenConfiguringCrossEntityTransactions`) — run locally without Docker, prove the off-by-default / auto-enable / startup-guard logic.
- **Multi-receiver emulator regression test** — two receivers on distinct entities in one host both deliver (the exact v1.0.0 hang scenario).
- Plus, folded in from a coverage audit, new high-value emulator tests: complex/nested/enum/bool payload round-trip + quoted-scalar read-leniency (guards the STJ migration), single-entity atomicity **rollback**, scheduled delivery, and the exact retry-attempts→dead-letter boundary.

## Validation

- Local `dotnet test`: **green net8.0 + net10.0, 0 failures** (ASB 148 passed / 19 skipped — emulator + real-namespace tests skip without Docker; the DI guard tests pass).
- The emulator CI lane runs the regression + all new tests for real.

## Known follow-up (separate)

The audit surfaced a **dead option**: `MaxConcurrentCalls` is hard-coded to 1 in `BrokeredMessageReceiver` (core), so the ASB-level setting is silently ignored. Not addressed here (separate fix); flagged so it isn't mistaken for working.

---
### Update — bundled robustness fix

CI (run on the fix branch) proved the **emulator regression + all gap tests pass live**. The build job surfaced a separate pre-existing core bug: `Chatter.CQRS`'s assembly-source scan called `Assembly.GetTypes()` without guarding `ReflectionTypeLoadException`, so a loaded dynamic-proxy/mock assembly (e.g. Moq's `DynamicProxyGenAssembly2`) aborted `AddChatterCqrs`'s handler scan. Fixed here via a `SafeGetLoadableTypes` guard (**Chatter.CQRS 0.8.0 → 0.8.1**). This PR now bumps two artifacts.

**Merge order:** #144 (tests) → #145 (this — ASB 1.1.0 + CQRS 0.8.1). Retarget #145 to `master` after #144 merges.