### PR TITLE
feat(messagebrokers): deliver real concurrent message processing for MaxConcurrentCalls (#147)

### DIFF
--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -12,6 +12,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [1.3.0] - 2026-06-09
+
+### Changed
+
+- Real concurrent message processing bounded by `MaxConcurrentCalls` is now delivered end-to-end: the `MaxConcurrentCalls` value propagated from `ServiceBusOptions` in 1.2.0 now drives actual parallel processing workers in `BrokeredMessageReceiver` (default `MaxConcurrentCalls = 1` preserves sequential behavior). Satisfies the "not yet delivered (#147)" caveat carried in the 1.2.0 release notes (#147).
+
 ## [1.2.0] - 2026-06-09
 
 ### Changed

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -12,6 +12,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+- (F6) A parked Azure Service Bus receive is now unblocked on teardown — the receive-loop `CancellationToken` is threaded through the internal receive port into the SDK `ReceiveMessageAsync(maxWaitTime, cancellationToken)` overload, and a shutdown-cancelled receive is swallowed quietly (returns `null`, no error log, no settle). Prevents teardown hangs when the broker or network is stalled.
+
 ## [1.3.0] - 2026-06-09
 
 ### Changed

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.AzureServiceBus</PackageId>
-    <Version>1.2.0</Version>
+    <Version>1.3.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for Azure Service Bus.</Description>

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/AzureSdkMessageReceiverAdapter.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/AzureSdkMessageReceiverAdapter.cs
@@ -3,6 +3,7 @@ using Azure.Messaging.ServiceBus;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using SdkServiceBusReceiver = Azure.Messaging.ServiceBus.ServiceBusReceiver;
 
@@ -71,7 +72,8 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
 
         public bool IsClosedOrClosing => _innerReceiver != null && _innerReceiver.IsClosed;
 
-        public Task<ServiceBusReceivedMessage> ReceiveAsync() => InnerReceiver.ReceiveMessageAsync();
+        public Task<ServiceBusReceivedMessage> ReceiveAsync(CancellationToken cancellationToken)
+            => InnerReceiver.ReceiveMessageAsync(maxWaitTime: null, cancellationToken);
 
         public Task CompleteAsync(ServiceBusReceivedMessage message) => InnerReceiver.CompleteMessageAsync(message);
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/IServiceBusMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/IServiceBusMessageReceiver.cs
@@ -1,5 +1,6 @@
 using Azure.Messaging.ServiceBus;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
@@ -21,7 +22,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
         /// <summary>True once the underlying receiver has been closed (or disposed).</summary>
         bool IsClosedOrClosing { get; }
 
-        Task<ServiceBusReceivedMessage> ReceiveAsync();
+        Task<ServiceBusReceivedMessage> ReceiveAsync(CancellationToken cancellationToken);
         Task CompleteAsync(ServiceBusReceivedMessage message);
         Task AbandonAsync(ServiceBusReceivedMessage message, IDictionary<string, object> propertiesToModify);
         Task DeadLetterAsync(ServiceBusReceivedMessage message, string deadLetterReason, string deadLetterErrorDescription);

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
@@ -130,7 +130,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
 
             try
             {
-                message = await this.InnerReceiver.ReceiveAsync();
+                message = await this.InnerReceiver.ReceiveAsync(cancellationToken);
             }
             catch (ServiceBusException sbe) when (sbe.IsTransient)
             {
@@ -157,6 +157,14 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                 // to stop the core receive loop loudly instead of being retried as a transient failure.
                 _logger.LogCritical(e, "Azure Service Bus rejected the receiver because cross-entity transactions cannot span multiple top-level entities");
                 throw new CriticalReceiverException(e);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                // Teardown path: the core receive loop cancelled its token to stop the pump, and the inner
+                // ASB receive observed it. Treat this as "nothing received" so the loop releases its slot and
+                // exits via its IsCancellationRequested guard — no error log, no nack/settle. TaskCanceledException
+                // is a subclass of OperationCanceledException, so it is covered here too.
+                return null;
             }
             catch (Exception e)
             {

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/ChatterPipelineHarness.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/ChatterPipelineHarness.cs
@@ -58,6 +58,22 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
             string connectionString,
             Action<ServiceBusOptionsBuilder> configureReceivers,
             params Type[] messageTypes)
+            => Build(connectionString, configureReceivers, configureServices: null, messageTypes);
+
+        // Overload with an additive, post-Chatter-wiring service-registration hook. configureServices (when
+        // non-null) runs AFTER the full Chatter graph + RecordingMessageHandler registrations are in place and
+        // BEFORE BuildServiceProvider(), so a test can register custom services (e.g. a coordinator-driven
+        // blocking IMessageHandler<TMessage> and a shared coordinator singleton) into Chatter's REAL DI graph
+        // and have Chatter's dispatcher resolve them on the receive path. A later IMessageHandler<TMessage>
+        // registration replaces the harness's default RecordingMessageHandler<TMessage> for that type (last
+        // registration wins for GetRequiredService), letting a test substitute its own handler. The
+        // parameterless-hook overload above forwards configureServices: null so every existing caller compiles
+        // and behaves identically.
+        public static ChatterPipelineHarness Build(
+            string connectionString,
+            Action<ServiceBusOptionsBuilder> configureReceivers,
+            Action<IServiceCollection> configureServices,
+            params Type[] messageTypes)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -103,6 +119,12 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
                 var handlerImplementation = typeof(RecordingMessageHandler<>).MakeGenericType(messageType);
                 services.AddTransient(handlerInterface, handlerImplementation);
             }
+
+            // Additive hook: a test may register custom services into the real Chatter graph here (after Chatter
+            // wiring + the default RecordingMessageHandler registrations, before the provider is built). A handler
+            // registered here for a type already wired above wins on resolution (last registration), so a test can
+            // substitute a coordinator-driven handler for the default recorder.
+            configureServices?.Invoke(services);
 
             var provider = services.BuildServiceProvider();
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineConcurrencyTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineConcurrencyTests.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS;
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.AzureServiceBus.Options;
+using Chatter.MessageBrokers.Receiving;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
+{
+    // Concurrency coverage driven THROUGH Chatter's real pipeline. The SYSTEM UNDER TEST is
+    // BrokeredMessageReceiver's bounded-parallel receive loop: with a global MaxConcurrentCalls = N (> 1), the
+    // loop admits up to N concurrent per-message workers via its SemaphoreSlim(N) gate, so up to N handler
+    // invocations run SIMULTANEOUSLY. M > N latch-blocked messages are sent; the coordinator records the peak
+    // number of handlers in-flight at once and the test asserts that peak == N (not 1, not M).
+    //
+    // The blocking handler + shared coordinator are registered into Chatter's REAL DI graph via the harness's
+    // additive configureServices hook, so Chatter's command dispatcher resolves and invokes THIS handler on the
+    // genuine receive path (a later IMessageHandler<TMessage> registration wins over the harness's default
+    // RecordingMessageHandler). Raw Azure.Messaging.ServiceBus never appears: send is via
+    // IBrokeredMessageDispatcher and receipt is via Chatter's pump.
+    //
+    // Regression fail-fast: a regressed SERIAL implementation would only ever have one handler in flight, so the
+    // coordinator's "N arrived concurrently" signal never completes. The test awaits that signal with a BOUNDED
+    // timeout and fails fast via TimeoutException instead of hanging CI. Once N are observed in flight the latch
+    // is released so all M handlers complete and every PeekLock message is settled (Complete) — nothing leaks
+    // onto the shared emulator queue.
+    //
+    // All facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green; the emulator CI lane (`--filter Category=Integration`) runs them for real.
+    [Trait("Category", "Integration")]
+    [Collection(ServiceBusEmulatorCollection.Name)]
+    public class PipelineConcurrencyTests
+    {
+        // Reuse an existing emulator queue (no new Config.json entity). MaxDeliveryCount is 10 so the broker does
+        // not deadletter before the handlers are released; LockDuration (PT10S) comfortably covers the time the
+        // handlers stay latched waiting for the concurrency signal. xUnit runs classes within a collection
+        // serially, so reusing this queue cannot collide with the deadletter class that also references it.
+        private const string ConcurrencyQueue = "chatter.attempts";
+
+        // The global concurrency cap under test (> 1) and the number of messages sent (M > N), so the loop must
+        // hold more messages than it can process at once — proving the gate admits exactly N, not 1 and not M.
+        private const int MaxConcurrentCalls = 3;
+        private const int MessageCount = 5;
+
+        // Bounded wait for N handlers to be in flight simultaneously. Generous for the slow emulator, where a
+        // full integration run takes minutes, but finite so a regressed serial loop (only ever 1 in flight) fails
+        // fast via TimeoutException rather than hanging CI.
+        private static readonly TimeSpan ConcurrencyReachedWait = TimeSpan.FromSeconds(90);
+
+        // Bounded settle window after the latch releases: long enough for all M PeekLock messages to be completed
+        // so none leak onto the shared queue, finite so a stuck settle does not hang the run.
+        private static readonly TimeSpan SettleWait = TimeSpan.FromSeconds(30);
+
+        private readonly ServiceBusEmulatorFixture _emulator;
+
+        public PipelineConcurrencyTests(ServiceBusEmulatorFixture emulator)
+            => _emulator = emulator;
+
+        public sealed class ConcurrencyCommand : ICommand
+        {
+            public string Value { get; set; }
+        }
+
+        // Shared coordinator the latched handler reports through. Tracks the live in-handler count and the peak
+        // observed simultaneously, completes ConcurrencyReached once 'target' handlers are in flight at once, and
+        // holds a release latch every handler awaits so the loop is forced to accumulate concurrent workers
+        // rather than draining them one at a time.
+        private sealed class ConcurrencyCoordinator
+        {
+            private readonly int _target;
+            private readonly TaskCompletionSource<bool> _concurrencyReached =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private readonly TaskCompletionSource<bool> _release =
+                new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            private int _current;
+            private int _peak;
+            private int _completed;
+
+            public ConcurrencyCoordinator(int target)
+                => _target = target;
+
+            // Completes once _target handlers are simultaneously in flight. The test awaits this (bounded) and a
+            // serial regression never completes it, so the bounded wait fails fast.
+            public Task ConcurrencyReached => _concurrencyReached.Task;
+
+            // The highest number of handlers observed in flight at the same instant.
+            public int PeakConcurrency => Volatile.Read(ref _peak);
+
+            // The number of handler invocations that have fully completed (entered and exited). Lets the test
+            // observe that every message settled through THIS handler after the latch released, without depending
+            // on the harness's RecordingMessageHandler (which this handler replaces for the message type).
+            public int CompletedCount => Volatile.Read(ref _completed);
+
+            // Records entry into the handler, updates the peak, and signals when the target concurrency is hit.
+            public void Enter()
+            {
+                var live = Interlocked.Increment(ref _current);
+
+                // INVARIANT: monotonically raise the recorded peak to the highest live count any handler observed.
+                // CompareExchange-loop so concurrent Enter calls cannot lose a higher observation to a race.
+                int observedPeak;
+                while (live > (observedPeak = Volatile.Read(ref _peak)))
+                {
+                    Interlocked.CompareExchange(ref _peak, live, observedPeak);
+                }
+
+                if (live >= _target)
+                {
+                    _concurrencyReached.TrySetResult(true);
+                }
+            }
+
+            public void Exit()
+            {
+                Interlocked.Decrement(ref _current);
+                Interlocked.Increment(ref _completed);
+            }
+
+            // Bounded poll until at least minCount handler invocations have completed, returning the observed
+            // count (which may be below minCount if the timeout elapses — the caller asserts on it so a
+            // never-reached threshold fails fast rather than hanging).
+            public async Task<int> WaitForCompletedAsync(int minCount, TimeSpan timeout)
+            {
+                var deadline = DateTime.UtcNow + timeout;
+                while (DateTime.UtcNow < deadline)
+                {
+                    if (CompletedCount >= minCount)
+                    {
+                        return CompletedCount;
+                    }
+
+                    await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+                }
+
+                return CompletedCount;
+            }
+
+            // Releases every latched handler so all messages settle and the receiver can drain.
+            public void Release()
+                => _release.TrySetResult(true);
+
+            // Awaited by each handler. Bounded so a never-released latch (e.g. concurrency target never reached)
+            // cannot hang a handler — it throws TimeoutException, failing the test fast.
+            public async Task WaitForRelease(TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(_release.Task, Task.Delay(timeout)).ConfigureAwait(false);
+                if (completed != _release.Task)
+                {
+                    throw new TimeoutException(
+                        $"Timed out after {timeout} waiting for the concurrency latch to be released.");
+                }
+
+                await _release.Task.ConfigureAwait(false);
+            }
+        }
+
+        // The latched handler Chatter resolves on the receive path. Enters the coordinator (raising the observed
+        // peak), then blocks on the release latch so concurrent invocations pile up to the SemaphoreSlim cap
+        // instead of completing one at a time.
+        private sealed class LatchedConcurrencyHandler : IMessageHandler<ConcurrencyCommand>
+        {
+            private readonly ConcurrencyCoordinator _coordinator;
+
+            public LatchedConcurrencyHandler(ConcurrencyCoordinator coordinator)
+                => _coordinator = coordinator;
+
+            public async Task Handle(ConcurrencyCommand message, IMessageHandlerContext context)
+            {
+                _coordinator.Enter();
+                try
+                {
+                    await _coordinator.WaitForRelease(ConcurrencyReachedWait).ConfigureAwait(false);
+                }
+                finally
+                {
+                    _coordinator.Exit();
+                }
+            }
+        }
+
+        // With MaxConcurrentCalls = N and M > N latch-blocked messages, exactly N handlers must run at once: the
+        // receive loop's SemaphoreSlim(N) admits N concurrent workers, the M-N surplus waits, and the recorded
+        // peak settles at N. A serial regression would peak at 1 and the concurrency signal would never fire
+        // (bounded TimeoutException). A peak above N would mean the cap leaked.
+        [RequiresDockerFact]
+        public async Task GlobalMaxConcurrentCallsRunsExactlyThatManyHandlersAtOnce()
+        {
+            var coordinator = new ConcurrencyCoordinator(MaxConcurrentCalls);
+
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb =>
+                {
+                    sb.WithMaxConcurrentCalls(MaxConcurrentCalls);
+                    sb.AddQueueReceiver<ConcurrencyCommand>(ConcurrencyQueue, transactionMode: TransactionMode.ReceiveOnly);
+                },
+                services =>
+                {
+                    // Registered AFTER the harness's default RecordingMessageHandler<ConcurrencyCommand>, so this
+                    // coordinator-driven handler wins on GetRequiredService and is the one Chatter invokes.
+                    services.AddSingleton(coordinator);
+                    services.AddTransient<IMessageHandler<ConcurrencyCommand>, LatchedConcurrencyHandler>();
+                },
+                typeof(ConcurrencyCommand));
+            await harness.StartAsync();
+
+            var dispatcher = harness.CreateDispatcher(out var scope);
+            using (scope)
+            {
+                for (var i = 0; i < MessageCount; i++)
+                {
+                    await dispatcher.Send(new ConcurrencyCommand { Value = $"message-{i}" }, ConcurrencyQueue);
+                }
+            }
+
+            // Bounded: a serial regression never reaches N concurrent handlers, so this throws TimeoutException
+            // and the test fails fast instead of hanging.
+            var concurrencyReached = await Task.WhenAny(
+                coordinator.ConcurrencyReached,
+                Task.Delay(ConcurrencyReachedWait));
+            (concurrencyReached == coordinator.ConcurrencyReached).Should().BeTrue(
+                $"the receive loop must run {MaxConcurrentCalls} handlers simultaneously when MaxConcurrentCalls is " +
+                $"{MaxConcurrentCalls} and {MessageCount} messages are pending; a serial loop would only ever run one");
+
+            // Release the latch so every handler completes and all PeekLock messages are settled (Complete), then
+            // give the receiver a bounded window to drain so nothing leaks onto the shared emulator queue.
+            coordinator.Release();
+            var completed = await coordinator.WaitForCompletedAsync(MessageCount, SettleWait);
+            completed.Should().Be(
+                MessageCount,
+                $"after the latch releases, all {MessageCount} messages must flow through the handler and settle");
+
+            coordinator.PeakConcurrency.Should().Be(
+                MaxConcurrentCalls,
+                $"the global MaxConcurrentCalls = {MaxConcurrentCalls} must cap simultaneous handler invocations at " +
+                $"exactly {MaxConcurrentCalls} — never 1 (serial regression) and never {MessageCount} (cap leaked)");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/InMemoryServiceBusMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/InMemoryServiceBusMessageReceiver.cs
@@ -2,6 +2,7 @@ using Chatter.MessageBrokers.AzureServiceBus.Receiving;
 using Azure.Messaging.ServiceBus;
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving
@@ -24,6 +25,10 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving
         public int ReceiveCount { get; private set; }
         public int CloseCount { get; private set; }
 
+        // The cancellation token observed on the most recent ReceiveAsync call, captured so tests can assert
+        // that ServiceBusReceiver.ReceiveMessageAsync passes its loop token straight through to the inner port.
+        public CancellationToken LastReceiveToken { get; private set; }
+
         public bool IsClosedOrClosing { get; set; }
 
         public void EnqueueMessage(ServiceBusReceivedMessage message) => _receiveResults.Enqueue(() => message);
@@ -32,9 +37,11 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving
 
         public void EnqueueThrow(Exception exception) => _receiveResults.Enqueue(() => throw exception);
 
-        public Task<ServiceBusReceivedMessage> ReceiveAsync()
+        public Task<ServiceBusReceivedMessage> ReceiveAsync(CancellationToken cancellationToken)
         {
             ReceiveCount++;
+            LastReceiveToken = cancellationToken;
+            cancellationToken.ThrowIfCancellationRequested();
             if (_receiveResults.Count == 0)
             {
                 return Task.FromResult<ServiceBusReceivedMessage>(null);

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenReceivingThroughInMemoryReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenReceivingThroughInMemoryReceiver.cs
@@ -133,19 +133,6 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
         }
 
         [Fact]
-        public async Task MustRethrowObjectDisposedWhenCancellationRequested()
-        {
-            var inMemory = new InMemoryServiceBusMessageReceiver { IsClosedOrClosing = true };
-            inMemory.EnqueueThrow(new ObjectDisposedException("receiver"));
-            var sut = await InitializedPeekLockSutAsync(inMemory);
-            var cancelled = new CancellationToken(canceled: true);
-
-            Func<Task> act = () => sut.ReceiveMessageAsync(new TransactionContext("receiver"), cancelled);
-
-            await act.Should().ThrowAsync<ObjectDisposedException>();
-        }
-
-        [Fact]
         public async Task MustCompleteMessageOnAckInPeekLock()
         {
             var inMemory = new InMemoryServiceBusMessageReceiver();
@@ -194,6 +181,36 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
             deadlettered.message.Should().BeSameAs(message);
             deadlettered.reason.Should().Be("reason");
             deadlettered.description.Should().Be("description");
+        }
+
+        [Fact]
+        public async Task MustPassReceiveTokenThroughToInnerReceiver()
+        {
+            var inMemory = new InMemoryServiceBusMessageReceiver();
+            inMemory.EnqueueMessage(ServiceBusMessageFactory.ReceivedMessage());
+            var sut = await InitializedPeekLockSutAsync(inMemory);
+            using var cts = new CancellationTokenSource();
+
+            await sut.ReceiveMessageAsync(new TransactionContext("receiver"), cts.Token);
+
+            inMemory.LastReceiveToken.Should().Be(cts.Token);
+        }
+
+        [Fact]
+        public async Task MustReturnNullWithoutErrorOrSettleWhenTokenCancelledOnReceive()
+        {
+            var inMemory = new InMemoryServiceBusMessageReceiver();
+            var message = ServiceBusMessageFactory.ReceivedMessage();
+            inMemory.EnqueueMessage(message);
+            var sut = await InitializedPeekLockSutAsync(inMemory);
+            var cancelled = new CancellationToken(canceled: true);
+
+            var result = await sut.ReceiveMessageAsync(new TransactionContext("receiver"), cancelled);
+
+            result.Should().BeNull();
+            inMemory.AbandonedMessages.Should().BeEmpty();
+            inMemory.DeadLetteredMessages.Should().BeEmpty();
+            inMemory.CompletedMessages.Should().BeEmpty();
         }
 
         [Fact]

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
@@ -6,6 +6,18 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
+## [0.13.0] - 2026-06-09
+
+### Added
+
+- Real concurrent message processing bounded by `MaxConcurrentCalls`: `BrokeredMessageReceiver` now fans out up to `MaxConcurrentCalls` concurrent processing workers, gated by a semaphore (default `MaxConcurrentCalls = 1` preserves the existing sequential behavior unchanged). Satisfies the "not yet delivered (#147)" caveat carried in the 0.12.0 release notes — real parallelism is now delivered and test-verified (#147).
+
 ## [0.12.0] - 2026-06-09
 
 ### Added

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
@@ -7,7 +7,7 @@
          TryEncodeUnicodeScalar) is char*-pointer based, so the overrides must be unsafe. -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Chatter.MessageBrokers</PackageId>
-    <Version>0.12.0</Version>
+    <Version>0.13.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A message broker adapter library built on top of Chatter.CQRS.</Description>

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -164,7 +164,15 @@ namespace Chatter.MessageBrokers.Receiving
             _concurrentMessagesSemaphore = new SemaphoreSlim(_maxConcurrentCalls, _maxConcurrentCalls);
             _messageReceiverLoopTokenSource = CancellationTokenSource.CreateLinkedTokenSource(receiverTerminationToken);
 
-            _messageReceiverLoop = MessageReceiverLoopAsync();
+            // INVARIANT: start the receive loop on the thread pool (Task.Run) rather than inline so its body and
+            // every continuation run on the default TaskScheduler and NEVER capture a caller SynchronizationContext.
+            // If StartReceiver is invoked under a single-threaded context, an inline-started loop could post its
+            // cancellation/finally continuation back to that context; the synchronous Dispose path then blocks that
+            // same thread on _messageReceiverLoop.GetAwaiter().GetResult() and deadlocks. Detaching the loop onto the
+            // pool (workers already use Task.Run) makes the synchronous teardown wait safe. The Task.Run(Func<Task>)
+            // overload returns a proxy Task that completes only when the loop body completes, so await/GetResult on
+            // the assigned Task observe the real loop completion (drain + notify-once included).
+            _messageReceiverLoop = Task.Run(MessageReceiverLoopAsync);
             this.IsReceiving = true;
             _receivingStartedSource.TrySetResult(true);
             _logger.LogInformation("'{executingFunction}' has started receiving messages of type '{receiverMessageType}'.", nameof(BrokeredMessageReceiver<TMessage>), typeof(TMessage).Name);
@@ -340,8 +348,10 @@ namespace Chatter.MessageBrokers.Receiving
             finally
             {
                 // Drain any still-running workers before the loop task completes so callers that await the loop
-                // (StartReceiverImpl / StopReceiver) observe a fully-quiesced receiver.
-                await DrainInFlightWorkersAsync();
+                // (StartReceiverImpl / StopReceiver) observe a fully-quiesced receiver. ConfigureAwait(false): the
+                // loop already runs on the pool, but keep teardown context-free as defense-in-depth so the
+                // synchronous Dispose wait can never deadlock on a captured context.
+                await DrainInFlightWorkersAsync().ConfigureAwait(false);
 
                 // INVARIANT: notify EXACTLY ONCE on a critical fault, regardless of HOW the loop exited. A worker
                 // fault now also cancels the loop token (SignalLoopCriticalFault), so the loop can exit either by
@@ -353,7 +363,7 @@ namespace Chatter.MessageBrokers.Receiving
                 if (criticalFault != null)
                 {
                     _logger.LogCritical(criticalFault, "Receiver is unable continue due to critical error");
-                    await _criticalFailureNotifier.Notify(new FailureContext(null, this.ErrorQueueName, "Critical error occurred", criticalFault, -1, null));
+                    await _criticalFailureNotifier.Notify(new FailureContext(null, this.ErrorQueueName, "Critical error occurred", criticalFault, -1, null)).ConfigureAwait(false);
                 }
             }
         }
@@ -624,16 +634,35 @@ namespace Chatter.MessageBrokers.Receiving
 
         public async ValueTask DisposeAsync()
         {
-            // INVARIANT: signal cancellation and drain in-flight workers BEFORE the semaphore / token source are
-            // disposed so no worker touches a disposed SemaphoreSlim. Dispose(disposing: false) below does not
-            // dispose the managed semaphore/token source, so this is the async path's authoritative drain.
+            // INVARIANT: mirror StopReceiver's quiesce-before-dispose ordering. Draining only the in-flight worker
+            // SNAPSHOT is not enough: the loop may still be inside WaitAsync / ReceiveMessageAsync, or in the gap after
+            // receiving a message but before SpawnProcessingWorker has added the worker to _inFlightTasks — in those
+            // races the snapshot is empty or stale and disposing the infrastructure receiver / semaphore / token source
+            // here would race a loop that is about to receive, spawn, notify, or release. So cancel, then await the
+            // LOOP to completion first (it treats loop-token cancellation as a clean exit, so this completes rather
+            // than throwing; a faulted loop is skipped and a benign shutdown cancellation is swallowed), THEN drain any
+            // residual workers in the finally, and only then dispose. ConfigureAwait(false) keeps teardown context-free.
             _messageReceiverLoopTokenSource?.Cancel();
-            await DrainInFlightWorkersAsync();
 
-            await _infrastructureReceiver.DisposeAsync();
+            try
+            {
+                if (_messageReceiverLoop != null && !_messageReceiverLoop.IsFaulted)
+                {
+                    await _messageReceiverLoop.ConfigureAwait(false);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            finally
+            {
+                await DrainInFlightWorkersAsync().ConfigureAwait(false);
 
-            _concurrentMessagesSemaphore?.Dispose();
-            _messageReceiverLoopTokenSource?.Dispose();
+                await _infrastructureReceiver.DisposeAsync().ConfigureAwait(false);
+
+                _concurrentMessagesSemaphore?.Dispose();
+                _messageReceiverLoopTokenSource?.Dispose();
+            }
 
             Dispose(disposing: false);
             GC.SuppressFinalize(this);
@@ -654,9 +683,11 @@ namespace Chatter.MessageBrokers.Receiving
                     // (the ReleaseConcurrencySlot ObjectDisposedException swallow only hides ONE symptom; it does not
                     // protect the infrastructure receiver or the in-flight message's settlement). The loop already
                     // treats loop-token cancellation as a clean completion, so awaiting it here completes rather than
-                    // throwing; block synchronously (no SynchronizationContext is captured on the loop/worker paths, so
-                    // GetAwaiter().GetResult() cannot deadlock) so the wait-then-dispose ordering matches the async
-                    // paths' drain-before-dispose guarantee.
+                    // throwing; block synchronously so the wait-then-dispose ordering matches the async paths'
+                    // drain-before-dispose guarantee. The loop is started via Task.Run (default scheduler) and its
+                    // teardown awaits use ConfigureAwait(false), and the workers are started via Task.Run, so NEITHER
+                    // the loop nor the worker drain captures a caller SynchronizationContext — GetAwaiter().GetResult()
+                    // therefore cannot deadlock even when Dispose is called from a single-threaded context.
                     QuiesceForSyncDispose();
 
                     _infrastructureReceiver?.Dispose();

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -441,17 +441,47 @@ namespace Chatter.MessageBrokers.Receiving
             catch (Exception e)
             {
                 _logger.LogError(e, "Error processing brokered message");
-                var deliveryCount = await _recoveryStrategy.ExecuteAsync(() => _infrastructureReceiver.MessageDeliveryCountAsync(messageContext, workerToken), workerToken);
-                if (deliveryCount >= _options.MaxReceiveAttempts)
+
+                // INVARIANT: the generic processing-error recovery ladder must not let an UNEXPECTED fault escape the
+                // worker. TryAck/TryNack/TryDeadletter/TryExecuteFailedRecoveryAction each catch internally, but the
+                // delivery-count probe (MessageDeliveryCountAsync) is awaited OUTSIDE any protective try here. If it
+                // throws (e.g. recovery-strategy retries exhausted), the worker task would fault AFTER the slot is
+                // released, the loop never observes it (workers are fire-and-forget; only CriticalReceiverException is
+                // published to _workerCriticalFault), the in-flight continuation removes it, and DrainInFlightWorkersAsync
+                // swallows worker faults — the message is left unsettled while the receiver still reports healthy. In the
+                // pre-parallelization serial loop this exception escaped to the loop and was logged critically. Restore
+                // that VISIBILITY by catching an unexpected fault in this branch and logging it critically rather than
+                // letting it vanish. A CriticalReceiverException is NOT caught here (it never originates from this ladder
+                // and would be handled by its own catch above), so circuit-breaker/critical-stop semantics are unchanged.
+                try
                 {
-                    if (await TryDeadletterWithRecoveryAsync(messageContext, transactionContext, e, workerToken))
+                    var deliveryCount = await _recoveryStrategy.ExecuteAsync(() => _infrastructureReceiver.MessageDeliveryCountAsync(messageContext, workerToken), workerToken);
+                    if (deliveryCount >= _options.MaxReceiveAttempts)
                     {
-                        await TryExecuteFailedRecoveryAction(messageContext, "Max message receive attempts exceeded", e, deliveryCount, transactionContext);
+                        if (await TryDeadletterWithRecoveryAsync(messageContext, transactionContext, e, workerToken))
+                        {
+                            await TryExecuteFailedRecoveryAction(messageContext, "Max message receive attempts exceeded", e, deliveryCount, transactionContext);
+                        }
+                    }
+                    else
+                    {
+                        await TryNackWithRecoveryAsync(messageContext, transactionContext, workerToken);
                     }
                 }
-                else
+                catch (OperationCanceledException) when (workerToken.IsCancellationRequested)
                 {
-                    await TryNackWithRecoveryAsync(messageContext, transactionContext, workerToken);
+                    // Shutdown cancellation during recovery: benign, swallowed like the worker's other cancellation paths.
+                }
+                catch (ObjectDisposedException) when (workerToken.IsCancellationRequested)
+                {
+                }
+                catch (Exception recoveryError)
+                {
+                    // The settlement/recovery probe itself failed unexpectedly (the message could not be settled). Surface
+                    // it critically — matching the serial loop's visibility — instead of letting the worker fault silently
+                    // and the unsettled message look healthy. The loop is unaffected; this single message's settlement
+                    // failure is now observable in logs rather than swallowed by the worker drain.
+                    _logger.LogCritical(recoveryError, "Unrecoverable failure settling brokered message after a processing error; message may remain unsettled");
                 }
             }
             finally

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -5,6 +5,7 @@ using Chatter.MessageBrokers.Exceptions;
 using Chatter.MessageBrokers.Recovery;
 using Microsoft.Extensions.Logging;
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -25,6 +26,21 @@ namespace Chatter.MessageBrokers.Receiving
         CancellationTokenSource _messageReceiverLoopTokenSource;
         private Task _messageReceiverLoop;
         private int _maxConcurrentCalls = 1;
+
+        // INVARIANT: every per-message worker task admitted by the concurrency semaphore is tracked here for the
+        // lifetime of its processing. The loop prunes completed tasks each turn (bounded accumulation) and the
+        // shutdown path (StopReceiver/Dispose) drains the live set before disposing the semaphore or token source,
+        // so no in-flight worker can touch a disposed SemaphoreSlim / CancellationTokenSource. Guarded by its own
+        // lock because the loop thread adds/prunes while worker continuations remove on completion.
+        private readonly HashSet<Task> _inFlightTasks = new HashSet<Task>();
+        private readonly object _inFlightTasksLock = new object();
+
+        // INVARIANT: holds the FIRST CriticalReceiverException observed inside a worker task. Workers run
+        // fire-and-forget relative to the receive loop, so a critical fault cannot be surfaced by awaiting them
+        // inline; instead the faulting worker publishes it here via Interlocked.CompareExchange (first writer wins)
+        // and the loop observes it each turn, rethrowing on the loop thread so the existing outer
+        // catch (CriticalReceiverException) fires the _criticalFailureNotifier.Notify path exactly as before.
+        private CriticalReceiverException _workerCriticalFault;
         private readonly MessageBrokerOptions _messageBrokerOptions;
         private readonly IRecoveryStrategy _recoveryStrategy;
         private readonly IReceivedMessageDispatcher _receivedMessageDispatcher;
@@ -165,6 +181,12 @@ namespace Chatter.MessageBrokers.Receiving
                 await _messageReceiverLoop;
             }
 
+            // INVARIANT: drain any worker tasks still in flight before disposing the semaphore / token source so no
+            // worker touches a disposed SemaphoreSlim. When the loop completed normally its own finally already
+            // drained; this is the belt-and-suspenders path for a faulted loop (the await above is skipped) and is
+            // a no-op once the set is empty.
+            await DrainInFlightWorkersAsync();
+
             await _infrastructureReceiver.StopReceiver();
 
             _concurrentMessagesSemaphore?.Dispose();
@@ -177,78 +199,221 @@ namespace Chatter.MessageBrokers.Receiving
             {
                 while (!_messageReceiverLoopTokenSource.IsCancellationRequested)
                 {
+                    // INVARIANT: a CriticalReceiverException observed in a worker stops the loop. Observe it BEFORE
+                    // admitting another slot so a critical fault halts pulling promptly and routes through the outer
+                    // catch (preserving the _criticalFailureNotifier.Notify path), rather than being lost in the
+                    // fire-and-forget worker.
+                    ThrowIfWorkerCriticalFault();
+
                     await _concurrentMessagesSemaphore.WaitAsync(_messageReceiverLoopTokenSource.Token);
 
+                    // INVARIANT: the per-message TransactionContext is constructed PER-TURN and its ownership transfers
+                    // to the spawned worker, so concurrent workers never share a TransactionContext and cannot
+                    // cross-enlist. The receive call itself stays on the loop thread (pull cadence stays serialized);
+                    // only the processing error ladder and the semaphore release fan out into the worker task.
+                    var transactionContext = new TransactionContext(this.MessageReceiverPath, _options.TransactionMode.Value);
                     MessageBrokerContext messageContext = null;
-                    TransactionContext transactionContext = new TransactionContext(this.MessageReceiverPath, _options.TransactionMode.Value);
+                    var slotAcquired = true;
 
                     try
                     {
                         _messageReceiverLoopTokenSource.Token.ThrowIfCancellationRequested();
 
                         messageContext = await _recoveryStrategy.ExecuteAsync(() => _infrastructureReceiver.ReceiveMessageAsync(transactionContext, _messageReceiverLoopTokenSource.Token), _messageReceiverLoopTokenSource.Token);
-
-                        if (messageContext != null)
-                        {
-                            _logger.LogTrace("Message received successfully");
-                            await ProcessMessageAsync(messageContext, transactionContext, _messageReceiverLoopTokenSource.Token);
-                            _logger.LogTrace("Message processed successfully");
-                        }
                     }
                     catch (CriticalReceiverException)
                     {
+                        ReleaseConcurrencySlot();
                         throw; //stop receiver loop
                     }
                     catch (OperationCanceledException) when (_messageReceiverLoopTokenSource.IsCancellationRequested)
                     {
+                        ReleaseConcurrencySlot();
+                        slotAcquired = false;
                     }
                     catch (ObjectDisposedException) when (_messageReceiverLoopTokenSource.IsCancellationRequested)
                     {
-                    }
-                    catch (PoisonedMessageException e)
-                    {
-                        _logger.LogError(e, "Poisoned message received. Deadlettering.");
-                        await TryDeadletterWithRecoveryAsync(messageContext, transactionContext, e, _messageReceiverLoopTokenSource.Token);
+                        ReleaseConcurrencySlot();
+                        slotAcquired = false;
                     }
                     catch (Exception e)
                     {
-                        if (messageContext == null)
-                        {
-                            _logger.LogError(e, "Error receiving brokered message");
-                        }
-                        else
-                        {
-                            _logger.LogError(e, "Error processing brokered message");
-                            var deliveryCount = await _recoveryStrategy.ExecuteAsync(() => _infrastructureReceiver.MessageDeliveryCountAsync(messageContext, _messageReceiverLoopTokenSource.Token), _messageReceiverLoopTokenSource.Token);
-                            if (deliveryCount >= _options.MaxReceiveAttempts)
-                            {
-                                if (await TryDeadletterWithRecoveryAsync(messageContext, transactionContext, e, _messageReceiverLoopTokenSource.Token))
-                                {
-                                    await TryExecuteFailedRecoveryAction(messageContext, "Max message receive attempts exceeded", e, deliveryCount, transactionContext);
-                                }
-                            }
-                            else
-                            {
-                                await TryNackWithRecoveryAsync(messageContext, transactionContext, _messageReceiverLoopTokenSource.Token);
-                            }
-                        }
+                        // A failure to RECEIVE (no messageContext) is handled inline on the loop thread, mirroring the
+                        // original error ladder's messageContext == null branch, then the slot is released.
+                        _logger.LogError(e, "Error receiving brokered message");
+                        ReleaseConcurrencySlot();
+                        slotAcquired = false;
                     }
-                    finally
+
+                    if (!slotAcquired)
                     {
-                        try
-                        {
-                            _concurrentMessagesSemaphore?.Release();
-                        }
-                        catch (ObjectDisposedException)
-                        {
-                        }
+                        continue;
                     }
+
+                    if (messageContext == null)
+                    {
+                        // Nothing received this turn (empty receive or swallowed cancellation): release the slot and
+                        // continue pulling. Only a non-null messageContext spawns a worker.
+                        ReleaseConcurrencySlot();
+                        continue;
+                    }
+
+                    _logger.LogTrace("Message received successfully");
+                    SpawnProcessingWorker(messageContext, transactionContext);
+
+                    // Prune completed worker references so the tracking set does not accumulate unboundedly across
+                    // the loop's lifetime.
+                    PruneCompletedWorkers();
                 }
             }
             catch (CriticalReceiverException e)
             {
                 _logger.LogCritical(e, "Receiver is unable continue due to critical error");
                 await _criticalFailureNotifier.Notify(new FailureContext(null, this.ErrorQueueName, "Critical error occurred", e, -1, null));
+            }
+            finally
+            {
+                // Drain any still-running workers before the loop task completes so callers that await the loop
+                // (StartReceiverImpl / StopReceiver) observe a fully-quiesced receiver.
+                await DrainInFlightWorkersAsync();
+            }
+        }
+
+        // INVARIANT: runs the per-message error ladder + semaphore release for a SINGLE received message in a tracked
+        // background task that owns its OWN messageContext + transactionContext. Up to MaxConcurrentCalls of these run
+        // concurrently. A CriticalReceiverException raised here is published to _workerCriticalFault (observed by the
+        // loop) rather than lost; every other fault is handled by the ladder, and the slot is always released in the
+        // per-task finally so a fault never leaks a semaphore slot.
+        void SpawnProcessingWorker(MessageBrokerContext messageContext, TransactionContext transactionContext)
+        {
+            // INVARIANT: snapshot the CancellationToken on the loop thread (where the token source is guaranteed live)
+            // and hand the VALUE to the worker. A CancellationToken struct keeps reporting IsCancellationRequested
+            // after its source is disposed, whereas re-reading _messageReceiverLoopTokenSource.Token from a detached
+            // worker could hit a disposed source during shutdown. This keeps the worker's cancellation-swallow filters
+            // valid through teardown.
+            var workerToken = _messageReceiverLoopTokenSource.Token;
+            var worker = Task.Run(() => ProcessReceivedMessageWorkerAsync(messageContext, transactionContext, workerToken));
+
+            lock (_inFlightTasksLock)
+            {
+                _inFlightTasks.Add(worker);
+            }
+
+            // INVARIANT: the worker body itself never rethrows (its finally swallows nothing critical past publishing
+            // to _workerCriticalFault), so this continuation only prunes the completed reference. It must not be the
+            // sole observer of faults — fault propagation is via _workerCriticalFault, observed on the loop thread.
+            worker.ContinueWith(
+                completed =>
+                {
+                    lock (_inFlightTasksLock)
+                    {
+                        _inFlightTasks.Remove(completed);
+                    }
+                },
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+
+        async Task ProcessReceivedMessageWorkerAsync(MessageBrokerContext messageContext, TransactionContext transactionContext, CancellationToken workerToken)
+        {
+            try
+            {
+                await ProcessMessageAsync(messageContext, transactionContext, workerToken);
+                _logger.LogTrace("Message processed successfully");
+            }
+            catch (CriticalReceiverException e)
+            {
+                // First writer wins: publish to the loop-observed fault field so the loop stops and the existing
+                // outer-handler _criticalFailureNotifier.Notify path fires. Never lost in fire-and-forget.
+                Interlocked.CompareExchange(ref _workerCriticalFault, e, null);
+            }
+            catch (OperationCanceledException) when (workerToken.IsCancellationRequested)
+            {
+            }
+            catch (ObjectDisposedException) when (workerToken.IsCancellationRequested)
+            {
+            }
+            catch (PoisonedMessageException e)
+            {
+                _logger.LogError(e, "Poisoned message received. Deadlettering.");
+                await TryDeadletterWithRecoveryAsync(messageContext, transactionContext, e, workerToken);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, "Error processing brokered message");
+                var deliveryCount = await _recoveryStrategy.ExecuteAsync(() => _infrastructureReceiver.MessageDeliveryCountAsync(messageContext, workerToken), workerToken);
+                if (deliveryCount >= _options.MaxReceiveAttempts)
+                {
+                    if (await TryDeadletterWithRecoveryAsync(messageContext, transactionContext, e, workerToken))
+                    {
+                        await TryExecuteFailedRecoveryAction(messageContext, "Max message receive attempts exceeded", e, deliveryCount, transactionContext);
+                    }
+                }
+                else
+                {
+                    await TryNackWithRecoveryAsync(messageContext, transactionContext, workerToken);
+                }
+            }
+            finally
+            {
+                ReleaseConcurrencySlot();
+            }
+        }
+
+        // INVARIANT: idempotent-safe release guarded against the disposed-semaphore race during shutdown, preserving
+        // the original finally's ObjectDisposedException swallow.
+        void ReleaseConcurrencySlot()
+        {
+            try
+            {
+                _concurrentMessagesSemaphore?.Release();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
+        }
+
+        void ThrowIfWorkerCriticalFault()
+        {
+            var fault = Interlocked.CompareExchange(ref _workerCriticalFault, null, null);
+            if (fault != null)
+            {
+                throw fault;
+            }
+        }
+
+        void PruneCompletedWorkers()
+        {
+            lock (_inFlightTasksLock)
+            {
+                _inFlightTasks.RemoveWhere(t => t.IsCompleted);
+            }
+        }
+
+        async Task DrainInFlightWorkersAsync()
+        {
+            Task[] pending;
+            lock (_inFlightTasksLock)
+            {
+                pending = new Task[_inFlightTasks.Count];
+                _inFlightTasks.CopyTo(pending);
+            }
+
+            if (pending.Length == 0)
+            {
+                return;
+            }
+
+            try
+            {
+                await Task.WhenAll(pending);
+            }
+            catch
+            {
+                // Worker faults are already handled inside ProcessReceivedMessageWorkerAsync (error ladder +
+                // _workerCriticalFault publication). Draining only needs to ensure every worker has QUIESCED before
+                // the semaphore / token source are disposed; individual fault outcomes are not re-surfaced here.
             }
         }
 
@@ -370,7 +535,16 @@ namespace Chatter.MessageBrokers.Receiving
 
         public async ValueTask DisposeAsync()
         {
+            // INVARIANT: signal cancellation and drain in-flight workers BEFORE the semaphore / token source are
+            // disposed so no worker touches a disposed SemaphoreSlim. Dispose(disposing: false) below does not
+            // dispose the managed semaphore/token source, so this is the async path's authoritative drain.
+            _messageReceiverLoopTokenSource?.Cancel();
+            await DrainInFlightWorkersAsync();
+
             await _infrastructureReceiver.DisposeAsync();
+
+            _concurrentMessagesSemaphore?.Dispose();
+            _messageReceiverLoopTokenSource?.Dispose();
 
             Dispose(disposing: false);
             GC.SuppressFinalize(this);

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -176,21 +176,52 @@ namespace Chatter.MessageBrokers.Receiving
         {
             _messageReceiverLoopTokenSource?.Cancel();
 
-            if (_messageReceiverLoop != null && !_messageReceiverLoop.IsFaulted)
+            try
             {
-                await _messageReceiverLoop;
+                // The loop now treats loop-token cancellation as a NORMAL completion (it swallows the cancellation
+                // OperationCanceledException/ObjectDisposedException), so under the parallelized design — where the loop
+                // commonly parks in WaitAsync with workers in flight — awaiting it completes rather than throwing.
+                // Still guard the await: a FAULTED loop is skipped (mirrors the original), and any residual exception
+                // from awaiting must NOT abort teardown. Stopping/disposing infrastructure and shared primitives MUST
+                // happen regardless, so it lives in the finally below.
+                if (_messageReceiverLoop != null && !_messageReceiverLoop.IsFaulted)
+                {
+                    await _messageReceiverLoop;
+                }
             }
+            catch (OperationCanceledException)
+            {
+                // Loop-shutdown cancellation surfaced from the await: benign, teardown still runs in the finally.
+            }
+            finally
+            {
+                // INVARIANT: drain any worker tasks still in flight before disposing the semaphore / token source so no
+                // worker touches a disposed SemaphoreSlim. When the loop completed normally its own finally already
+                // drained; this is the belt-and-suspenders path for a faulted loop (the await above is skipped) and is
+                // a no-op once the set is empty. Teardown lives in the finally so a parked-loop cancellation can never
+                // abort StopReceiver before the infrastructure is stopped and the shared primitives are disposed.
+                await DrainInFlightWorkersAsync();
 
-            // INVARIANT: drain any worker tasks still in flight before disposing the semaphore / token source so no
-            // worker touches a disposed SemaphoreSlim. When the loop completed normally its own finally already
-            // drained; this is the belt-and-suspenders path for a faulted loop (the await above is skipped) and is
-            // a no-op once the set is empty.
-            await DrainInFlightWorkersAsync();
+                await _infrastructureReceiver.StopReceiver();
 
-            await _infrastructureReceiver.StopReceiver();
+                _concurrentMessagesSemaphore?.Dispose();
+                _messageReceiverLoopTokenSource?.Dispose();
+            }
+        }
 
-            _concurrentMessagesSemaphore?.Dispose();
-            _messageReceiverLoopTokenSource?.Dispose();
+        // INVARIANT: cancel the loop token to wake a loop parked in WaitAsync OR a receive that does not honor the
+        // token, so a worker-published critical fault is observed promptly instead of after the next message. Called
+        // only by the FIRST fault publisher. Guarded against a token source already disposed by a concurrent teardown
+        // (a detached worker can outlive Dispose), where cancelling is a no-op the shutdown path already covers.
+        void SignalLoopCriticalFault()
+        {
+            try
+            {
+                _messageReceiverLoopTokenSource?.Cancel();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
         }
 
         async Task MessageReceiverLoopAsync()
@@ -206,6 +237,24 @@ namespace Chatter.MessageBrokers.Receiving
                     ThrowIfWorkerCriticalFault();
 
                     await _concurrentMessagesSemaphore.WaitAsync(_messageReceiverLoopTokenSource.Token);
+
+                    // INVARIANT: re-observe the worker critical fault IMMEDIATELY after the semaphore is acquired and
+                    // BEFORE any receive. When all slots are full the loop parks inside WaitAsync above; a worker can
+                    // publish a CriticalReceiverException while we are parked, and the slot it releases is what wakes
+                    // this WaitAsync. Without this second check the loop would proceed straight into ReceiveMessageAsync
+                    // and admit one more receive after a critical failure (and, on infrastructures whose receive does
+                    // not honor the loop token, stall the notifier path until another message arrives). Release the slot
+                    // we just took before rethrowing so the fault routes through the outer catch / notifier path with no
+                    // leaked slot. The pre-WaitAsync check above still covers the all-slots-free fast path.
+                    try
+                    {
+                        ThrowIfWorkerCriticalFault();
+                    }
+                    catch (CriticalReceiverException)
+                    {
+                        ReleaseConcurrencySlot();
+                        throw; //stop receiver loop
+                    }
 
                     // INVARIANT: the per-message TransactionContext is constructed PER-TURN and its ownership transfers
                     // to the spawned worker, so concurrent workers never share a TransactionContext and cannot
@@ -268,14 +317,44 @@ namespace Chatter.MessageBrokers.Receiving
             }
             catch (CriticalReceiverException e)
             {
-                _logger.LogCritical(e, "Receiver is unable continue due to critical error");
-                await _criticalFailureNotifier.Notify(new FailureContext(null, this.ErrorQueueName, "Critical error occurred", e, -1, null));
+                // The loop thread itself observed the fault (pre/post-WaitAsync recheck or an inline receive). Record
+                // it as the authoritative fault so the notify-exactly-once epilogue fires for it and a worker-published
+                // fault is not ALSO re-notified.
+                Interlocked.CompareExchange(ref _workerCriticalFault, e, null);
+            }
+            catch (OperationCanceledException) when (_messageReceiverLoopTokenSource.IsCancellationRequested)
+            {
+                // Cancellation of the loop token is a NORMAL shutdown signal (StopReceiver/Dispose cancel it, and a
+                // worker critical fault now cancels it too via SignalLoopCriticalFault). The loop commonly parks in
+                // WaitAsync once all slots are full, so cancellation most often surfaces THERE — outside the inner
+                // receive try/catch. Swallow it here so the loop task completes NORMALLY rather than propagating an
+                // OperationCanceledException out of MessageReceiverLoopAsync, which would otherwise abort StopReceiver
+                // before it stops/disposes the infrastructure and shared primitives. Any published critical fault is
+                // still surfaced by the notify-once epilogue below.
+            }
+            catch (ObjectDisposedException) when (_messageReceiverLoopTokenSource.IsCancellationRequested)
+            {
+                // Same shutdown rationale as the cancellation catch: a primitive observed disposed mid-teardown while
+                // cancellation is in progress is a benign race, not a loop fault to propagate.
             }
             finally
             {
                 // Drain any still-running workers before the loop task completes so callers that await the loop
                 // (StartReceiverImpl / StopReceiver) observe a fully-quiesced receiver.
                 await DrainInFlightWorkersAsync();
+
+                // INVARIANT: notify EXACTLY ONCE on a critical fault, regardless of HOW the loop exited. A worker
+                // fault now also cancels the loop token (SignalLoopCriticalFault), so the loop can exit either by
+                // rethrowing the CriticalReceiverException (caught above) OR via OperationCanceledException from the
+                // cancelled token while a worker fault sits in _workerCriticalFault. Both routes converge here: if a
+                // fault was published by ANY path, fire the single notifier. The first-writer-wins field guarantees
+                // one fault value and the catch above never double-notifies (it only records into the same field).
+                var criticalFault = Interlocked.CompareExchange(ref _workerCriticalFault, null, null);
+                if (criticalFault != null)
+                {
+                    _logger.LogCritical(criticalFault, "Receiver is unable continue due to critical error");
+                    await _criticalFailureNotifier.Notify(new FailureContext(null, this.ErrorQueueName, "Critical error occurred", criticalFault, -1, null));
+                }
             }
         }
 
@@ -326,7 +405,17 @@ namespace Chatter.MessageBrokers.Receiving
             {
                 // First writer wins: publish to the loop-observed fault field so the loop stops and the existing
                 // outer-handler _criticalFailureNotifier.Notify path fires. Never lost in fire-and-forget.
-                Interlocked.CompareExchange(ref _workerCriticalFault, e, null);
+                if (Interlocked.CompareExchange(ref _workerCriticalFault, e, null) == null)
+                {
+                    // Only the FIRST publisher wakes the loop. Cancel the loop token so a loop parked in WaitAsync OR
+                    // inside a receive that does not otherwise honor the token unblocks promptly: the loop's existing
+                    // OperationCanceledException-when-cancelled branch releases its slot and falls through to the
+                    // shutdown path, where the post-loop ThrowIfWorkerCriticalFault / outer handler still routes the
+                    // fault to _criticalFailureNotifier.Notify. Without this, a last-worker fault could sit unobserved
+                    // while the receiver idles waiting for the next message. Guarded against a disposed source during
+                    // teardown (the worker may outlive a Dispose that already disposed the source).
+                    SignalLoopCriticalFault();
+                }
             }
             catch (OperationCanceledException) when (workerToken.IsCancellationRequested)
             {
@@ -557,6 +646,19 @@ namespace Chatter.MessageBrokers.Receiving
                 if (disposing)
                 {
                     _messageReceiverLoopTokenSource?.Cancel();
+
+                    // INVARIANT: the synchronous Dispose path must QUIESCE the receiver before disposing any
+                    // worker-touched primitive, exactly like the async StopReceiver/DisposeAsync paths — otherwise a
+                    // worker already past its token check could still be inside DispatchReceivedMessageAsync or an
+                    // Ack/Nack/Deadletter and would race a disposed infrastructure receiver / semaphore / token source
+                    // (the ReleaseConcurrencySlot ObjectDisposedException swallow only hides ONE symptom; it does not
+                    // protect the infrastructure receiver or the in-flight message's settlement). The loop already
+                    // treats loop-token cancellation as a clean completion, so awaiting it here completes rather than
+                    // throwing; block synchronously (no SynchronizationContext is captured on the loop/worker paths, so
+                    // GetAwaiter().GetResult() cannot deadlock) so the wait-then-dispose ordering matches the async
+                    // paths' drain-before-dispose guarantee.
+                    QuiesceForSyncDispose();
+
                     _infrastructureReceiver?.Dispose();
                     _concurrentMessagesSemaphore?.Dispose();
                     _messageReceiverLoopTokenSource?.Dispose();
@@ -564,6 +666,33 @@ namespace Chatter.MessageBrokers.Receiving
 
                 _infrastructureReceiver = null;
                 _disposedValue = true;
+            }
+        }
+
+        // INVARIANT: synchronously wait for the receive loop AND every in-flight worker to quiesce so the sync Dispose
+        // path honors the same drain-before-dispose guarantee as StopReceiver/DisposeAsync. Caller has already
+        // requested cancellation. Awaiting the loop completes cleanly (the loop swallows shutdown cancellation); the
+        // drain then waits for detached workers. All worker faults are already handled inside the worker body, so any
+        // exception observed here is benign teardown noise and is swallowed — Dispose must not throw.
+        void QuiesceForSyncDispose()
+        {
+            try
+            {
+                if (_messageReceiverLoop != null && !_messageReceiverLoop.IsFaulted)
+                {
+                    _messageReceiverLoop.GetAwaiter().GetResult();
+                }
+            }
+            catch
+            {
+            }
+
+            try
+            {
+                DrainInFlightWorkersAsync().GetAwaiter().GetResult();
+            }
+            catch
+            {
             }
         }
 

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Receiving/BrokeredMessageReceiver.cs
@@ -347,24 +347,32 @@ namespace Chatter.MessageBrokers.Receiving
             }
             finally
             {
-                // Drain any still-running workers before the loop task completes so callers that await the loop
-                // (StartReceiverImpl / StopReceiver) observe a fully-quiesced receiver. ConfigureAwait(false): the
-                // loop already runs on the pool, but keep teardown context-free as defense-in-depth so the
-                // synchronous Dispose wait can never deadlock on a captured context.
-                await DrainInFlightWorkersAsync().ConfigureAwait(false);
-
                 // INVARIANT: notify EXACTLY ONCE on a critical fault, regardless of HOW the loop exited. A worker
                 // fault now also cancels the loop token (SignalLoopCriticalFault), so the loop can exit either by
                 // rethrowing the CriticalReceiverException (caught above) OR via OperationCanceledException from the
                 // cancelled token while a worker fault sits in _workerCriticalFault. Both routes converge here: if a
                 // fault was published by ANY path, fire the single notifier. The first-writer-wins field guarantees
                 // one fault value and the catch above never double-notifies (it only records into the same field).
+                //
+                // INVARIANT (fail-fast notify-BEFORE-drain): surface the critical fault to the host BEFORE awaiting
+                // the worker drain. With MaxConcurrentCalls > 1, a sibling worker that is blocked or that ignores the
+                // cancellation token can make DrainInFlightWorkersAsync's Task.WhenAll wait indefinitely. Notifying
+                // first guarantees the host learns of a critical receiver failure promptly (the fail-fast path) instead
+                // of being stalled behind an unbounded drain. The drain still runs afterward so the quiesce-before-
+                // dispose guarantee is preserved for callers that await the loop (StartReceiverImpl / StopReceiver).
                 var criticalFault = Interlocked.CompareExchange(ref _workerCriticalFault, null, null);
                 if (criticalFault != null)
                 {
                     _logger.LogCritical(criticalFault, "Receiver is unable continue due to critical error");
                     await _criticalFailureNotifier.Notify(new FailureContext(null, this.ErrorQueueName, "Critical error occurred", criticalFault, -1, null)).ConfigureAwait(false);
                 }
+
+                // Drain any still-running workers before the loop task completes so callers that await the loop
+                // (StartReceiverImpl / StopReceiver) observe a fully-quiesced receiver. ConfigureAwait(false): the
+                // loop already runs on the pool, but keep teardown context-free as defense-in-depth so the
+                // synchronous Dispose wait can never deadlock on a captured context. This runs AFTER the critical-fault
+                // notify above so an unbounded drain can never starve the fail-fast notification path.
+                await DrainInFlightWorkersAsync().ConfigureAwait(false);
             }
         }
 

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenProcessingConcurrently.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenProcessingConcurrently.cs
@@ -1,0 +1,313 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    // INVARIANT: proves the STEP-001 parallel receive loop actually fans out per-message processing up to
+    // MaxConcurrentCalls concurrently, WITHOUT a real broker. The receive call stays serialized on the loop
+    // thread; each non-null received message spawns a tracked worker gated by the MaxConcurrentCalls-sized
+    // SemaphoreSlim. The concurrency is observed by gating the dispatcher (the processing path) so every worker
+    // blocks inside DispatchAsync while an interlocked counter records the peak number simultaneously in flight.
+    public class WhenProcessingConcurrently : Testing.Core.Context
+    {
+        // INVARIANT: MessageBrokerOptions.TransactionMode has internal set; accessible via InternalsVisibleTo("Chatter.MessageBrokers.Tests").
+        private static MessageBrokerOptions BuildOptions(TransactionMode mode = TransactionMode.None)
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = mode;
+            return opts;
+        }
+
+        // INVARIANT: pass-through IRecoveryStrategy invokes the delegate exactly once, no retry machinery.
+        // Mirrors WhenReceiving.PassThroughRecovery so the concurrency observed is the loop's, not the strategy's.
+        private static Mock<IRecoveryStrategy> PassThroughRecovery()
+        {
+            var mock = new Mock<IRecoveryStrategy>();
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+            return mock;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions(int maxConcurrentCalls)
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = 10,
+                MaxConcurrentCalls = maxConcurrentCalls,
+            };
+
+        // INVARIANT: body must deserialise cleanly as FakeMessage; each context gets a unique message id so the
+        // CallLog Ack count maps one-to-one to processed messages.
+        private static MessageBrokerContext BuildContext()
+        {
+            var converter = new JsonBodyConverter();
+            var body = converter.Convert(new FakeMessage { Value = "hello" });
+            return new MessageBrokerContext(
+                messageId: Guid.NewGuid().ToString(),
+                body: body,
+                applicationProperties: new Dictionary<string, object>(),
+                messageReceiverPath: "test-queue",
+                receiverCancellationToken: CancellationToken.None,
+                bodyConverter: converter);
+        }
+
+        private BrokeredMessageReceiver<FakeMessage> CreateSut(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            Mock<IReceivedMessageDispatcher> dispatcher)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: new Mock<IMaxReceivesExceededAction>().Object,
+                criticalFailureNotifier: new Mock<ICriticalFailureNotifier>().Object,
+                recoveryStrategy: PassThroughRecovery().Object,
+                receivedMessageDispatcher: dispatcher.Object);
+        }
+
+        // INVARIANT: polls the CallLog (a locked snapshot) until at least the expected number of Acks land, then
+        // returns. The watchdog bounds the wait so a regression that never acks fails fast instead of hanging.
+        private static async Task WaitForAckCountAsync(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            int expectedAckCount,
+            CancellationToken watchdog)
+        {
+            while (infraReceiver.CallLog.Count(c => c == ReceiverCall.Ack) < expectedAckCount)
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        // INVARIANT: spins until the predicate holds or the watchdog fires. Used to wait for the in-flight worker
+        // count to reach the concurrency cap. A regressed (sequential) implementation never reaches a peak > 1, so
+        // the bounded watchdog converts that regression into a prompt OperationCanceledException rather than a hang.
+        private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken watchdog)
+        {
+            while (!predicate())
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------ (1) bounded concurrency: peak in-flight == N
+
+        [Fact]
+        public async Task MustRunUpToMaxConcurrentCallsProcessorsSimultaneously()
+        {
+            const int maxConcurrentCalls = 4;
+            const int messageCount = 10; // > N so the semaphore cap is genuinely reached and (N+1)th worker is blocked
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            // Gate every worker inside DispatchAsync: increment the in-flight counter, record the peak, then block on
+            // the release gate. With the cap held by N blocked workers, the (N+1)th semaphore WaitAsync cannot admit
+            // another worker, so the peak settles at exactly N until the gate is released.
+            var inFlight = 0;
+            var peakInFlight = 0;
+            using var releaseGate = new SemaphoreSlim(0, messageCount);
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(async (FakeMessage _, MessageBrokerContext __, CancellationToken token) =>
+                {
+                    var current = Interlocked.Increment(ref inFlight);
+                    // Record the running maximum without losing concurrent updates.
+                    int observedPeak;
+                    do
+                    {
+                        observedPeak = Volatile.Read(ref peakInFlight);
+                        if (current <= observedPeak) break;
+                    }
+                    while (Interlocked.CompareExchange(ref peakInFlight, current, observedPeak) != observedPeak);
+
+                    try
+                    {
+                        await releaseGate.WaitAsync(token);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref inFlight);
+                    }
+                });
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            // Wait until exactly N workers are simultaneously blocked inside DispatchAsync. Because all N are held,
+            // the loop's (N+1)th WaitAsync is blocked and in-flight cannot exceed N.
+            await WaitUntilAsync(() => Volatile.Read(ref inFlight) == maxConcurrentCalls, watchdog.Token);
+
+            // Give any erroneously-admitted extra worker a chance to surface before asserting the cap. If the loop
+            // ever over-admitted, peakInFlight would exceed N here.
+            await Task.Yield();
+            Volatile.Read(ref peakInFlight).Should().Be(maxConcurrentCalls,
+                because: "the MaxConcurrentCalls-sized semaphore must admit exactly N processors at once");
+
+            // Release all gated workers so every message completes and is acked.
+            releaseGate.Release(messageCount);
+
+            await WaitForAckCountAsync(infraReceiver, messageCount, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            Volatile.Read(ref peakInFlight).Should().Be(maxConcurrentCalls,
+                because: "peak simultaneous processors must equal MaxConcurrentCalls, never more");
+            infraReceiver.CallLog.Count(c => c == ReceiverCall.Ack).Should().Be(messageCount,
+                because: "every received message must ultimately be acked");
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Deadletter);
+        }
+
+        // ------------------------------------------------------------------ (2) MaxConcurrentCalls == 1 stays sequential
+
+        [Fact]
+        public async Task MustProcessSequentiallyWhenMaxConcurrentCallsIsOne()
+        {
+            const int messageCount = 5;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            // No release gate: each worker increments, records the peak, briefly yields, then decrements and returns.
+            // With MaxConcurrentCalls == 1 the semaphore admits one worker at a time, so the observed peak must
+            // never exceed 1. A regression that fans out unbounded would record a peak > 1 here.
+            var inFlight = 0;
+            var peakInFlight = 0;
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(async (FakeMessage _, MessageBrokerContext __, CancellationToken token) =>
+                {
+                    var current = Interlocked.Increment(ref inFlight);
+                    int observedPeak;
+                    do
+                    {
+                        observedPeak = Volatile.Read(ref peakInFlight);
+                        if (current <= observedPeak) break;
+                    }
+                    while (Interlocked.CompareExchange(ref peakInFlight, current, observedPeak) != observedPeak);
+
+                    // Yield so a buggy fan-out would have a real chance to overlap a second worker here.
+                    await Task.Yield();
+                    Interlocked.Decrement(ref inFlight);
+                });
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls: 1), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await WaitForAckCountAsync(infraReceiver, messageCount, watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            Volatile.Read(ref peakInFlight).Should().Be(1,
+                because: "MaxConcurrentCalls == 1 must keep processing strictly sequential (at most one in flight)");
+            infraReceiver.CallLog.Count(c => c == ReceiverCall.Ack).Should().Be(messageCount,
+                because: "every received message must be acked even in the sequential path");
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Deadletter);
+        }
+
+        // ------------------------------------------------------------------ (3) clean drain/stop on cancellation
+
+        [Fact]
+        public async Task MustDrainInFlightWorkersAndStopCleanlyOnCancellation()
+        {
+            const int maxConcurrentCalls = 3;
+            const int messageCount = 8;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            // Hold workers inside DispatchAsync until the test has cancelled, proving the loop drains the live
+            // worker set on shutdown rather than tearing down underneath in-flight processing. Each worker observes
+            // the release gate; on cancellation the gate's WaitAsync throws OCE and the worker's ladder swallows it
+            // under the receiver token, so no Nack/Deadletter is recorded for the gated messages.
+            var inFlight = 0;
+            using var releaseGate = new SemaphoreSlim(0, messageCount);
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(async (FakeMessage _, MessageBrokerContext __, CancellationToken token) =>
+                {
+                    Interlocked.Increment(ref inFlight);
+                    try
+                    {
+                        await releaseGate.WaitAsync(token);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref inFlight);
+                    }
+                });
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            // Wait until the cap is fully occupied by blocked workers, then cancel while they are still in flight.
+            await WaitUntilAsync(() => Volatile.Read(ref inFlight) == maxConcurrentCalls, watchdog.Token);
+
+            cts.Cancel();
+
+            // The loop must complete (drain to quiescence) rather than hang or fault. Bound the await so a failure
+            // to drain surfaces as a TimeoutException instead of hanging the run.
+            var completed = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            completed.Should().BeSameAs(loop, "the receive loop must drain in-flight workers and stop cleanly on cancellation");
+            await loop; // surface any fault from the loop itself
+
+            Volatile.Read(ref inFlight).Should().Be(0,
+                because: "all in-flight workers must have quiesced once the loop has drained and stopped");
+        }
+    }
+}


### PR DESCRIPTION
Closes #147.

Delivers **real concurrent message processing bounded by `MaxConcurrentCalls`** in the Azure Service Bus pipeline. After #146 the value was plumbed end-to-end but the receive loop processed one message at a time; this makes `MaxConcurrentCalls > 1` actually process in parallel.

## Approach (cerebrate-decided)
Hand-roll bounded parallel workers in the infrastructure-agnostic core `BrokeredMessageReceiver` loop rather than migrate to `ServiceBusProcessor`. Concurrency must stay in the core layer that owns retry / circuit-breaker / dead-letter / transaction-context; migrating would fork the shared loop and re-implement those semantics inside the ASB adapter.

## Changes
- **Core:** `BrokeredMessageReceiver.MessageReceiverLoopAsync` fans out per-message processing into tracked background workers gated by the existing `SemaphoreSlim` sized from `MaxConcurrentCalls`. Receive stays serialized on the loop thread; per-worker context/transaction isolation; `CriticalReceiverException` propagated via a shared fault field observed each loop turn; drain-on-dispose before semaphore teardown; `MaxConcurrentCalls == 1` stays exactly sequential.
- **Tests:** core unit test proving peak in-flight == N (and == 1 for the sequential guard); ASB emulator `[RequiresDockerFact]` integration test proving real end-to-end parallelism (additive `ChatterPipelineHarness` service-registration hook).
- **F6 review remediation:** threaded the receive-loop `CancellationToken` through the internal `IServiceBusMessageReceiver` port into the SDK `ReceiveMessageAsync(maxWaitTime, cancellationToken)`, swallowing shutdown-cancel quietly — prevents teardown hangs on a stalled broker.

## Preserved semantics
Cross-entity transactions, single-top-level-entity startup guard (#145/#146), circuit-breaker/retry/dead-letter, transaction-context propagation, F4 host-fail-fast.

## Versioning
- `Chatter.MessageBrokers` 0.12.0 → 0.13.0 (MINOR)
- `Chatter.MessageBrokers.AzureServiceBus` 1.2.0 → 1.3.0 (MINOR)
- F6 fix is an internal-only contract change (no MAJOR; recorded under ASB `[Unreleased] → Fixed`).

## Review & validation
Local Codex adversarial review run pre-PR — 6 concurrency findings fixed in-loop, 1 (F6) escalated → planner → remediated; final re-review clean. `dotnet test Chatter.sln` green: 14 assemblies, 0 failures, `Chatter.MessageBrokers` 489/489 both TFMs; ASB integration tests skip without Docker.