### PR TITLE
test(messagebrokers): cover outbox/inbox reliability behaviors (#152)

### DIFF
--- a/src/Chatter.MessageBrokers/tests/Reliability/Inbox/UsingInboxBehavior/WhenHandling.cs
+++ b/src/Chatter.MessageBrokers/tests/Reliability/Inbox/UsingInboxBehavior/WhenHandling.cs
@@ -1,0 +1,101 @@
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Reliability.Inbox;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Reliability.Inbox.UsingInboxBehavior
+{
+    public class WhenHandling : Testing.Core.Context
+    {
+        private class FakeCommand : ICommand { }
+
+        private readonly Mock<IBrokeredMessageInbox> _inbox = new Mock<IBrokeredMessageInbox>();
+        // FakeCommand is private, so Castle cannot proxy ILogger<InboxBehavior<FakeCommand>>;
+        // a real NullLogger sidesteps the dynamic proxy. The behavior under test never asserts on logging.
+        private readonly ILogger<InboxBehavior<FakeCommand>> _logger = NullLogger<InboxBehavior<FakeCommand>>.Instance;
+        private readonly InboxBehavior<FakeCommand> _sut;
+
+        public WhenHandling()
+        {
+            _sut = new InboxBehavior<FakeCommand>(_inbox.Object, _logger);
+        }
+
+        [Fact]
+        public void MustThrowArgumentNullExceptionWhenInboxIsNull()
+            => FluentActions.Invoking(() => new InboxBehavior<FakeCommand>(null, _logger))
+                .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public void MustThrowArgumentNullExceptionWhenLoggerIsNull()
+            => FluentActions.Invoking(() => new InboxBehavior<FakeCommand>(_inbox.Object, null))
+                .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public async Task MustReceiveViaInboxWhenContextIsMessageBrokerContext()
+        {
+            var message = new FakeCommand();
+            var brokerContext = new Mock<IMessageBrokerContext>();
+
+            await _sut.Handle(message, brokerContext.Object, () => Task.CompletedTask);
+
+            _inbox.Verify(i => i.ReceiveViaInbox(message, brokerContext.Object, It.IsAny<Func<Task>>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustWrapNextInTheReceiverDelegate()
+        {
+            var invoked = false;
+            var brokerContext = new Mock<IMessageBrokerContext>();
+            _inbox.Setup(i => i.ReceiveViaInbox(It.IsAny<FakeCommand>(), It.IsAny<IMessageBrokerContext>(), It.IsAny<Func<Task>>()))
+                  .Returns<FakeCommand, IMessageBrokerContext, Func<Task>>((_, __, messageReceiver) => messageReceiver());
+
+            await _sut.Handle(new FakeCommand(), brokerContext.Object, () => { invoked = true; return Task.CompletedTask; });
+
+            invoked.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task MustInvokeNextAndSkipInboxWhenContextIsNotMessageBrokerContext()
+        {
+            var invoked = false;
+            var handlerContext = new Mock<IMessageHandlerContext>();
+
+            await _sut.Handle(new FakeCommand(), handlerContext.Object, () => { invoked = true; return Task.CompletedTask; });
+
+            invoked.Should().BeTrue();
+            _inbox.Verify(i => i.ReceiveViaInbox(It.IsAny<FakeCommand>(), It.IsAny<IMessageBrokerContext>(), It.IsAny<Func<Task>>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task MustNotInvokeNextOnDuplicateMessageId()
+        {
+            // A real InMemoryBrokeredMessageInbox proves the behavior dedupes already-processed
+            // message ids end to end rather than asserting only on a mock interaction.
+            var bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+            bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+            var inbox = new InMemoryBrokeredMessageInbox(new Mock<ILogger<InMemoryBrokeredMessageInbox>>().Object);
+            var sut = new InboxBehavior<FakeCommand>(inbox, _logger);
+
+            var inbound = new InboundBrokeredMessage("id-1", new byte[] { 1 }, new Dictionary<string, object>(), "receiver-path", bodyConverter.Object);
+            var brokerContext = new Mock<IMessageBrokerContext>();
+            brokerContext.SetupGet(c => c.BrokeredMessage).Returns(inbound);
+
+            var firstInvoked = false;
+            await sut.Handle(new FakeCommand(), brokerContext.Object, () => { firstInvoked = true; return Task.CompletedTask; });
+            firstInvoked.Should().BeTrue();
+
+            var secondInvoked = false;
+            await sut.Handle(new FakeCommand(), brokerContext.Object, () => { secondInvoked = true; return Task.CompletedTask; });
+            secondInvoked.Should().BeFalse();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Reliability/Outbox/UsingBrokeredMessageOutboxProcessor/WhenSendingOutboxMessages.cs
+++ b/src/Chatter.MessageBrokers/tests/Reliability/Outbox/UsingBrokeredMessageOutboxProcessor/WhenSendingOutboxMessages.cs
@@ -1,0 +1,223 @@
+using Chatter.MessageBrokers.Reliability.Configuration;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Reliability.Outbox.UsingBrokeredMessageOutboxProcessor
+{
+    public class WhenSendingOutboxMessages : Testing.Core.Context
+    {
+        // BrokeredMessageOutboxProcessor is internal, so Castle cannot proxy ILogger<BrokeredMessageOutboxProcessor>
+        // (DynamicProxyGenAssembly2 lacks access to the SUT type in the closed generic). A hand-written
+        // recording logger captures levels without a dynamic proxy.
+        private sealed class RecordingLogger : ILogger<BrokeredMessageOutboxProcessor>
+        {
+            public List<LogLevel> Levels { get; } = new List<LogLevel>();
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+                => Levels.Add(logLevel);
+
+            private sealed class NullScope : IDisposable
+            {
+                public static readonly NullScope Instance = new NullScope();
+                public void Dispose() { }
+            }
+        }
+
+        private readonly RecordingLogger _logger = new RecordingLogger();
+        private readonly ReliabilityOptions _reliabilityOptions = new ReliabilityOptions();
+        private readonly Mock<IServiceScopeFactory> _serviceScopeFactory = new Mock<IServiceScopeFactory>();
+        private readonly Mock<IServiceScope> _serviceScope = new Mock<IServiceScope>();
+        private readonly Mock<IServiceProvider> _serviceProvider = new Mock<IServiceProvider>();
+        private readonly Mock<IBrokeredMessageOutbox> _outbox = new Mock<IBrokeredMessageOutbox>();
+        private readonly Mock<IOutboxProcessor> _processor = new Mock<IOutboxProcessor>();
+        private readonly BrokeredMessageOutboxProcessor _sut;
+
+        public WhenSendingOutboxMessages()
+        {
+            // A long interval parks the loop at Task.Delay after the first drain so a single
+            // pass is observable and deterministic; the test signals completion off a TCS, never sleeps.
+            _reliabilityOptions.OutboxProcessingIntervalInMilliseconds = 60000;
+
+            _serviceScopeFactory.Setup(f => f.CreateScope()).Returns(_serviceScope.Object);
+            _serviceScope.SetupGet(s => s.ServiceProvider).Returns(_serviceProvider.Object);
+            // GetRequiredService<T>() resolves through GetService(Type); both must be set or it throws.
+            _serviceProvider.Setup(p => p.GetService(typeof(IBrokeredMessageOutbox))).Returns(_outbox.Object);
+            _serviceProvider.Setup(p => p.GetService(typeof(IOutboxProcessor))).Returns(_processor.Object);
+
+            _sut = new BrokeredMessageOutboxProcessor(_logger, _reliabilityOptions, _serviceScopeFactory.Object);
+        }
+
+        private static OutboxMessage CreateOutboxMessage(int id, DateTime sentToOutboxAtUtc)
+            => new OutboxMessage
+            {
+                Id = id,
+                MessageId = $"message-{id}",
+                Destination = "destination",
+                SentToOutboxAtUtc = sentToOutboxAtUtc,
+            };
+
+        private void SetupOutboxReturns(IEnumerable<OutboxMessage> messages)
+            => _outbox.Setup(o => o.GetUnprocessedMessagesFromOutbox(It.IsAny<CancellationToken>()))
+                      .ReturnsAsync(messages);
+
+        // Drives a single drain pass to completion: starts the hosted service, waits for the
+        // supplied signal (fired from the last dependency invoked on the path under test), then stops.
+        private async Task RunSingleDrainAsync(Task signal)
+        {
+            await _sut.StartAsync(CancellationToken.None);
+            await signal.WaitAsync(TimeSpan.FromSeconds(5));
+            await _sut.StopAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public void MustThrowArgumentNullExceptionWhenLoggerIsNull()
+            => FluentActions.Invoking(() => new BrokeredMessageOutboxProcessor(null, _reliabilityOptions, _serviceScopeFactory.Object))
+                .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public void MustThrowArgumentNullExceptionWhenReliabilityOptionsIsNull()
+            => FluentActions.Invoking(() => new BrokeredMessageOutboxProcessor(_logger, null, _serviceScopeFactory.Object))
+                .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public void MustThrowArgumentNullExceptionWhenServiceScopeFactoryIsNull()
+            => FluentActions.Invoking(() => new BrokeredMessageOutboxProcessor(_logger, _reliabilityOptions, null))
+                .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public async Task MustDrainUnprocessedMessagesFromOutbox()
+        {
+            var drained = new TaskCompletionSource();
+            _outbox.Setup(o => o.GetUnprocessedMessagesFromOutbox(It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(Enumerable.Empty<OutboxMessage>())
+                   .Callback(() => drained.TrySetResult());
+
+            await RunSingleDrainAsync(drained.Task);
+
+            _outbox.Verify(o => o.GetUnprocessedMessagesFromOutbox(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task MustCreateScopePerDrainPass()
+        {
+            var drained = new TaskCompletionSource();
+            _outbox.Setup(o => o.GetUnprocessedMessagesFromOutbox(It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(Enumerable.Empty<OutboxMessage>())
+                   .Callback(() => drained.TrySetResult());
+
+            await RunSingleDrainAsync(drained.Task);
+
+            _serviceScopeFactory.Verify(f => f.CreateScope(), Times.AtLeastOnce);
+        }
+
+        [Fact]
+        public async Task MustDelegateEachUnprocessedMessageToOutboxProcessor()
+        {
+            var processed = 0;
+            var bothProcessed = new TaskCompletionSource();
+            SetupOutboxReturns(new[]
+            {
+                CreateOutboxMessage(1, new DateTime(2026, 6, 7, 0, 0, 0, DateTimeKind.Utc)),
+                CreateOutboxMessage(2, new DateTime(2026, 6, 7, 0, 1, 0, DateTimeKind.Utc)),
+            });
+            _processor.Setup(p => p.Process(It.IsAny<OutboxMessage>(), It.IsAny<CancellationToken>()))
+                      .Returns(Task.CompletedTask)
+                      .Callback(() =>
+                      {
+                          if (Interlocked.Increment(ref processed) == 2)
+                          {
+                              bothProcessed.TrySetResult();
+                          }
+                      });
+
+            await RunSingleDrainAsync(bothProcessed.Task);
+
+            _processor.Verify(p => p.Process(It.IsAny<OutboxMessage>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task MustProcessMessagesInAscendingSentToOutboxOrder()
+        {
+            var earlier = CreateOutboxMessage(1, new DateTime(2026, 6, 7, 0, 0, 0, DateTimeKind.Utc));
+            var later = CreateOutboxMessage(2, new DateTime(2026, 6, 7, 0, 5, 0, DateTimeKind.Utc));
+            // Supplied out of chronological order so OrderBy(m => m.SentToOutboxAtUtc) is exercised.
+            SetupOutboxReturns(new[] { later, earlier });
+
+            var processedOrder = new List<int>();
+            var bothProcessed = new TaskCompletionSource();
+            _processor.Setup(p => p.Process(It.IsAny<OutboxMessage>(), It.IsAny<CancellationToken>()))
+                      .Returns(Task.CompletedTask)
+                      .Callback<OutboxMessage, CancellationToken>((m, _) =>
+                      {
+                          processedOrder.Add(m.Id);
+                          if (processedOrder.Count == 2)
+                          {
+                              bothProcessed.TrySetResult();
+                          }
+                      });
+
+            await RunSingleDrainAsync(bothProcessed.Task);
+
+            processedOrder.Should().Equal(earlier.Id, later.Id);
+        }
+
+        [Fact]
+        public async Task MustNotProcessAnyMessageWhenOutboxIsEmpty()
+        {
+            var drained = new TaskCompletionSource();
+            _outbox.Setup(o => o.GetUnprocessedMessagesFromOutbox(It.IsAny<CancellationToken>()))
+                   .ReturnsAsync(Enumerable.Empty<OutboxMessage>())
+                   .Callback(() => drained.TrySetResult());
+
+            await RunSingleDrainAsync(drained.Task);
+
+            _processor.Verify(p => p.Process(It.IsAny<OutboxMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task MustLogErrorAndNotTearDownPollerWhenDrainingThrows()
+        {
+            var attempted = new TaskCompletionSource();
+            // The drain failure leaves messages pending; the loop's catch swallows it so the
+            // poller survives and retries on the next interval rather than crashing.
+            _outbox.Setup(o => o.GetUnprocessedMessagesFromOutbox(It.IsAny<CancellationToken>()))
+                   .Callback(() => attempted.TrySetResult())
+                   .ThrowsAsync(new InvalidOperationException("boom"));
+
+            await FluentActions.Invoking(() => RunSingleDrainAsync(attempted.Task))
+                .Should().NotThrowAsync();
+
+            VerifyErrorLogged();
+        }
+
+        [Fact]
+        public async Task MustLogErrorAndNotTearDownPollerWhenProcessingThrows()
+        {
+            SetupOutboxReturns(new[] { CreateOutboxMessage(1, new DateTime(2026, 6, 7, 0, 0, 0, DateTimeKind.Utc)) });
+
+            var attempted = new TaskCompletionSource();
+            _processor.Setup(p => p.Process(It.IsAny<OutboxMessage>(), It.IsAny<CancellationToken>()))
+                      .Callback(() => attempted.TrySetResult())
+                      .ThrowsAsync(new InvalidOperationException("boom"));
+
+            await FluentActions.Invoking(() => RunSingleDrainAsync(attempted.Task))
+                .Should().NotThrowAsync();
+
+            VerifyErrorLogged();
+        }
+
+        private void VerifyErrorLogged()
+            => _logger.Levels.Should().Contain(LogLevel.Error);
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Reliability/Outbox/UsingOutboxProcessingBehavior/WhenHandling.cs
+++ b/src/Chatter.MessageBrokers/tests/Reliability/Outbox/UsingOutboxProcessingBehavior/WhenHandling.cs
@@ -1,0 +1,133 @@
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.CQRS.Pipeline;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Reliability.Outbox.UsingOutboxProcessingBehavior
+{
+    public class WhenHandling : Testing.Core.Context
+    {
+        private class FakeCommand : ICommand { }
+
+        private const string CurrentTransactionIdKey = "CurrentTransactionId";
+
+        private readonly Mock<IOutboxProcessor> _outboxProcessor = new Mock<IOutboxProcessor>();
+        // FakeCommand is private, so Castle cannot proxy ILogger<OutboxProcessingBehavior<FakeCommand>>;
+        // a real NullLogger sidesteps the dynamic proxy. The behavior under test never asserts on logging.
+        private readonly ILogger<OutboxProcessingBehavior<FakeCommand>> _logger = NullLogger<OutboxProcessingBehavior<FakeCommand>>.Instance;
+        private readonly Mock<IMessageHandlerContext> _context = new Mock<IMessageHandlerContext>();
+        private readonly ContextContainer _container = new ContextContainer();
+        private readonly CancellationToken _cancellationToken = new CancellationTokenSource().Token;
+        private readonly OutboxProcessingBehavior<FakeCommand> _sut;
+
+        public WhenHandling()
+        {
+            _context.SetupGet(c => c.Container).Returns(_container);
+            _context.SetupGet(c => c.CancellationToken).Returns(_cancellationToken);
+            _sut = new OutboxProcessingBehavior<FakeCommand>(_outboxProcessor.Object, _logger);
+        }
+
+        private static CommandHandlerDelegate RecordingNext(List<string> order)
+            => () =>
+            {
+                order.Add("next");
+                return Task.CompletedTask;
+            };
+
+        private void IncludeTransactionContext(Guid? transactionId)
+        {
+            var transactionContext = new TransactionContext();
+            if (transactionId.HasValue)
+            {
+                transactionContext.Container.Include<Guid>(CurrentTransactionIdKey, transactionId.Value);
+            }
+            _container.Include(transactionContext);
+        }
+
+        [Fact]
+        public void MustThrowArgumentNullExceptionWhenOutboxProcessorIsNull()
+            => FluentActions.Invoking(() => new OutboxProcessingBehavior<FakeCommand>(null, _logger))
+                .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public void MustThrowArgumentNullExceptionWhenLoggerIsNull()
+            => FluentActions.Invoking(() => new OutboxProcessingBehavior<FakeCommand>(_outboxProcessor.Object, null))
+                .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public async Task MustInvokeNext()
+        {
+            var invoked = false;
+
+            await _sut.Handle(new FakeCommand(), _context.Object, () => { invoked = true; return Task.CompletedTask; });
+
+            invoked.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task MustProcessBatchWithTransactionIdWhenTransactionContextPresent()
+        {
+            var transactionId = Guid.NewGuid();
+            IncludeTransactionContext(transactionId);
+
+            await _sut.Handle(new FakeCommand(), _context.Object, () => Task.CompletedTask);
+
+            _outboxProcessor.Verify(p => p.ProcessBatch(transactionId, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustProcessBatchWithEmptyGuidWhenTransactionIdMissing()
+        {
+            IncludeTransactionContext(null);
+
+            await _sut.Handle(new FakeCommand(), _context.Object, () => Task.CompletedTask);
+
+            _outboxProcessor.Verify(p => p.ProcessBatch(Guid.Empty, It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustNotProcessBatchWhenTransactionContextAbsent()
+        {
+            var invoked = false;
+
+            await _sut.Handle(new FakeCommand(), _context.Object, () => { invoked = true; return Task.CompletedTask; });
+
+            invoked.Should().BeTrue();
+            _outboxProcessor.Verify(p => p.ProcessBatch(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+        }
+
+        [Fact]
+        public async Task MustInvokeNextBeforeProcessingBatch()
+        {
+            IncludeTransactionContext(Guid.NewGuid());
+            var order = new List<string>();
+            _outboxProcessor.Setup(p => p.ProcessBatch(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                            .Returns(Task.CompletedTask)
+                            .Callback(() => order.Add("processBatch"));
+
+            await _sut.Handle(new FakeCommand(), _context.Object, RecordingNext(order));
+
+            order.Should().Equal("next", "processBatch");
+        }
+
+        [Fact]
+        public async Task MustPropagateCancellationTokenFromContextToProcessBatch()
+        {
+            IncludeTransactionContext(Guid.NewGuid());
+
+            await _sut.Handle(new FakeCommand(), _context.Object, () => Task.CompletedTask);
+
+            _outboxProcessor.Verify(p => p.ProcessBatch(It.IsAny<Guid>(), _cancellationToken), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
Test-only change — no production code touched.

Adds 24 unit tests (per TFM) across 3 new xUnit files covering previously-zero-coverage reliability types in `Chatter.MessageBrokers`:

- **BrokeredMessageOutboxProcessor** (background poller): ctor null guards, drain via `GetUnprocessedMessagesFromOutbox`, per-message `IOutboxProcessor.Process` delegation, `SentToOutboxAtUtc` ordering, empty-outbox skip, and failure-isolation (drain/Process throw leaves the poller alive → next interval re-drains, i.e. failure leaves messages pending for retry).
- **OutboxProcessingBehavior**: ctor null guards, always invokes the handler (`next`), flushes the outbox batch via `ProcessBatch` under the captured `CurrentTransactionId` (and `Guid.Empty` when missing) only when a `TransactionContext` is present, never otherwise, with handler-before-flush ordering.
- **InboxBehavior**: ctor null guards, routes `IMessageBrokerContext` messages through `IBrokeredMessageInbox.ReceiveViaInbox` (wrapped receiver runs `next`), falls through to `next()` for non-broker contexts, and proves idempotent dedupe of duplicate message ids via the real `InMemoryBrokeredMessageInbox`.

In-memory stores only — no DB, no broker emulator.

Validated: `dotnet test Chatter.sln` green on net8.0 + net10.0 (0 failures; 20 ASB integration tests skipped — no emulator). No version bump (changes live only in the non-packable `Chatter.MessageBrokers.Tests` project).

Closes #152.