### PR TITLE
ASB cross-entity startup guard hardening (#146): protect attribute/hosted receivers, fail-fast, honest MaxConcurrentCalls

### DIFF
--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -12,6 +12,18 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [1.2.0] - 2026-06-09
+
+### Changed
+
+- The global `ServiceBusOptions.MaxConcurrentCalls` is now propagated to receivers (was previously a dead option — receivers always ran single-threaded).
+
+### Fixed
+
+- (F3) Attribute-registered (`[BrokeredMessage]`) receivers are now included in the cross-entity-transactions single-top-level-entity startup guard via the new discovered-receiver seam — previously they bypassed the registry and were unprotected.
+- (F4) A cross-entity startup guard violation now fails host startup with a plain `InvalidOperationException` instead of being silently swallowed by the core receiver.
+- (F5) Explicit `WithMaxConcurrentCalls(...)` / `WithPrefetchCount(...)` calls set to the default value are no longer silently dropped in favor of configuration (nullable builder backing fields distinguish "unset" from "set-to-default").
+
 ## [1.1.0] - 2026-06-09
 
 ### Added

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -16,7 +16,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Changed
 
-- The global `ServiceBusOptions.MaxConcurrentCalls` is now propagated to receivers (was previously a dead option — receivers always ran single-threaded).
+- The global `ServiceBusOptions.MaxConcurrentCalls` is now propagated to receivers as a source-of-truth value (previously a dead option). NOTE: this does not yet enable parallel message processing — that is tracked as a follow-up (#147).
 
 ### Fixed
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -20,7 +20,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
-- (F3) Attribute-registered (`[BrokeredMessage]`) receivers are now included in the cross-entity-transactions single-top-level-entity startup guard via the new discovered-receiver seam — previously they bypassed the registry and were unprotected.
+- (F3) Attribute-registered (`[BrokeredMessage]`) receivers are now included in the cross-entity-transactions single-top-level-entity startup guard via the new discovered-receiver seam — previously they bypassed the registry and were unprotected. The fold-in now respects the core's default-infrastructure resolution: a blank-`InfrastructureType` receiver is attributed to Azure Service Bus only when Azure Service Bus is the resolved default (no other broker registered its infrastructure first), so in a multi-broker host a non-ASB blank-typed receiver is no longer mis-claimed by the ASB guard or stamped with ASB's `MaxConcurrentCalls`.
 - (F4) A cross-entity startup guard violation now fails host startup with a plain `InvalidOperationException` instead of being silently swallowed by the core receiver.
 - (F5) Explicit `WithMaxConcurrentCalls(...)` / `WithPrefetchCount(...)` calls set to the default value are no longer silently dropped in favor of configuration (nullable builder backing fields distinguish "unset" from "set-to-default").
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.AzureServiceBus</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for Azure Service Bus.</Description>

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
@@ -219,6 +219,18 @@ namespace Microsoft.Extensions.DependencyInjection
         // registration time (no provider build) — the same object the receivers' hosted-service closures
         // captured. Stamping MaxConcurrentCalls on a retained instance is therefore visible when
         // BrokeredMessageReceiver reads ReceiverOptions.MaxConcurrentCalls at init.
+        //
+        // INVARIANT: a blank/empty ReceiverOptions.InfrastructureType is resolved by the core
+        // MessagingInfrastructureProvider to the FIRST-REGISTERED IMessagingInfrastructure (its _default =
+        // infrastructures.FirstOrDefault()), NOT unconditionally to ASB. This method runs BEFORE ASB registers
+        // its OWN IMessagingInfrastructure descriptor (the AddSingleton<IMessagingInfrastructure> in
+        // AddAzureServiceBus, below this call), so ANY IMessagingInfrastructure descriptor already present in
+        // `services` at this point belongs to an EARLIER-registered broker. If one exists, that earlier broker —
+        // not ASB — is the core's default, so blank-typed receivers are NOT ASB's and must not be claimed.
+        // `asbIsDefault` reproduces the core's first-registered-wins resolution BY CONSTRUCTION at ASB's own
+        // registration time. ACCEPTED BOUNDARY: a consumer that reorders registrations by adding an
+        // IMessagingInfrastructure AFTER AddAzureServiceBus would shift the core default away from ASB; this
+        // method only sees the descriptors present when AddAzureServiceBus runs.
         private static void PopulateFromDiscoveredReceivers(IServiceCollection services, ServiceBusReceiverRegistry receiverRegistry, ServiceBusOptions options)
         {
             var discoveredRegistry = services
@@ -229,9 +241,11 @@ namespace Microsoft.Extensions.DependencyInjection
                 return;
             }
 
+            var asbIsDefault = !services.Any(d => d.ServiceType == typeof(IMessagingInfrastructure));
+
             foreach (var receiverOptions in discoveredRegistry.DiscoveredReceivers)
             {
-                if (!IsAzureServiceBusReceiver(receiverOptions.InfrastructureType))
+                if (!IsAzureServiceBusReceiver(receiverOptions.InfrastructureType, asbIsDefault))
                 {
                     continue;
                 }
@@ -254,11 +268,15 @@ namespace Microsoft.Extensions.DependencyInjection
             }
         }
 
-        // An ASB receiver is one explicitly typed to ASB OR one left on the default infrastructure (empty
-        // InfrastructureType), which the runtime resolves to the FIRST registered infrastructure
-        // (MessagingInfrastructureProvider). Receivers typed to a DIFFERENT infrastructure are excluded.
-        private static bool IsAzureServiceBusReceiver(string infrastructureType)
-            => string.IsNullOrWhiteSpace(infrastructureType)
+        // An ASB receiver is one EXPLICITLY typed to ASB (always claimed) OR one left on the default
+        // infrastructure (blank/empty InfrastructureType) ONLY WHEN ASB is the core's resolved default. The core
+        // MessagingInfrastructureProvider resolves a blank InfrastructureType to the FIRST-REGISTERED
+        // IMessagingInfrastructure, so a blank-typed receiver is ASB's only when no earlier broker registered its
+        // own infrastructure first (asbIsDefault == true). When an earlier broker is the default, blank-typed
+        // receivers belong to it and are excluded here, matching the runtime's attribution. Receivers typed to a
+        // DIFFERENT non-ASB infrastructure are always excluded.
+        private static bool IsAzureServiceBusReceiver(string infrastructureType, bool asbIsDefault)
+            => (asbIsDefault && string.IsNullOrWhiteSpace(infrastructureType))
             || string.Equals(infrastructureType, ASBMessageContext.InfrastructureType, StringComparison.Ordinal);
 
         // Mirrors AzureServiceBusEntityPathBuilder's queue-vs-subscription inference: a queue receiver's

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
@@ -47,7 +47,14 @@ namespace Microsoft.Extensions.DependencyInjection
             // host), so the shared-client factory can always resolve it. AddQueueReceiver/AddTopicSubscription
             // run before this (the options delegate completes before AddAzureServiceBus(builder, options)),
             // so any populated registry is reused here rather than replaced.
-            GetOrAddReceiverRegistry(builder.Services);
+            var receiverRegistry = GetOrAddReceiverRegistry(builder.Services);
+
+            // Fold attribute-registered receivers ([BrokeredMessageAttribute] assembly scan) into the ASB
+            // receiver registry and stamp the global MaxConcurrentCalls. This runs at registration time, before
+            // the shared-client factory reads the registry at lazy resolve. `options` (the built ServiceBusOptions)
+            // is the only place the finalized global MaxConcurrentCalls is known — it is resolved at
+            // optBuilder.Build(), AFTER the receiver-registration options delegate has already run.
+            PopulateFromDiscoveredReceivers(builder.Services, receiverRegistry, options);
 
             // INVARIANT: a single shared ServiceBusClient per namespace. The client is a singleton built once
             // from ServiceBusOptions; receivers and senders are created off this one client. The client is
@@ -200,6 +207,71 @@ namespace Microsoft.Extensions.DependencyInjection
             registry = new ServiceBusReceiverRegistry();
             services.AddSingleton(registry);
             return registry;
+        }
+
+        // Folds attribute-registered receivers (the core [BrokeredMessageAttribute] assembly scan, which never
+        // calls AddQueueReceiver/AddTopicSubscription) into the ASB receiver registry so the cross-entity
+        // effective-flag computation and single-top-level-entity guard see them, and stamps the global
+        // MaxConcurrentCalls onto each ASB receiver's retained ReceiverOptions.
+        //
+        // The core IDiscoveredReceiverRegistry retains the LIVE ReceiverOptions instances; it is registered as a
+        // singleton ImplementationInstance, so it is read directly off the IServiceCollection here at
+        // registration time (no provider build) — the same object the receivers' hosted-service closures
+        // captured. Stamping MaxConcurrentCalls on a retained instance is therefore visible when
+        // BrokeredMessageReceiver reads ReceiverOptions.MaxConcurrentCalls at init.
+        private static void PopulateFromDiscoveredReceivers(IServiceCollection services, ServiceBusReceiverRegistry receiverRegistry, ServiceBusOptions options)
+        {
+            var discoveredRegistry = services
+                .FirstOrDefault(d => d.ServiceType == typeof(IDiscoveredReceiverRegistry))?
+                .ImplementationInstance as IDiscoveredReceiverRegistry;
+            if (discoveredRegistry is null)
+            {
+                return;
+            }
+
+            foreach (var receiverOptions in discoveredRegistry.DiscoveredReceivers)
+            {
+                if (!IsAzureServiceBusReceiver(receiverOptions.InfrastructureType))
+                {
+                    continue;
+                }
+
+                // (MaxConcurrentCalls) Stamp the finalized global value onto the retained live instance, before
+                // any hosted-service pumps. Visible at receiver init via ReceiverOptions.MaxConcurrentCalls.
+                receiverOptions.MaxConcurrentCalls = options.MaxConcurrentCalls;
+
+                // (F3) Infer the ASB top-level entity (queue vs topic) using the same SendingPath/ReceiverPath
+                // convention as AzureServiceBusEntityPathBuilder: a queue receiver has SendingPath empty or equal
+                // to its receiver path (top-level = receiver path); a topic subscription has a distinct
+                // SendingPath that is the topic (top-level = SendingPath). Register with per-call transactionMode
+                // null so it inherits the global mode in AnyRequiresCrossEntityTransactions, matching how the
+                // inline AddQueueReceiver/AddTopicSubscription guard treats no-per-call-mode receivers. The ASB
+                // registry de-dups top-level entities case-insensitively (DistinctTopLevelEntities), so a receiver
+                // registered BOTH via attribute and explicit AddQueueReceiver/AddTopicSubscription is not
+                // double-counted as a distinct top-level entity.
+                var topLevelEntity = InferTopLevelEntity(receiverOptions.SendingPath, receiverOptions.MessageReceiverPath);
+                receiverRegistry.Register(topLevelEntity, receiverOptions.TransactionMode);
+            }
+        }
+
+        // An ASB receiver is one explicitly typed to ASB OR one left on the default infrastructure (empty
+        // InfrastructureType), which the runtime resolves to the FIRST registered infrastructure
+        // (MessagingInfrastructureProvider). Receivers typed to a DIFFERENT infrastructure are excluded.
+        private static bool IsAzureServiceBusReceiver(string infrastructureType)
+            => string.IsNullOrWhiteSpace(infrastructureType)
+            || string.Equals(infrastructureType, ASBMessageContext.InfrastructureType, StringComparison.Ordinal);
+
+        // Mirrors AzureServiceBusEntityPathBuilder's queue-vs-subscription inference: a queue receiver's
+        // sending path is empty or equals its receiver path (the queue IS the top-level entity); a topic
+        // subscription's sending path is the distinct topic (the TOPIC is the top-level entity).
+        private static string InferTopLevelEntity(string sendingPath, string messageReceiverPath)
+        {
+            if (string.IsNullOrWhiteSpace(sendingPath) || string.Equals(sendingPath, messageReceiverPath, StringComparison.Ordinal))
+            {
+                return messageReceiverPath;
+            }
+
+            return sendingPath;
         }
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptionsBuilder.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptionsBuilder.cs
@@ -14,8 +14,17 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         private string _connectionString = null;
         private string _azureServiceBusSectionName = null;
         private IConfiguration _configuration;
-        private int _maxConcurrentCalls = _defaultMaxConcurrentCalls;
-        private int _prefetchCount = _defaultPrefetchCount;
+        // INVARIANT: null means WithMaxConcurrentCalls was never called, so the config-bound value is
+        // left untouched. A non-null value means the fluent method was called and its value overrides any
+        // config-bound value in EITHER direction (explicit 1 overrides config 5, explicit 0 overrides
+        // config 1). This distinguishes "fluent method not called" from "called with the default value"
+        // — a plain int defaulting to 1 could not tell those apart, silently dropping an explicit
+        // WithMaxConcurrentCalls(1) when config bound something else.
+        private int? _maxConcurrentCalls = null;
+        // INVARIANT: null means WithPrefetchCount was never called, so the config-bound value is
+        // left untouched. A non-null value means the fluent method was called and its value overrides
+        // any config-bound value in EITHER direction (explicit 0 overrides config 10).
+        private int? _prefetchCount = null;
         private ServiceBusRetryOptions _retryOptions = null;
         private IConfigurationSection _serviceBusOptionsSection = null;
         // INVARIANT: null means WithCrossEntityTransactions was never called, so the config-bound value is
@@ -201,14 +210,20 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
                 options.TokenCredential = _tokenCredential;
             }
 
-            if (_maxConcurrentCalls != _defaultMaxConcurrentCalls)
+            // Explicit fluent call wins over configuration: apply the fluent value only when
+            // WithMaxConcurrentCalls was actually called, leaving the config-bound value untouched
+            // otherwise.
+            if (_maxConcurrentCalls.HasValue)
             {
-                options.MaxConcurrentCalls = _maxConcurrentCalls;
+                options.MaxConcurrentCalls = _maxConcurrentCalls.Value;
             }
 
-            if (_prefetchCount != _defaultPrefetchCount)
+            // Explicit fluent call wins over configuration: apply the fluent value only when
+            // WithPrefetchCount was actually called, leaving the config-bound value untouched
+            // otherwise.
+            if (_prefetchCount.HasValue)
             {
-                options.PrefetchCount = _prefetchCount;
+                options.PrefetchCount = _prefetchCount.Value;
             }
 
             // Explicit fluent call wins over configuration: apply the fluent value only when

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
@@ -3,6 +3,7 @@ using Chatter.MessageBrokers.AzureServiceBus;
 using Chatter.MessageBrokers.AzureServiceBus.Options;
 using Chatter.MessageBrokers.Configuration;
 using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Sending;
 using FluentAssertions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -505,6 +506,147 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
                 .Single(r => r.MessageReceiverPath == "core-queue-a");
 
             asbReceiver.MaxConcurrentCalls.Should().Be(1);
+        }
+
+        // ----------------------------------------------------------------- default-infrastructure resolution (multi-broker)
+
+        // A non-ASB IMessagingInfrastructure whose Type is a distinct key. Registering this BEFORE AddAzureServiceBus
+        // makes it the core MessagingInfrastructureProvider's default (_default = infrastructures.FirstOrDefault()),
+        // so a blank-InfrastructureType receiver resolves to THIS broker, not ASB. Only the Type is exercised by
+        // these DI-time guard tests; the factory members are never invoked, so they are left unimplemented.
+        private sealed class PriorInfrastructure : IMessagingInfrastructure
+        {
+            public const string PriorInfrastructureType = "prior-broker-test";
+
+            public string Type => PriorInfrastructureType;
+
+            public IMessagingInfrastructureReceiver ReceiveInfrastructure
+                => throw new NotImplementedException();
+
+            public IMessagingInfrastructureDispatcher DispatchInfrastructure
+                => throw new NotImplementedException();
+
+            public IBrokeredMessagePathBuilder PathBuilder
+                => throw new NotImplementedException();
+        }
+
+        // Builds services where a non-ASB IMessagingInfrastructure is registered (via the core message-broker seam)
+        // BEFORE AddAzureServiceBus runs, plus core-route receivers. The prior infrastructure is added inside the
+        // AddMessageBrokers(configureReceivers) delegate, which the harness invokes before AddAzureServiceBus, so at
+        // PopulateFromDiscoveredReceivers time an earlier IMessagingInfrastructure descriptor already exists and ASB
+        // is NOT the resolved default — exactly the multi-broker ordering the default-resolution guard depends on.
+        private static ServiceCollection BuildServicesWithPriorInfrastructureAndCoreReceivers(
+            Action<ServiceBusOptionsBuilder> configureServiceBus,
+            Action<MessageBrokerOptionsBuilder> configureReceivers)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddChatterCqrs(EmptyConfig(), typeof(WhenConfiguringCrossEntityTransactions))
+                    .AddMessageBrokers(mb =>
+                    {
+                        mb.Services.AddSingleton<IMessagingInfrastructure>(new PriorInfrastructure());
+                        configureReceivers(mb);
+                    })
+                    .AddAzureServiceBus(sb =>
+                    {
+                        sb.WithConnectionString(_connectionString);
+                        configureServiceBus(sb);
+                    });
+
+            return services;
+        }
+
+        [Fact]
+        public async Task MustNotFoldBlankTypedReceiverIntoGuardWhenAnotherInfrastructureIsDefault()
+        {
+            // (a) A non-ASB broker is registered FIRST, so the core resolves blank-InfrastructureType receivers to
+            // IT, not ASB. A blank-typed receiver on a 2nd distinct top-level entity (under cross-entity-effective
+            // mode via global FullAtomicity) must NOT be folded into ASB's single-top-level-entity guard: only the
+            // single ASB-typed receiver counts, so the client is constructed and the guard does NOT throw.
+            await using var provider = BuildServicesWithPriorInfrastructureAndCoreReceivers(
+                sb => { },
+                mb =>
+                {
+                    mb.WithTransactionMode(TransactionMode.FullAtomicityViaInfrastructure);
+                    mb.AddReceiver<FirstCommand>("asb-queue-a", senderPath: "asb-queue-a", infrastructureType: ASBMessageContext.InfrastructureType);
+                    mb.AddReceiver<SecondCommand>("other-queue-b", senderPath: "other-queue-b");
+                }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustNotStampMaxConcurrentCallsOntoBlankTypedReceiverWhenAnotherInfrastructureIsDefault()
+        {
+            // (a) The non-ASB-default blank-typed receiver is also NOT stamped with ASB's global MaxConcurrentCalls:
+            // with WithMaxConcurrentCalls(7) configured, the ASB-typed receiver is stamped to 7 but the blank-typed
+            // (other-broker) receiver keeps the default 1 — proving the stamp is gated by ASB-default resolution.
+            await using var provider = BuildServicesWithPriorInfrastructureAndCoreReceivers(
+                sb => sb.WithMaxConcurrentCalls(7),
+                mb =>
+                {
+                    mb.AddReceiver<FirstCommand>("asb-queue-a", senderPath: "asb-queue-a", infrastructureType: ASBMessageContext.InfrastructureType);
+                    mb.AddReceiver<SecondCommand>("other-queue-b", senderPath: "other-queue-b");
+                }).BuildServiceProvider();
+
+            var discoveredRegistry = provider.GetRequiredService<IDiscoveredReceiverRegistry>();
+            var asbReceiver = discoveredRegistry.DiscoveredReceivers.Single(r => r.MessageReceiverPath == "asb-queue-a");
+            var blankReceiver = discoveredRegistry.DiscoveredReceivers.Single(r => r.MessageReceiverPath == "other-queue-b");
+
+            asbReceiver.MaxConcurrentCalls.Should().Be(7);
+            blankReceiver.MaxConcurrentCalls.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task MustStillFoldBlankTypedReceiverIntoGuardWhenAsbIsSoleInfrastructure()
+        {
+            // (b) Regression: when ASB is the SOLE/first infrastructure (no prior broker), a blank-InfrastructureType
+            // receiver IS still claimed — two blank-typed receivers on distinct top-level entities under cross-entity
+            // -effective mode trip the guard exactly as before, proving single-broker fold-in behavior is preserved.
+            await using var provider = BuildServicesWithCoreReceivers(
+                sb => { },
+                mb =>
+                {
+                    mb.WithTransactionMode(TransactionMode.FullAtomicityViaInfrastructure);
+                    mb.AddReceiver<FirstCommand>("blank-queue-a", senderPath: "blank-queue-a");
+                    mb.AddReceiver<SecondCommand>("blank-queue-b", senderPath: "blank-queue-b");
+                }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*single top-level receiver entity*")
+                .WithMessage("*blank-queue-a*")
+                .WithMessage("*blank-queue-b*");
+        }
+
+        [Fact]
+        public async Task MustAlwaysFoldExplicitlyAsbTypedReceiverEvenWhenAnotherInfrastructureIsDefault()
+        {
+            // Edge: a receiver EXPLICITLY typed to ASB is always claimed regardless of which broker is the default.
+            // With a prior non-ASB infrastructure registered first, two explicitly-ASB-typed receivers on distinct
+            // top-level entities under cross-entity-effective mode still trip ASB's guard — explicit typing overrides
+            // the blank-default resolution.
+            await using var provider = BuildServicesWithPriorInfrastructureAndCoreReceivers(
+                sb => sb.WithCrossEntityTransactions(),
+                mb =>
+                {
+                    mb.AddReceiver<FirstCommand>("asb-queue-a", senderPath: "asb-queue-a", infrastructureType: ASBMessageContext.InfrastructureType);
+                    mb.AddReceiver<SecondCommand>("asb-queue-b", senderPath: "asb-queue-b", infrastructureType: ASBMessageContext.InfrastructureType);
+                }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*single top-level receiver entity*")
+                .WithMessage("*asb-queue-a*")
+                .WithMessage("*asb-queue-b*");
         }
 
         private sealed class FirstEvent : CQRS.Events.IEvent { }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
@@ -1,4 +1,5 @@
 using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.AzureServiceBus;
 using Chatter.MessageBrokers.AzureServiceBus.Options;
 using Chatter.MessageBrokers.Configuration;
 using Chatter.MessageBrokers.Receiving;
@@ -7,6 +8,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 using ServiceBusClient = Azure.Messaging.ServiceBus.ServiceBusClient;
@@ -328,6 +330,181 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
             var options = provider.GetRequiredService<ServiceBusOptions>();
 
             options.EnableCrossEntityTransactions.Should().BeFalse();
+        }
+
+        // ----------------------------------------------------------------- (F3) attribute/core-registered receivers reach the guard
+
+        // Registers ASB receivers via the CORE AddReceiver route (MessageBrokerOptionsBuilder), which never
+        // calls AddQueueReceiver/AddTopicSubscription and so historically bypassed the ASB ServiceBusReceiverRegistry
+        // entirely — the same registration path the [BrokeredMessageAttribute] assembly scan converges on
+        // (ChatterMessageBrokerExtensions.AddReceiverImpl). STEP-003's PopulateFromDiscoveredReceivers now folds
+        // these into the ASB registry so the cross-entity guard counts them. Cross-entity is forced on via the
+        // fluent ServiceBus opt-in. A queue receiver's sending path equals its receiver path (the queue IS the
+        // top-level entity); a topic subscription's sending path is the distinct topic.
+        private static ServiceCollection BuildServicesWithCoreReceivers(
+            Action<ServiceBusOptionsBuilder> configureServiceBus,
+            Action<MessageBrokerOptionsBuilder> configureReceivers)
+        {
+            var services = new ServiceCollection();
+            services.AddLogging();
+
+            services.AddChatterCqrs(EmptyConfig(), typeof(WhenConfiguringCrossEntityTransactions))
+                    .AddMessageBrokers(configureReceivers)
+                    .AddAzureServiceBus(sb =>
+                    {
+                        sb.WithConnectionString(_connectionString);
+                        configureServiceBus(sb);
+                    });
+
+            return services;
+        }
+
+        [Fact]
+        public async Task MustTripGuardForCoreRegisteredReceiversOnMultipleTopLevelEntities()
+        {
+            // F3: two ASB receivers registered ONLY via the core AddReceiver route (no AddQueueReceiver call) on
+            // two DISTINCT top-level queue entities, with cross-entity forced on. Before STEP-003 these bypassed
+            // the ASB registry, so the guard saw zero entities and did NOT trip; now PopulateFromDiscoveredReceivers
+            // folds them in, so the unsupportable combination fails fast at client build — proving the
+            // attribute/core route is counted.
+            await using var provider = BuildServicesWithCoreReceivers(
+                sb => sb.WithCrossEntityTransactions(),
+                mb =>
+                {
+                    mb.AddReceiver<FirstCommand>("core-queue-a", senderPath: "core-queue-a", infrastructureType: ASBMessageContext.InfrastructureType);
+                    mb.AddReceiver<SecondCommand>("core-queue-b", senderPath: "core-queue-b", infrastructureType: ASBMessageContext.InfrastructureType);
+                }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*single top-level receiver entity*")
+                .WithMessage("*core-queue-a*")
+                .WithMessage("*core-queue-b*");
+        }
+
+        [Fact]
+        public async Task MustNotTripGuardForCoreRegisteredSubscriptionsOnSameTopic()
+        {
+            // F3: two core-registered ASB topic subscriptions on the SAME topic (distinct sending path = the
+            // topic) share one top-level entity, so even folded into the ASB registry they count once and the
+            // guard does not trip. Mirrors the explicit AddTopicSubscription same-topic case but via the core
+            // route, proving InferTopLevelEntity resolves the topic (not the subscription) as the top-level entity.
+            await using var provider = BuildServicesWithCoreReceivers(
+                sb => sb.WithCrossEntityTransactions(),
+                mb =>
+                {
+                    mb.AddReceiver<FirstEvent>("core-sub-1", senderPath: "core-shared-topic", infrastructureType: ASBMessageContext.InfrastructureType);
+                    mb.AddReceiver<SecondEvent>("core-sub-2", senderPath: "core-shared-topic", infrastructureType: ASBMessageContext.InfrastructureType);
+                }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustTripGuardWhenCoreRegisteredReceiverUsesGlobalFullAtomicity()
+        {
+            // F3: a core-registered ASB receiver with NO per-call transaction mode is folded in with null mode,
+            // inheriting the GLOBAL FullAtomicityViaInfrastructure mode — which auto-enables cross-entity — so a
+            // second distinct top-level entity trips the guard without any explicit WithCrossEntityTransactions().
+            // Proves the folded receivers participate in the effective-mode (global fold-in) computation, not just
+            // the explicit opt-in.
+            await using var provider = BuildServicesWithCoreReceivers(
+                sb => { },
+                mb =>
+                {
+                    mb.WithTransactionMode(TransactionMode.FullAtomicityViaInfrastructure);
+                    mb.AddReceiver<FirstCommand>("core-queue-a", senderPath: "core-queue-a", infrastructureType: ASBMessageContext.InfrastructureType);
+                    mb.AddReceiver<SecondCommand>("core-queue-b", senderPath: "core-queue-b", infrastructureType: ASBMessageContext.InfrastructureType);
+                }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should()
+                .Throw<InvalidOperationException>()
+                .WithMessage("*single top-level receiver entity*");
+        }
+
+        // ----------------------------------------------------------------- (F4) host-fail-fast without a live broker
+
+        [Fact]
+        public async Task MustThrowPlainInvalidOperationExceptionForUnsupportableComboWithoutBroker()
+        {
+            // F4: the unsupportable >1-top-level-entity + cross-entity combination fails fast at client resolve
+            // with a PLAIN InvalidOperationException (the cross-entity guard) — NOT an Azure SDK connection error
+            // — proving the guard fires at DI/build time with no live namespace. The exception type is the bare
+            // InvalidOperationException, not a derived/aggregate type.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.WithCrossEntityTransactions();
+                sb.AddQueueReceiver<FirstCommand>("queue-a");
+                sb.AddQueueReceiver<SecondCommand>("queue-b");
+            }).BuildServiceProvider();
+
+            Action resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            var thrown = resolveClient.Should().Throw<InvalidOperationException>().Which;
+            thrown.GetType().Should().Be<InvalidOperationException>();
+        }
+
+        [Fact]
+        public async Task MustNotThrowForSupportableSingleEntityHostWithoutBroker()
+        {
+            // F4: a valid single-top-level-entity host with cross-entity on resolves the client without throwing,
+            // again with no live broker — confirming fail-fast is scoped to the unsupportable combination only.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.WithCrossEntityTransactions();
+                sb.AddQueueReceiver<FirstCommand>("queue-a");
+            }).BuildServiceProvider();
+
+            var resolveClient = () => provider.GetRequiredService<ServiceBusClient>();
+
+            resolveClient.Should().NotThrow();
+            resolveClient().Should().NotBeNull();
+        }
+
+        // ----------------------------------------------------------------- MaxConcurrentCalls source-of-truth flow
+
+        [Fact]
+        public async Task MustStampGlobalMaxConcurrentCallsOntoDiscoveredAsbReceiverOptions()
+        {
+            // The global ServiceBusOptions.MaxConcurrentCalls (set fluently to 7) is stamped by
+            // PopulateFromDiscoveredReceivers onto each ASB receiver's RETAINED live ReceiverOptions, so the value
+            // reaches the receiver init seam. Asserted on the live ReceiverOptions held in IDiscoveredReceiverRegistry
+            // — the same instance BrokeredMessageReceiver reads MaxConcurrentCalls from at startup.
+            await using var provider = BuildServicesWithCoreReceivers(
+                sb => sb.WithMaxConcurrentCalls(7),
+                mb => mb.AddReceiver<FirstCommand>("core-queue-a", senderPath: "core-queue-a", infrastructureType: ASBMessageContext.InfrastructureType))
+                .BuildServiceProvider();
+
+            var discoveredRegistry = provider.GetRequiredService<IDiscoveredReceiverRegistry>();
+            var asbReceiver = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "core-queue-a");
+
+            asbReceiver.MaxConcurrentCalls.Should().Be(7);
+        }
+
+        [Fact]
+        public async Task MustLeaveDiscoveredAsbReceiverMaxConcurrentCallsAtDefaultWhenGlobalUnset()
+        {
+            // Zero-behavior-change guard: with the global MaxConcurrentCalls unset (default 1), the stamp leaves
+            // each ASB receiver's effective MaxConcurrentCalls at the default 1 — proving the flow does not alter
+            // existing single-call (sequential) receive behavior for hosts that never configure it.
+            await using var provider = BuildServicesWithCoreReceivers(
+                sb => { },
+                mb => mb.AddReceiver<FirstCommand>("core-queue-a", senderPath: "core-queue-a", infrastructureType: ASBMessageContext.InfrastructureType))
+                .BuildServiceProvider();
+
+            var discoveredRegistry = provider.GetRequiredService<IDiscoveredReceiverRegistry>();
+            var asbReceiver = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "core-queue-a");
+
+            asbReceiver.MaxConcurrentCalls.Should().Be(1);
         }
 
         private sealed class FirstEvent : CQRS.Events.IEvent { }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Options/UsingServiceBusOptionsBuilder/WhenBuilding.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Options/UsingServiceBusOptionsBuilder/WhenBuilding.cs
@@ -235,6 +235,70 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Options.UsingServiceBusOp
             options.PrefetchCount.Should().Be(0);
         }
 
+        // -------------------------------------------------- (F5) explicit fluent value wins over config binding
+
+        [Fact]
+        public void MustPreferExplicitDefaultMaxConcurrentCallsOverConfigValue()
+        {
+            // F5 nullable-backing-field guard: WithMaxConcurrentCalls(1) is the DEFAULT value, but calling it
+            // explicitly must still win over a config-bound non-default value. A plain int backing field
+            // defaulting to 1 could not distinguish "called with 1" from "never called" and would silently
+            // drop the explicit override, leaving the config-bound 5 in place.
+            var config = ConfigWith(new Dictionary<string, string>
+            {
+                [$"{_sectionName}:ConnectionString"] = _sasConnectionString,
+                [$"{_sectionName}:MaxConcurrentCalls"] = "5",
+            });
+            var options = Create(new ServiceCollection(), config)
+                .WithMaxConcurrentCalls(1)
+                .Build();
+            options.MaxConcurrentCalls.Should().Be(1);
+        }
+
+        [Fact]
+        public void MustPreserveConfigMaxConcurrentCallsWhenFluentNotCalled()
+        {
+            // F5: WithMaxConcurrentCalls NOT called leaves the config-bound value untouched — the nullable
+            // backing field stays null so no fluent override is applied.
+            var config = ConfigWith(new Dictionary<string, string>
+            {
+                [$"{_sectionName}:ConnectionString"] = _sasConnectionString,
+                [$"{_sectionName}:MaxConcurrentCalls"] = "5",
+            });
+            var options = Create(new ServiceCollection(), config).Build();
+            options.MaxConcurrentCalls.Should().Be(5);
+        }
+
+        [Fact]
+        public void MustPreferExplicitDefaultPrefetchCountOverConfigValue()
+        {
+            // F5 nullable-backing-field guard: WithPrefetchCount(0) is the DEFAULT value, but calling it
+            // explicitly must still win over a config-bound non-default value (10), exactly as
+            // MaxConcurrentCalls does.
+            var config = ConfigWith(new Dictionary<string, string>
+            {
+                [$"{_sectionName}:ConnectionString"] = _sasConnectionString,
+                [$"{_sectionName}:PrefetchCount"] = "10",
+            });
+            var options = Create(new ServiceCollection(), config)
+                .WithPrefetchCount(0)
+                .Build();
+            options.PrefetchCount.Should().Be(0);
+        }
+
+        [Fact]
+        public void MustPreserveConfigPrefetchCountWhenFluentNotCalled()
+        {
+            // F5: WithPrefetchCount NOT called leaves the config-bound value untouched.
+            var config = ConfigWith(new Dictionary<string, string>
+            {
+                [$"{_sectionName}:ConnectionString"] = _sasConnectionString,
+                [$"{_sectionName}:PrefetchCount"] = "10",
+            });
+            var options = Create(new ServiceCollection(), config).Build();
+            options.PrefetchCount.Should().Be(10);
+        }
+
         [Fact]
         public void MustNotApplyTokenCredentialWhenConnectionStringHasSas()
         {

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
@@ -10,7 +10,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Added
 
-- `ReceiverOptions.MaxConcurrentCalls` (default 1) — concurrency is now a live, honored option instead of hard-coded to 1.
+- `ReceiverOptions.MaxConcurrentCalls` (default 1) — is now carried through as a source-of-truth value (previously hard-coded to 1) and sizes the receive-loop semaphore. NOTE: actual parallel message processing is not yet delivered; the value is honored at receiver init but the receive loop still processes one message at a time. Real concurrency is tracked as a follow-up (#147).
+- `IReceiveMessages.ReceivingStarted` (`Task`) — completes when a receiver transitions to the receiving state, enabling host startup to await go-live without polling.
 - `IDiscoveredReceiverRegistry` / `DiscoveredReceiverRegistry` — a generic, infrastructure-agnostic seam that retains discovered receiver options so any messaging infrastructure (in-repo, out-of-repo, or consumer-built) can participate in its own startup bookkeeping without re-scanning assemblies.
 
 ### Fixed

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
@@ -6,6 +6,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-06-09
+
+### Added
+
+- `ReceiverOptions.MaxConcurrentCalls` (default 1) — concurrency is now a live, honored option instead of hard-coded to 1.
+- `IDiscoveredReceiverRegistry` / `DiscoveredReceiverRegistry` — a generic, infrastructure-agnostic seam that retains discovered receiver options so any messaging infrastructure (in-repo, out-of-repo, or consumer-built) can participate in its own startup bookkeeping without re-scanning assemblies.
+
+### Fixed
+
+- Startup-fatal receiver errors (e.g. an infrastructure's cross-entity startup guard) now propagate out of `IHostedService.StartAsync` to abort host startup loudly instead of being silently swallowed (the receiver no longer stops silently while the host keeps running).
+
 ## [0.11.1] - 2026-06-09
 
 ### Changed

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
@@ -11,7 +11,6 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 ### Added
 
 - `ReceiverOptions.MaxConcurrentCalls` (default 1) — is now carried through as a source-of-truth value (previously hard-coded to 1) and sizes the receive-loop semaphore. NOTE: actual parallel message processing is not yet delivered; the value is honored at receiver init but the receive loop still processes one message at a time. Real concurrency is tracked as a follow-up (#147).
-- `IReceiveMessages.ReceivingStarted` (`Task`) — completes when a receiver transitions to the receiving state, enabling host startup to await go-live without polling.
 - `IDiscoveredReceiverRegistry` / `DiscoveredReceiverRegistry` — a generic, infrastructure-agnostic seam that retains discovered receiver options so any messaging infrastructure (in-repo, out-of-repo, or consumer-built) can participate in its own startup bookkeeping without re-scanning assemblies.
 
 ### Fixed

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
@@ -7,7 +7,7 @@
          TryEncodeUnicodeScalar) is char*-pointer based, so the overrides must be unsafe. -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Chatter.MessageBrokers</PackageId>
-    <Version>0.11.1</Version>
+    <Version>0.12.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A message broker adapter library built on top of Chatter.CQRS.</Description>

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/DependencyInjection/ChatterMessageBrokerExtensions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/DependencyInjection/ChatterMessageBrokerExtensions.cs
@@ -249,12 +249,37 @@ namespace Microsoft.Extensions.DependencyInjection
 
         private static void AddReceiverImpl(this IServiceCollection services, ReceiverOptions options, Type closedBrokeredMessageReceiverInterface, Type closedConcreteBrokeredMessageReceiver, Type closedConcreteReceiverBackgroundService)
         {
+            // Retain the LIVE options instance — the SAME one captured into the hosted-service closure below —
+            // in the infrastructure-agnostic registry. Both registration routes (the [BrokeredMessageAttribute]
+            // assembly scan via GetAllReceiverTypes and the explicit AddReceiver<TMessage> overload) converge
+            // here, so retaining at this single seam covers both. An infrastructure package can read these
+            // options post-build and mutate a retained instance (e.g. stamp an infrastructure-resolved value)
+            // such that the mutation is visible when the receiver reads its options at init.
+            GetOrAddDiscoveredReceiverRegistry(services).Register(options);
+
             services.AddScoped(closedBrokeredMessageReceiverInterface, closedConcreteBrokeredMessageReceiver);
             services.AddSingleton(typeof(IHostedService), sp =>
             {
                 using var scope = sp.CreateScope();
                 return Activator.CreateInstance(closedConcreteReceiverBackgroundService, options, scope.ServiceProvider);
             });
+        }
+
+        // Resolves the single DiscoveredReceiverRegistry instance shared across all receiver registrations,
+        // registering it on first use. The instance is captured directly into the singleton descriptor so the
+        // same object is both written here (at registration) and resolved from DI by infrastructure packages
+        // (post-build) — mirroring how each receiver's live ReceiverOptions is retained here and read at init.
+        private static IDiscoveredReceiverRegistry GetOrAddDiscoveredReceiverRegistry(IServiceCollection services)
+        {
+            var existing = services.FirstOrDefault(d => d.ServiceType == typeof(IDiscoveredReceiverRegistry));
+            if (existing?.ImplementationInstance is IDiscoveredReceiverRegistry registry)
+            {
+                return registry;
+            }
+
+            registry = new DiscoveredReceiverRegistry();
+            services.AddSingleton(registry);
+            return registry;
         }
 
         private static void AddReceiverImpl(this IServiceCollection services, Type messageTypeToReceive, ReceiverOptions options)

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -113,6 +113,19 @@ namespace Chatter.MessageBrokers.Receiving
             _options = options;
             _maxConcurrentCalls = _options.MaxConcurrentCalls;
 
+            // Floor-at-the-sink: MaxConcurrentCalls is the single convergence point for every ingress path
+            // (the ASB WithMaxConcurrentCalls fluent setter, config binding, and the ASB MaxConcurrentCalls
+            // stamp onto retained ReceiverOptions), all of which accept an unvalidated int. A value < 1 would
+            // reach 'new SemaphoreSlim(count, count)' below and throw an opaque ArgumentOutOfRangeException at
+            // receiver startup. Validate here so a misconfigured value fails fast with a message that names the
+            // bad value and its source, surfaced through the same startup-fatal propagation path as the
+            // cross-entity guard rather than as an obscure semaphore error.
+            if (_maxConcurrentCalls < 1)
+            {
+                throw new InvalidOperationException(
+                    $"ReceiverOptions.MaxConcurrentCalls must be at least 1 for receiver '{options.MessageReceiverPath}'; found {_maxConcurrentCalls}. Configure a value >= 1.");
+            }
+
             _logger.LogTrace("Initializing messaging infrastructure");
             await _infrastructureReceiver.InitializeAsync(_options, receiverTerminationToken);
             _logger.LogTrace("Successfully initialized messaging infrastructure");

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -70,8 +70,11 @@ namespace Chatter.MessageBrokers.Receiving
         /// </summary>
         public bool IsReceiving { get; private set; } = false;
 
-        ///<inheritdoc/>
-        public Task ReceivingStarted => _receivingStartedSource.Task;
+        // EXPLICIT interface implementation: the go-live signal is reachable ONLY through the internal
+        // IReceiverStartupSignal seam, never as a member of the public BrokeredMessageReceiver<TMessage> surface.
+        // This keeps the relocated signal fully off the public contract (the public-API regression guard asserts
+        // its absence from IReceiveMessages, IBrokeredMessageReceiver<>, and this concrete type).
+        Task IReceiverStartupSignal.ReceivingStarted => _receivingStartedSource.Task;
 
         public string SendingPath { get; private set; }
         public string MessageReceiverPath { get; private set; }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -24,7 +24,7 @@ namespace Chatter.MessageBrokers.Receiving
         private SemaphoreSlim _concurrentMessagesSemaphore;
         CancellationTokenSource _messageReceiverLoopTokenSource;
         private Task _messageReceiverLoop;
-        private readonly int _maxConcurrentCalls = 1; //TODO: add configuration for maxconcurrentcalls to messagebrokeroptions and/or receiveroptions
+        private int _maxConcurrentCalls = 1;
         private readonly MessageBrokerOptions _messageBrokerOptions;
         private readonly IRecoveryStrategy _recoveryStrategy;
         private readonly IReceivedMessageDispatcher _receivedMessageDispatcher;
@@ -101,6 +101,7 @@ namespace Chatter.MessageBrokers.Receiving
 
             options.TransactionMode ??= _messageBrokerOptions.TransactionMode;
             _options = options;
+            _maxConcurrentCalls = _options.MaxConcurrentCalls;
 
             _logger.LogTrace("Initializing messaging infrastructure");
             await _infrastructureReceiver.InitializeAsync(_options, receiverTerminationToken);

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -14,7 +14,7 @@ namespace Chatter.MessageBrokers.Receiving
     /// An infrastructure agnostic receiver of brokered messages of type <typeparamref name="TMessage"/>
     /// </summary>
     /// <typeparam name="TMessage">The type of messages the brokered message receiver accepts</typeparam>
-    public class BrokeredMessageReceiver<TMessage> : IBrokeredMessageReceiver<TMessage> where TMessage : class, IMessage
+    public class BrokeredMessageReceiver<TMessage> : IBrokeredMessageReceiver<TMessage>, IReceiverStartupSignal where TMessage : class, IMessage
     {
         private IMessagingInfrastructureReceiver _infrastructureReceiver;
         private readonly IMessagingInfrastructureProvider _infrastructureProvider;

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -31,6 +31,12 @@ namespace Chatter.MessageBrokers.Receiving
         private readonly IMaxReceivesExceededAction _failedRecoveryAction;
         private readonly ICriticalFailureNotifier _criticalFailureNotifier;
 
+        // INVARIANT: completed exactly once, at the IsReceiving = true seam in StartReceiverImpl. Backs the
+        // ReceivingStarted startup-completion signal so callers gate on go-live without polling IsReceiving.
+        // RunContinuationsAsynchronously keeps the awaiter's continuation off the receive-loop start path.
+        private readonly TaskCompletionSource<bool> _receivingStartedSource =
+            new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
         /// <summary>
         /// Creates a brokered message receiver that receives messages of <typeparamref name="TMessage"/>
         /// </summary>
@@ -63,6 +69,9 @@ namespace Chatter.MessageBrokers.Receiving
         /// Indicates if the <see cref="BrokeredMessageReceiverBackgroundService{TMessage}"/> is currently receiving messages
         /// </summary>
         public bool IsReceiving { get; private set; } = false;
+
+        ///<inheritdoc/>
+        public Task ReceivingStarted => _receivingStartedSource.Task;
 
         public string SendingPath { get; private set; }
         public string MessageReceiverPath { get; private set; }
@@ -138,6 +147,7 @@ namespace Chatter.MessageBrokers.Receiving
 
             _messageReceiverLoop = MessageReceiverLoopAsync();
             this.IsReceiving = true;
+            _receivingStartedSource.TrySetResult(true);
             _logger.LogInformation("'{executingFunction}' has started receiving messages of type '{receiverMessageType}'.", nameof(BrokeredMessageReceiver<TMessage>), typeof(TMessage).Name);
             await _messageReceiverLoop;
             _logger.LogInformation("'{executingFunction}' for messages of type '{receiverMessageType}' is shutting down.", nameof(BrokeredMessageReceiver<TMessage>), typeof(TMessage).Name);

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -79,10 +79,20 @@ namespace Chatter.MessageBrokers.Receiving
             {
                 await StartReceiverImpl(options, receiverTerminationToken);
             }
-            catch (Exception e)
+            catch (Exception e) when (this.IsReceiving)
             {
+                // INVARIANT: this.IsReceiving only becomes true once StartReceiverImpl has finished the startup
+                // phase (infrastructure resolve + InitializeAsync) and the steady-state receive loop is live.
+                // Exceptions caught here therefore escaped the running loop, NOT the startup phase. The receive
+                // loop owns its own transient/retry/circuit-breaker handling, so anything that reaches here is a
+                // post-startup runtime fault: log it critically and let the host keep running (existing behavior).
                 _logger.LogCritical(e, "Critical unhandled error occured during {executingFunction}", nameof(MessageReceiverLoopAsync));
             }
+            // INVARIANT: startup-fatal exceptions (e.g. the Azure Service Bus cross-entity-transactions guard's
+            // InvalidOperationException, or any infrastructure/configuration failure surfaced before the receive
+            // loop goes live) are intentionally NOT caught here. They propagate to the caller so that, when this
+            // runs under IHostedService.StartAsync, .NET aborts host startup loudly instead of leaving a silently
+            // stopped receiver in a still-running host.
 
             return this;
         }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiverBackgroundService.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiverBackgroundService.cs
@@ -35,7 +35,19 @@ namespace Chatter.MessageBrokers.Receiving
             // startup-fatal receiver failure (e.g. the Azure Service Bus cross-entity-transactions guard's
             // InvalidOperationException) would be silently dropped and the host would keep running broken.
             //
-            // Start the base BackgroundService first (this assigns the ExecuteAsync Task), then await until the
+            // Resolve the startup-completion signal BEFORE starting the receive loop. The signal lives on the
+            // internal IReceiverStartupSignal seam, not the public IBrokeredMessageReceiver<TMessage> surface. The
+            // only registered receiver is the concrete BrokeredMessageReceiver<TMessage>, which implements it.
+            // Validating the cast here — before base.StartAsync kicks off ExecuteAsync — fails fast on an
+            // unsupported receiver so the receive loop is never started outside the go-live/executeTask
+            // observation path, leaving nothing stranded when host startup aborts.
+            if (_receiver is not IReceiverStartupSignal startupSignal)
+            {
+                throw new InvalidOperationException(
+                    $"Receiver '{_receiver.GetType().Name}' does not implement {nameof(IReceiverStartupSignal)}; host startup cannot gate on receiver go-live.");
+            }
+
+            // Start the base BackgroundService (this assigns the ExecuteAsync Task), then await until the
             // receiver either:
             //   - goes live (IsReceiving == true) — the startup phase succeeded; return so the receive loop
             //     keeps running for the receiver's lifetime, and
@@ -56,15 +68,6 @@ namespace Chatter.MessageBrokers.Receiving
             //   - ReceivingStarted: the receiver went live (IsReceiving became true); startup succeeded.
             //   - executeTask: ExecuteAsync completed/faulted before going live; a fault is startup-fatal.
             //   - cancellationToken: host startup was cancelled.
-            // The startup-completion signal lives on the internal IReceiverStartupSignal seam, not the public
-            // IBrokeredMessageReceiver<TMessage> surface. The only registered receiver is the concrete
-            // BrokeredMessageReceiver<TMessage>, which implements it; cast to reach the signal.
-            if (_receiver is not IReceiverStartupSignal startupSignal)
-            {
-                throw new InvalidOperationException(
-                    $"Receiver '{_receiver.GetType().Name}' does not implement {nameof(IReceiverStartupSignal)}; host startup cannot gate on receiver go-live.");
-            }
-
             var startedSignal = startupSignal.ReceivingStarted;
             var cancellationSignal = Task.Delay(Timeout.Infinite, cancellationToken);
             await Task.WhenAny(startedSignal, executeTask, cancellationSignal).ConfigureAwait(false);

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiverBackgroundService.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiverBackgroundService.cs
@@ -56,7 +56,16 @@ namespace Chatter.MessageBrokers.Receiving
             //   - ReceivingStarted: the receiver went live (IsReceiving became true); startup succeeded.
             //   - executeTask: ExecuteAsync completed/faulted before going live; a fault is startup-fatal.
             //   - cancellationToken: host startup was cancelled.
-            var startedSignal = _receiver.ReceivingStarted;
+            // The startup-completion signal lives on the internal IReceiverStartupSignal seam, not the public
+            // IBrokeredMessageReceiver<TMessage> surface. The only registered receiver is the concrete
+            // BrokeredMessageReceiver<TMessage>, which implements it; cast to reach the signal.
+            if (_receiver is not IReceiverStartupSignal startupSignal)
+            {
+                throw new InvalidOperationException(
+                    $"Receiver '{_receiver.GetType().Name}' does not implement {nameof(IReceiverStartupSignal)}; host startup cannot gate on receiver go-live.");
+            }
+
+            var startedSignal = startupSignal.ReceivingStarted;
             var cancellationSignal = Task.Delay(Timeout.Infinite, cancellationToken);
             await Task.WhenAny(startedSignal, executeTask, cancellationSignal).ConfigureAwait(false);
 

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiverBackgroundService.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiverBackgroundService.cs
@@ -28,6 +28,48 @@ namespace Chatter.MessageBrokers.Receiving
         }
 
         ///<inheritdoc/>
+        public override async Task StartAsync(CancellationToken cancellationToken)
+        {
+            // The default BackgroundService.StartAsync kicks off ExecuteAsync and stores its Task without
+            // awaiting it, so any exception ExecuteAsync throws is never observed at host startup — a
+            // startup-fatal receiver failure (e.g. the Azure Service Bus cross-entity-transactions guard's
+            // InvalidOperationException) would be silently dropped and the host would keep running broken.
+            //
+            // Start the base BackgroundService first (this assigns the ExecuteAsync Task), then await until the
+            // receiver either:
+            //   - goes live (IsReceiving == true) — the startup phase succeeded; return so the receive loop
+            //     keeps running for the receiver's lifetime, and
+            //   - or its ExecuteAsync Task faults before going live — a startup-fatal failure; surface it from
+            //     StartAsync so .NET aborts host startup loudly.
+            await base.StartAsync(cancellationToken).ConfigureAwait(false);
+
+            var executeTask = this.ExecuteTask;
+
+            // ExecuteTask is null only if ExecuteAsync completed synchronously; in that case there is nothing
+            // further to observe for startup.
+            if (executeTask is null)
+            {
+                return;
+            }
+
+            while (!_receiver.IsReceiving)
+            {
+                if (executeTask.IsCompleted)
+                {
+                    // Faulted before going live => startup-fatal. Awaiting re-throws the original exception
+                    // (e.g. the cross-entity guard's InvalidOperationException) so host startup aborts.
+                    // A clean completion before going live means the receiver shut down during startup with
+                    // nothing to run, so there is nothing left to await for the lifetime.
+                    await executeTask.ConfigureAwait(false);
+                    return;
+                }
+
+                cancellationToken.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        ///<inheritdoc/>
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             await using var _ = await _receiver.StartReceiver(_options, stoppingToken).ConfigureAwait(false);

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiverBackgroundService.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiverBackgroundService.cs
@@ -52,21 +52,27 @@ namespace Chatter.MessageBrokers.Receiving
                 return;
             }
 
-            while (!_receiver.IsReceiving)
-            {
-                if (executeTask.IsCompleted)
-                {
-                    // Faulted before going live => startup-fatal. Awaiting re-throws the original exception
-                    // (e.g. the cross-entity guard's InvalidOperationException) so host startup aborts.
-                    // A clean completion before going live means the receiver shut down during startup with
-                    // nothing to run, so there is nothing left to await for the lifetime.
-                    await executeTask.ConfigureAwait(false);
-                    return;
-                }
+            // Wait — without busy-polling IsReceiving — for the first of three ordering signals:
+            //   - ReceivingStarted: the receiver went live (IsReceiving became true); startup succeeded.
+            //   - executeTask: ExecuteAsync completed/faulted before going live; a fault is startup-fatal.
+            //   - cancellationToken: host startup was cancelled.
+            var startedSignal = _receiver.ReceivingStarted;
+            var cancellationSignal = Task.Delay(Timeout.Infinite, cancellationToken);
+            await Task.WhenAny(startedSignal, executeTask, cancellationSignal).ConfigureAwait(false);
 
-                cancellationToken.ThrowIfCancellationRequested();
-                await Task.Yield();
+            if (executeTask.IsCompleted && !startedSignal.IsCompleted)
+            {
+                // ExecuteAsync ended before the receiver signalled go-live. Awaiting re-throws a startup-fatal
+                // fault (e.g. the cross-entity guard's InvalidOperationException) so .NET aborts host startup
+                // loudly. A clean completion before going live means the receiver shut down during startup with
+                // nothing to run, so there is nothing left to await for the lifetime.
+                await executeTask.ConfigureAwait(false);
+                return;
             }
+
+            // Either the receiver went live (return so ExecuteAsync keeps running for the receiver's lifetime)
+            // or startup was cancelled (surface the OperationCanceledException as the prior code did).
+            cancellationToken.ThrowIfCancellationRequested();
         }
 
         ///<inheritdoc/>

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/DiscoveredReceiverRegistry.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/DiscoveredReceiverRegistry.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace Chatter.MessageBrokers.Receiving
+{
+    // INVARIANT: retains the LIVE ReceiverOptions reference (never a copy) for every discovered/registered
+    // receiver, so a later mutation by an infrastructure package (e.g. stamping an infrastructure-resolved
+    // value) is visible when the receiver reads its options at init. Infrastructure-agnostic: this type holds
+    // no knowledge of any specific messaging infrastructure.
+    public sealed class DiscoveredReceiverRegistry : IDiscoveredReceiverRegistry
+    {
+        private readonly List<ReceiverOptions> _receivers = new List<ReceiverOptions>();
+
+        public void Register(ReceiverOptions options)
+        {
+            _receivers.Add(options);
+        }
+
+        public IReadOnlyCollection<ReceiverOptions> DiscoveredReceivers => _receivers;
+    }
+}

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/IDiscoveredReceiverRegistry.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/IDiscoveredReceiverRegistry.cs
@@ -1,0 +1,30 @@
+using System.Collections.Generic;
+
+namespace Chatter.MessageBrokers.Receiving
+{
+    /// <summary>
+    /// An infrastructure-agnostic registry that RETAINS the live <see cref="ReceiverOptions"/> instance for every
+    /// receiver discovered or registered during Chatter message broker configuration. Registered as a singleton.
+    /// </summary>
+    /// <remarks>
+    /// The SAME <see cref="ReceiverOptions"/> instance captured into a receiver's hosted-service closure is retained
+    /// here, so an infrastructure package may read these options after the broker is built (e.g. to enforce
+    /// infrastructure-specific startup guards) and may mutate a retained instance (e.g. to stamp an
+    /// infrastructure-resolved value) such that the mutation is visible when the receiver reads its options at init.
+    /// Core holds no infrastructure concept; any infrastructure-specific interpretation (entity-name inference,
+    /// <see cref="ReceiverOptions.InfrastructureType"/> matching) lives in the infrastructure package that consumes
+    /// this registry.
+    /// </remarks>
+    public interface IDiscoveredReceiverRegistry
+    {
+        /// <summary>
+        /// Retains the live <see cref="ReceiverOptions"/> instance for a discovered or registered receiver.
+        /// </summary>
+        void Register(ReceiverOptions options);
+
+        /// <summary>
+        /// The retained live <see cref="ReceiverOptions"/> instances for every discovered or registered receiver.
+        /// </summary>
+        IReadOnlyCollection<ReceiverOptions> DiscoveredReceivers { get; }
+    }
+}

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/IReceiveMessages.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/IReceiveMessages.cs
@@ -1,4 +1,6 @@
-﻿namespace Chatter.MessageBrokers.Receiving
+﻿using System.Threading.Tasks;
+
+namespace Chatter.MessageBrokers.Receiving
 {
     public interface IReceiveMessages
     {
@@ -6,5 +8,14 @@
         /// Indicates if messages are currently being received
         /// </summary>
         public bool IsReceiving { get; }
+
+        /// <summary>
+        /// A <see cref="Task"/> that completes successfully exactly when the receiver goes live
+        /// (the moment <see cref="IsReceiving"/> transitions to <c>true</c>). It provides an awaitable
+        /// startup-completion signal so callers can gate on the receiver reaching steady state without
+        /// polling <see cref="IsReceiving"/>. It never faults: a startup-fatal failure surfaces through the
+        /// receive task itself, not this signal.
+        /// </summary>
+        public Task ReceivingStarted { get; }
     }
 }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/IReceiveMessages.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/IReceiveMessages.cs
@@ -1,5 +1,3 @@
-﻿using System.Threading.Tasks;
-
 namespace Chatter.MessageBrokers.Receiving
 {
     public interface IReceiveMessages
@@ -8,14 +6,5 @@ namespace Chatter.MessageBrokers.Receiving
         /// Indicates if messages are currently being received
         /// </summary>
         public bool IsReceiving { get; }
-
-        /// <summary>
-        /// A <see cref="Task"/> that completes successfully exactly when the receiver goes live
-        /// (the moment <see cref="IsReceiving"/> transitions to <c>true</c>). It provides an awaitable
-        /// startup-completion signal so callers can gate on the receiver reaching steady state without
-        /// polling <see cref="IsReceiving"/>. It never faults: a startup-fatal failure surfaces through the
-        /// receive task itself, not this signal.
-        /// </summary>
-        public Task ReceivingStarted { get; }
     }
 }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/IReceiverStartupSignal.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/IReceiverStartupSignal.cs
@@ -1,0 +1,21 @@
+using System.Threading.Tasks;
+
+namespace Chatter.MessageBrokers.Receiving
+{
+    /// <summary>
+    /// An internal startup-completion seam for brokered message receivers. The concrete
+    /// <see cref="BrokeredMessageReceiver{TMessage}"/> produces this signal; the internal
+    /// <see cref="BrokeredMessageReceiverBackgroundService{TMessage}"/> is its only consumer.
+    /// </summary>
+    internal interface IReceiverStartupSignal
+    {
+        /// <summary>
+        /// A <see cref="Task"/> that completes successfully exactly when the receiver goes live
+        /// (the moment <see cref="IReceiveMessages.IsReceiving"/> transitions to <c>true</c>). It provides an
+        /// awaitable startup-completion signal so callers can gate on the receiver reaching steady state without
+        /// polling <see cref="IReceiveMessages.IsReceiving"/>. It never faults: a startup-fatal failure surfaces
+        /// through the receive task itself, not this signal.
+        /// </summary>
+        Task ReceivingStarted { get; }
+    }
+}

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/ReceiverOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/ReceiverOptions.cs
@@ -45,5 +45,11 @@
         /// comparing actual receive attempts to the max will not execute.
         /// </summary>
         public int MaxReceiveAttempts { get; set; } = 10;
+
+        /// <summary>
+        /// The maximum number of messages the receiver will process concurrently. Defaults to 1, preserving
+        /// single-call (sequential) receive behavior for any receiver that does not configure it.
+        /// </summary>
+        public int MaxConcurrentCalls { get; set; } = 1;
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
@@ -45,7 +45,7 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             return mock;
         }
 
-        private static ReceiverOptions BuildReceiverOptions(int maxReceiveAttempts = 10)
+        private static ReceiverOptions BuildReceiverOptions(int maxReceiveAttempts = 10, int maxConcurrentCalls = 1)
             => new ReceiverOptions
             {
                 InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
@@ -55,6 +55,7 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
                 DeadLetterQueuePath = "deadletter-queue",
                 TransactionMode = TransactionMode.None,
                 MaxReceiveAttempts = maxReceiveAttempts,
+                MaxConcurrentCalls = maxConcurrentCalls,
             };
 
         // INVARIANT: body must deserialise cleanly as FakeMessage for non-poison tests.
@@ -265,6 +266,39 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack);
             infraReceiver.CallLog.Should().NotContain(ReceiverCall.Ack);
             maxReceivesAction.Verify(a => a.ExecuteAsync(It.IsAny<FailureContext>()), Times.Once);
+        }
+
+        // ------------------------------------------------------------------ (MaxConcurrentCalls) honored at receiver init
+
+        [Fact]
+        public async Task MustReceiveSuccessfullyWhenMaxConcurrentCallsAboveDefault()
+        {
+            // StartReceiverImpl reads ReceiverOptions.MaxConcurrentCalls into the concurrency semaphore at init
+            // (_concurrentMessagesSemaphore = new SemaphoreSlim(maxConcurrentCalls, maxConcurrentCalls)). A value
+            // above the default 1 must be accepted and leave the receive→dispatch→Ack path working — proving the
+            // new option is wired through receiver startup without regressing the loop. (The single receive loop
+            // is sequential, so concurrency throughput is not observable through the in-memory double; this pins
+            // that a >1 value is honored at init rather than rejected.)
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls: 4), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await AwaitDrainedAsync(infraReceiver, watchdog.Token);
+            await WaitForDispositionAsync(infraReceiver, ReceiverCall.Ack, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Ack);
+            dispatcher.Verify(
+                d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()),
+                Times.Once);
         }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
@@ -11,6 +11,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -337,14 +338,25 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
             await loop;
         }
 
-        // INVARIANT: public-API-shape guard. ReceivingStarted must NOT be a member of the public IReceiveMessages
-        // contract — it was reverted off the public surface to keep 0.12.0 a non-breaking MINOR. This guard fails
-        // if the breaking member is ever silently re-added to the public interface.
+        // INVARIANT: public-API-shape guard. ReceivingStarted must NOT be reachable on ANY public surface — not the
+        // IReceiveMessages contract, not the IBrokeredMessageReceiver<> contract, and not the public concrete
+        // BrokeredMessageReceiver<> type. It was relocated to the internal IReceiverStartupSignal seam (implemented
+        // explicitly on the concrete receiver) to keep 0.12.0 a non-breaking MINOR. This guard fails if the member
+        // is ever silently re-added to a public interface OR re-exposed as a public/implicit member on the concrete
+        // receiver (e.g. by reverting the explicit interface implementation).
         [Fact]
         public void MustNotExposeReceivingStartedOnPublicReceiveMessagesContract()
         {
-            typeof(IReceiveMessages).GetProperty("ReceivingStarted")
-                .Should().BeNull("ReceivingStarted lives on the internal IReceiverStartupSignal seam, not the public contract");
+            const BindingFlags PublicInstance = BindingFlags.Public | BindingFlags.Instance;
+
+            typeof(IReceiveMessages).GetProperty("ReceivingStarted", PublicInstance)
+                .Should().BeNull("ReceivingStarted lives on the internal IReceiverStartupSignal seam, not the public IReceiveMessages contract");
+
+            typeof(IBrokeredMessageReceiver<>).GetProperty("ReceivingStarted", PublicInstance)
+                .Should().BeNull("ReceivingStarted must not leak onto the public IBrokeredMessageReceiver<> contract");
+
+            typeof(BrokeredMessageReceiver<>).GetProperty("ReceivingStarted", PublicInstance)
+                .Should().BeNull("ReceivingStarted must be an explicit IReceiverStartupSignal implementation, not a public member of the concrete receiver");
         }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiving.cs
@@ -300,5 +300,51 @@ namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
                 d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()),
                 Times.Once);
         }
+
+        // ------------------------------------------------------------------ (startup signal) internal seam + public-surface guard
+
+        // INVARIANT: the go-live startup signal lives on the INTERNAL IReceiverStartupSignal seam (reachable here
+        // via InternalsVisibleTo("Chatter.MessageBrokers.Tests")), NOT the public IReceiveMessages contract. The
+        // concrete receiver produces it; BrokeredMessageReceiverBackgroundService is its only consumer.
+        [Fact]
+        public async Task MustCompleteReceivingStartedSignalOnGoLive()
+        {
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            sut.Should().BeAssignableTo<IReceiverStartupSignal>(
+                "the go-live signal lives on the internal IReceiverStartupSignal seam");
+            var startupSignal = (IReceiverStartupSignal)sut;
+            startupSignal.ReceivingStarted.IsCompleted.Should().BeFalse("the receiver has not started yet");
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
+
+            // Drained fires once the receive loop is live; go-live (IsReceiving = true) is set on the same path
+            // immediately before the loop is awaited, so ReceivingStarted has completed by the time it drains.
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+            await AwaitDrainedAsync(infraReceiver, watchdog.Token);
+            await WaitForDispositionAsync(infraReceiver, ReceiverCall.Ack, watchdog.Token);
+
+            sut.IsReceiving.Should().BeTrue();
+            startupSignal.ReceivingStarted.IsCompletedSuccessfully
+                .Should().BeTrue("the signal completes exactly when the receiver goes live");
+
+            cts.Cancel();
+            await loop;
+        }
+
+        // INVARIANT: public-API-shape guard. ReceivingStarted must NOT be a member of the public IReceiveMessages
+        // contract — it was reverted off the public surface to keep 0.12.0 a non-breaking MINOR. This guard fails
+        // if the breaking member is ever silently re-added to the public interface.
+        [Fact]
+        public void MustNotExposeReceivingStartedOnPublicReceiveMessagesContract()
+        {
+            typeof(IReceiveMessages).GetProperty("ReceivingStarted")
+                .Should().BeNull("ReceivingStarted lives on the internal IReceiverStartupSignal seam, not the public contract");
+        }
     }
 }


### PR DESCRIPTION
Closes #146.

Hardens the Azure Service Bus cross-entity startup guard so it protects **real hosted and attribute-registered receivers**, fixes the builder "differs-from-default" conflation, and turns the dead `MaxConcurrentCalls` option into an honest source-of-truth value. Deferred follow-up tracked in #147.

## What changed

### F4 — host fails fast instead of silently swallowing (core)
`BrokeredMessageReceiver.StartReceiver` previously caught **all** exceptions (LogCritical, no rethrow), so a cross-entity startup guard violation silently stopped a hosted receiver while the host kept running. Now startup-fatal exceptions (before the receive loop goes live) propagate out of `IHostedService.StartAsync` to abort host startup loudly, as a plain `InvalidOperationException`. Steady-state loop swallow/retry/circuit-breaker semantics are unchanged (`catch ... when (IsReceiving)`). Startup go-live is gated by a `TaskCompletionSource` (no busy-poll), via an **internal** `IReceiverStartupSignal` — no public-contract change.

### F3 — attribute-registered receivers reach the guard (generic seam)
New **infrastructure-agnostic** core `IDiscoveredReceiverRegistry` retains the live `ReceiverOptions` of every discovered receiver (both the `[BrokeredMessage]` attribute scan and the explicit registration path). Any messaging infrastructure — in-repo, out-of-repo, or consumer-built — can consume it; **core leaks no ASB concept**. ASB reads it, claims only the receivers it actually owns (respecting the core's first-registered default-infrastructure resolution, so a multi-broker host never mis-attributes another broker's receivers to ASB), infers the top-level entity, and folds them into the cross-entity single-top-level-entity guard.

### F5 — builder no longer drops explicit-default values
`ServiceBusOptionsBuilder` `MaxConcurrentCalls`/`PrefetchCount` backing fields are now nullable (`HasValue`-gated in `Build()`), mirroring `EnableCrossEntityTransactions`, so an explicit fluent call set to the default value is no longer silently overridden by configuration.

### MaxConcurrentCalls — plumbed as source of truth
Core `ReceiverOptions.MaxConcurrentCalls` (default 1) drives the receive-loop semaphore (was hard-coded to 1); ASB stamps the global `ServiceBusOptions.MaxConcurrentCalls` onto discovered receivers. **Note:** this carries the value end-to-end but does **not yet** deliver parallel processing — the receive loop still processes one message at a time. Real concurrency (and an investigation into using the SDK's native `ServiceBusProcessor.MaxConcurrentCalls` rather than hand-rolling it) is tracked in **#147**. CHANGELOG wording reflects this honestly.

## Versioning
- `Chatter.MessageBrokers` 0.11.1 → **0.12.0** (minor — additive: `MaxConcurrentCalls`, `IDiscoveredReceiverRegistry`)
- `Chatter.MessageBrokers.AzureServiceBus` 1.1.0 → **1.2.0** (minor — F3/F4/F5 + MaxConcurrentCalls propagation)
- `Chatter.CQRS` unchanged (no source change).

## Tests / validation
Full `dotnet test` (Category!=Integration) green — 14/14 assemblies across net8.0 + net10.0, 0 failed. New DI-time (no-Docker) coverage for F3 (attribute/core-route receivers reach the guard; multi-broker default-attribution; same-topic counts once), F4 (plain `InvalidOperationException` host-abort), F5 (config-vs-fluent precedence), the MaxConcurrentCalls flow, and a public-API-shape guard test.

## Review
Pre-PR local Codex review ran to convergence over 3 iterations: a multi-broker default-attribution correctness bug, a SemVer-breaking public-interface addition, and several quality findings were caught and fixed before this PR was opened.
