### PR TITLE
test(messagebrokers): cover BrokeredMessageReceiver concurrency/shutdown/fault-ordering paths (#151)

### DIFF
--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenMisconfigured.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenMisconfigured.cs
@@ -1,0 +1,107 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    // INVARIANT: the MaxConcurrentCalls floor guard (value < 1) fails fast and STARTUP-FATALLY. The guard throws in
+    // StartReceiverImpl BEFORE IsReceiving flips true, so it is NOT absorbed by StartReceiver's when(this.IsReceiving)
+    // post-startup catch and PROPAGATES to the caller — exactly the path .NET relies on to abort host startup loudly
+    // rather than leave a silently-stopped receiver running. The message must name the bad value and the receiver path.
+    public class WhenMisconfigured : Testing.Core.Context
+    {
+        private static MessageBrokerOptions BuildOptions(TransactionMode mode = TransactionMode.None)
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = mode;
+            return opts;
+        }
+
+        private static Mock<IRecoveryStrategy> PassThroughRecovery()
+        {
+            var mock = new Mock<IRecoveryStrategy>();
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+            return mock;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions(int maxConcurrentCalls)
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = 10,
+                MaxConcurrentCalls = maxConcurrentCalls,
+            };
+
+        private BrokeredMessageReceiver<FakeMessage> CreateSut(InMemoryMessagingInfrastructureReceiver infraReceiver)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: new Mock<IMaxReceivesExceededAction>().Object,
+                criticalFailureNotifier: new Mock<ICriticalFailureNotifier>().Object,
+                recoveryStrategy: PassThroughRecovery().Object,
+                receivedMessageDispatcher: new Mock<IReceivedMessageDispatcher>().Object);
+        }
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------ MaxConcurrentCalls floor guard is startup-fatal and propagates
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-1)]
+        public async Task MustThrowStartupFatalWhenMaxConcurrentCallsBelowOne(int maxConcurrentCalls)
+        {
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 0);
+
+            var sut = CreateSut(infraReceiver);
+
+            using var cts = new CancellationTokenSource();
+
+            // The guard must PROPAGATE to the caller (startup-fatal), not be swallowed by the when(this.IsReceiving)
+            // post-startup catch — IsReceiving is still false when the guard fires.
+            Func<Task> act = () => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token);
+
+            var assertion = await act.Should().ThrowAsync<InvalidOperationException>(
+                "a MaxConcurrentCalls value below 1 must fail fast and propagate as a startup-fatal exception");
+
+            // The message must name the bad value and the receiver path so the misconfiguration is diagnosable.
+            assertion.Which.Message.Should().Contain(maxConcurrentCalls.ToString(),
+                "the message must name the bad MaxConcurrentCalls value");
+            assertion.Which.Message.Should().Contain("test-queue",
+                "the message must name the receiver path");
+
+            sut.IsReceiving.Should().BeFalse("the guard fires before go-live, so the receiver never started");
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Receive,
+                "no message may be received when startup fails fast on the floor guard");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiveLoopFaults.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiveLoopFaults.cs
@@ -1,0 +1,312 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Exceptions;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    // INVARIANT: drives the receive-loop fault paths that the happy-path tests never reach: a loop Task that becomes
+    // IsFaulted (because the notify epilogue itself threw), the inline receive-error ladder (a failure to RECEIVE,
+    // handled on the loop thread), and the empty-receive continue branch. NullLogger keeps the critical-log calls
+    // no-ops; gating primitives + a 15s watchdog convert any teardown/drain regression into a Timeout, not a hang.
+    public class WhenReceiveLoopFaults : Testing.Core.Context
+    {
+        private static MessageBrokerOptions BuildOptions(TransactionMode mode = TransactionMode.None)
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = mode;
+            return opts;
+        }
+
+        // INVARIANT: pass-through IRecoveryStrategy invokes the delegate exactly once, no retry machinery. Tests that
+        // need a faulting receive override only the MessageBrokerContext overload via FaultingThenPassThroughRecovery.
+        private static Mock<IRecoveryStrategy> PassThroughRecovery()
+        {
+            var mock = new Mock<IRecoveryStrategy>();
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+            return mock;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions(int maxConcurrentCalls)
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = 10,
+                MaxConcurrentCalls = maxConcurrentCalls,
+            };
+
+        private static MessageBrokerContext BuildContext()
+        {
+            var converter = new JsonBodyConverter();
+            var body = converter.Convert(new FakeMessage { Value = "hello" });
+            return new MessageBrokerContext(
+                messageId: Guid.NewGuid().ToString(),
+                body: body,
+                applicationProperties: new Dictionary<string, object>(),
+                messageReceiverPath: "test-queue",
+                receiverCancellationToken: CancellationToken.None,
+                bodyConverter: converter);
+        }
+
+        private BrokeredMessageReceiver<FakeMessage> CreateSut(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            Mock<IReceivedMessageDispatcher> dispatcher,
+            Mock<IRecoveryStrategy> recovery = null,
+            Mock<ICriticalFailureNotifier> criticalNotifier = null)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+            recovery ??= PassThroughRecovery();
+            criticalNotifier ??= new Mock<ICriticalFailureNotifier>();
+
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: new Mock<IMaxReceivesExceededAction>().Object,
+                criticalFailureNotifier: criticalNotifier.Object,
+                recoveryStrategy: recovery.Object,
+                receivedMessageDispatcher: dispatcher.Object);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken watchdog)
+        {
+            while (!predicate())
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------ (a) faulted-loop belt-and-suspenders drain
+
+        [Fact]
+        public async Task MustDrainAndStopCleanlyWhenLoopTaskFaultedFromNotifyEpilogue()
+        {
+            const int maxConcurrentCalls = 2;
+            const int messageCount = 2;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            // One worker faults critically; the other (sibling) gates in-flight. The Notify epilogue then throws a
+            // NON-critical InvalidOperationException, so MessageReceiverLoopAsync's finally throws and the loop Task
+            // becomes IsFaulted BEFORE its own drain runs — leaving the sibling still gated. StopReceiver must SKIP the
+            // faulted-loop await (the !IsFaulted guard) and run its belt-and-suspenders finally drain so the sibling
+            // quiesces once we release the gate, then record Stop and dispose without throwing.
+            using var siblingReleaseGate = new SemaphoreSlim(0, 1);
+            var siblingEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var inFlight = new StrongBox<int>(0);
+            var faultArmed = new StrongBox<int>(0);
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(async (FakeMessage _, MessageBrokerContext __, CancellationToken token) =>
+                {
+                    // The faulter waits until the sibling has entered (and is in the in-flight set) before throwing, so
+                    // the loop genuinely has a gated sibling left undrained when the notify epilogue faults the loop.
+                    if (Interlocked.Increment(ref faultArmed.Value) == 1)
+                    {
+                        await siblingEntered.Task;
+                        throw new CriticalReceiverException("boom");
+                    }
+
+                    Interlocked.Increment(ref inFlight.Value);
+                    siblingEntered.TrySetResult(true);
+                    try
+                    {
+                        // Wait WITHOUT the worker token so cancellation (SignalLoopCriticalFault) can NOT self-quiesce the
+                        // sibling. The ONLY release is the explicit gate release the test issues right before StopReceiver,
+                        // so the sibling stays genuinely in-flight until StopReceiver's belt-and-suspenders drain awaits it.
+                        await siblingReleaseGate.WaitAsync();
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref inFlight.Value);
+                    }
+                });
+
+            var loopFaulted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var criticalNotifier = new Mock<ICriticalFailureNotifier>();
+            criticalNotifier
+                .Setup(n => n.Notify(It.IsAny<FailureContext>()))
+                .Returns((FailureContext _) =>
+                {
+                    loopFaulted.TrySetResult(true);
+                    // Non-critical throw inside the epilogue: this escapes MessageReceiverLoopAsync's finally and faults
+                    // the loop Task before its own drain executes.
+                    throw new InvalidOperationException("notify failed");
+                });
+
+            var sut = CreateSut(infraReceiver, dispatcher, criticalNotifier: criticalNotifier);
+
+            using var cts = new CancellationTokenSource();
+            // Do NOT await StartReceiver's loop here: StartReceiverImpl awaits the (now faulting) loop, so the
+            // StartReceiver task would surface the InvalidOperationException unless IsReceiving has flipped. Run it
+            // detached; the receiver instance is reachable via sut for the teardown calls.
+            _ = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            var siblingCompleted = await Task.WhenAny(siblingEntered.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            siblingCompleted.Should().BeSameAs(siblingEntered.Task, "the sibling worker must gate in-flight");
+
+            var faultCompleted = await Task.WhenAny(loopFaulted.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            faultCompleted.Should().BeSameAs(loopFaulted.Task, "the notify epilogue must run (and then fault the loop)");
+            await loopFaulted.Task;
+
+            // Release the gate so the StopReceiver drain can quiesce the sibling, then stop. StopReceiver must not throw
+            // despite the loop having faulted.
+            siblingReleaseGate.Release();
+
+            var stop = sut.StopReceiver();
+            var stopCompleted = await Task.WhenAny(stop, Task.Delay(TimeSpan.FromSeconds(15)));
+            stopCompleted.Should().BeSameAs(stop, "StopReceiver must skip the faulted loop, drain, and complete without throwing");
+            await stop;
+
+            Volatile.Read(ref inFlight.Value).Should().Be(0, "the belt-and-suspenders drain must quiesce the gated sibling");
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Stop, "StopReceiver must stop the infrastructure receiver even when the loop faulted");
+        }
+
+        // ------------------------------------------------------------------ (b) inline receive-error ladder
+
+        [Fact]
+        public async Task MustReleaseSlotAndContinueWhenReceiveThrowsGenericError()
+        {
+            const int messageCount = 1;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            infraReceiver.Enqueue(BuildContext());
+
+            // The IRecoveryStrategy MessageBrokerContext overload throws a generic Exception on its FIRST call, then
+            // delegates through. The loop's catch(Exception) handles the failed receive inline on the loop thread,
+            // releases the slot, and continues pulling — eventually the real receive succeeds and the message is acked.
+            // No Nack/Deadletter is recorded (those are worker-side dispositions, not receive-error handling).
+            var receiveCalls = new StrongBox<int>(0);
+            var recovery = new Mock<IRecoveryStrategy>();
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) =>
+                {
+                    if (Interlocked.Increment(ref receiveCalls.Value) == 1)
+                    {
+                        throw new Exception("transient receive failure");
+                    }
+                    return action();
+                });
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+
+            var sut = CreateSut(infraReceiver, dispatcher, recovery: recovery);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls: 1), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            // Despite the first receive throwing, the loop continues pulling and the message is ultimately acked.
+            await WaitUntilAsync(() => infraReceiver.CallLog.Contains(ReceiverCall.Ack), watchdog.Token);
+
+            cts.Cancel();
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop, "the loop must continue after an inline receive error and cancel cleanly");
+            await loop;
+
+            receiveCalls.Value.Should().BeGreaterThan(1, "the first receive threw and the loop must have continued to receive again");
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Ack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack, "a failure to RECEIVE must not Nack");
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Deadletter, "a failure to RECEIVE must not Deadletter");
+        }
+
+        // ------------------------------------------------------------------ (c) messageContext == null continue branch
+
+        [Fact]
+        public async Task MustReleaseSlotAndContinueWhenReceiveReturnsNull()
+        {
+            const int messageCount = 1;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            infraReceiver.Enqueue(BuildContext());
+
+            // The receive overload returns null on its FIRST call (an empty receive), then delegates through. The loop's
+            // messageContext == null branch releases the slot and continues; the next pull receives the real message,
+            // which is acked. Proves the empty-receive continue path does not leak a slot or spawn a worker.
+            var receiveCalls = new StrongBox<int>(0);
+            var recovery = new Mock<IRecoveryStrategy>();
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) =>
+                {
+                    if (Interlocked.Increment(ref receiveCalls.Value) == 1)
+                    {
+                        return Task.FromResult<MessageBrokerContext>(null);
+                    }
+                    return action();
+                });
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+
+            var sut = CreateSut(infraReceiver, dispatcher, recovery: recovery);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls: 1), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await WaitUntilAsync(() => infraReceiver.CallLog.Contains(ReceiverCall.Ack), watchdog.Token);
+
+            cts.Cancel();
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop, "the loop must continue after an empty receive and cancel cleanly");
+            await loop;
+
+            receiveCalls.Value.Should().BeGreaterThan(1, "the first receive returned null and the loop must have pulled again");
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Ack);
+            dispatcher.Verify(
+                d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()),
+                Times.Once,
+                "only the non-null received message must spawn a worker");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenShuttingDownGracefully.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenShuttingDownGracefully.cs
@@ -1,0 +1,287 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    // INVARIANT: exercises the explicit teardown paths the steady-state tests never call. WhenProcessingConcurrently
+    // only cancels the loop token; here StopReceiver(), DisposeAsync(), and synchronous Dispose() are invoked directly
+    // WHILE workers are gated in-flight, proving each drains the live worker set to quiescence before disposing the
+    // shared primitives and records its infrastructure call exactly once. Gating primitives (SemaphoreSlim gate +
+    // interlocked counter + 15s watchdog) make a teardown regression surface as a Timeout/OperationCanceled, not a hang.
+    public class WhenShuttingDownGracefully : Testing.Core.Context
+    {
+        // INVARIANT: MessageBrokerOptions.TransactionMode has internal set; accessible via InternalsVisibleTo("Chatter.MessageBrokers.Tests").
+        private static MessageBrokerOptions BuildOptions(TransactionMode mode = TransactionMode.None)
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = mode;
+            return opts;
+        }
+
+        // INVARIANT: pass-through IRecoveryStrategy invokes the delegate exactly once, no retry machinery.
+        private static Mock<IRecoveryStrategy> PassThroughRecovery()
+        {
+            var mock = new Mock<IRecoveryStrategy>();
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+            return mock;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions(int maxConcurrentCalls)
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = 10,
+                MaxConcurrentCalls = maxConcurrentCalls,
+            };
+
+        private static MessageBrokerContext BuildContext()
+        {
+            var converter = new JsonBodyConverter();
+            var body = converter.Convert(new FakeMessage { Value = "hello" });
+            return new MessageBrokerContext(
+                messageId: Guid.NewGuid().ToString(),
+                body: body,
+                applicationProperties: new Dictionary<string, object>(),
+                messageReceiverPath: "test-queue",
+                receiverCancellationToken: CancellationToken.None,
+                bodyConverter: converter);
+        }
+
+        private BrokeredMessageReceiver<FakeMessage> CreateSut(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            Mock<IReceivedMessageDispatcher> dispatcher)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: new Mock<IMaxReceivesExceededAction>().Object,
+                criticalFailureNotifier: new Mock<ICriticalFailureNotifier>().Object,
+                recoveryStrategy: PassThroughRecovery().Object,
+                receivedMessageDispatcher: dispatcher.Object);
+        }
+
+        // INVARIANT: spins until the predicate holds or the watchdog fires, converting a stuck teardown into a prompt
+        // OperationCanceledException instead of a hang.
+        private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken watchdog)
+        {
+            while (!predicate())
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        // INVARIANT: builds a dispatcher whose every worker increments the in-flight counter, blocks on the supplied
+        // release gate, and decrements on exit. The teardown call is issued only after in-flight has reached the cap,
+        // so the drain genuinely has live workers to await.
+        private static Mock<IReceivedMessageDispatcher> GatedDispatcher(SemaphoreSlim releaseGate, StrongBox<int> inFlight)
+        {
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(async (FakeMessage _, MessageBrokerContext __, CancellationToken token) =>
+                {
+                    Interlocked.Increment(ref inFlight.Value);
+                    try
+                    {
+                        await releaseGate.WaitAsync(token);
+                    }
+                    finally
+                    {
+                        Interlocked.Decrement(ref inFlight.Value);
+                    }
+                });
+            return dispatcher;
+        }
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------ (a) StopReceiver drains in-flight workers
+
+        [Fact]
+        public async Task MustDrainInFlightWorkersAndRecordStopWhenStopReceiverCalled()
+        {
+            const int maxConcurrentCalls = 3;
+            const int messageCount = 6;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            var inFlight = new StrongBox<int>(0);
+            using var releaseGate = new SemaphoreSlim(0, messageCount);
+            var dispatcher = GatedDispatcher(releaseGate, inFlight);
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            // Confirm exactly the cap is occupied by blocked workers BEFORE releasing the gate, so StopReceiver's drain
+            // has real in-flight work to await.
+            await WaitUntilAsync(() => Volatile.Read(ref inFlight.Value) == maxConcurrentCalls, watchdog.Token);
+
+            // Release the gate ONLY after confirming in-flight == N, then stop: the workers complete and StopReceiver
+            // drains them to quiescence.
+            releaseGate.Release(messageCount);
+
+            var stop = sut.StopReceiver();
+            var completed = await Task.WhenAny(stop, Task.Delay(TimeSpan.FromSeconds(15)));
+            completed.Should().BeSameAs(stop, "StopReceiver must drain in-flight workers and complete cleanly");
+            await stop; // surface any fault
+
+            Volatile.Read(ref inFlight.Value).Should().Be(0, "all in-flight workers must have quiesced before StopReceiver returns");
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Stop, "StopReceiver must stop the infrastructure receiver");
+        }
+
+        // ------------------------------------------------------------------ (b) DisposeAsync cancels, drains, records Dispose once
+
+        [Fact]
+        public async Task MustCancelDrainAndRecordDisposeOnceWhenDisposeAsyncCalled()
+        {
+            const int maxConcurrentCalls = 3;
+            const int messageCount = 6;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            var inFlight = new StrongBox<int>(0);
+            using var releaseGate = new SemaphoreSlim(0, messageCount);
+            var dispatcher = GatedDispatcher(releaseGate, inFlight);
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            _ = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await WaitUntilAsync(() => Volatile.Read(ref inFlight.Value) == maxConcurrentCalls, watchdog.Token);
+
+            // DisposeAsync cancels the loop token (unblocking the gated workers via OCE on the worker token) and drains.
+            releaseGate.Release(messageCount);
+            var dispose = sut.DisposeAsync().AsTask();
+            var completed = await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(15)));
+            completed.Should().BeSameAs(dispose, "DisposeAsync must drain in-flight workers and complete cleanly");
+            await dispose;
+
+            Volatile.Read(ref inFlight.Value).Should().Be(0, "all in-flight workers must have quiesced before DisposeAsync returns");
+            infraReceiver.CallLog.Count(c => c == ReceiverCall.Dispose)
+                .Should().Be(1, "DisposeAsync must dispose the infrastructure receiver exactly once");
+        }
+
+        // ------------------------------------------------------------------ (c) synchronous Dispose quiesces off any SynchronizationContext
+
+        [Fact]
+        public async Task MustQuiesceWithoutDeadlockWhenSynchronousDisposeCalled()
+        {
+            const int maxConcurrentCalls = 3;
+            const int messageCount = 6;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            var inFlight = new StrongBox<int>(0);
+            using var releaseGate = new SemaphoreSlim(0, messageCount);
+            var dispatcher = GatedDispatcher(releaseGate, inFlight);
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            _ = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await WaitUntilAsync(() => Volatile.Read(ref inFlight.Value) == maxConcurrentCalls, watchdog.Token);
+
+            // Release the gate so the synchronously-blocking QuiesceForSyncDispose can complete its drain, then call
+            // Dispose() OFF any SynchronizationContext (Task.Run) to honor the no-deadlock contract. The sync wait
+            // (GetAwaiter().GetResult) must return rather than deadlock because the loop and workers never capture a
+            // caller context.
+            releaseGate.Release(messageCount);
+            var dispose = Task.Run(() => sut.Dispose());
+            var completed = await Task.WhenAny(dispose, Task.Delay(TimeSpan.FromSeconds(15)));
+            completed.Should().BeSameAs(dispose, "synchronous Dispose must quiesce without deadlocking");
+            await dispose;
+
+            Volatile.Read(ref inFlight.Value).Should().Be(0, "all in-flight workers must have quiesced after synchronous Dispose returns");
+            infraReceiver.CallLog.Count(c => c == ReceiverCall.Dispose)
+                .Should().Be(1, "synchronous Dispose must dispose the infrastructure receiver exactly once");
+        }
+
+        // ------------------------------------------------------------------ (d) double Dispose()/DisposeAsync() is idempotent
+
+        [Fact]
+        public async Task MustBeIdempotentAcrossDisposeAsyncAndDispose()
+        {
+            const int maxConcurrentCalls = 3;
+            const int messageCount = 6;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            var inFlight = new StrongBox<int>(0);
+            using var releaseGate = new SemaphoreSlim(0, messageCount);
+            var dispatcher = GatedDispatcher(releaseGate, inFlight);
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            _ = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await WaitUntilAsync(() => Volatile.Read(ref inFlight.Value) == maxConcurrentCalls, watchdog.Token);
+
+            releaseGate.Release(messageCount);
+
+            // First teardown via DisposeAsync, then redundant synchronous Dispose calls. The _disposedValue guard makes
+            // each subsequent synchronous Dispose a no-op, and RecordCallOnce keeps the infrastructure Dispose count at 1.
+            var first = sut.DisposeAsync().AsTask();
+            var completed = await Task.WhenAny(first, Task.Delay(TimeSpan.FromSeconds(15)));
+            completed.Should().BeSameAs(first, "the first DisposeAsync must complete cleanly");
+            await first;
+
+            // The synchronous Dispose path is guarded by _disposedValue, so repeated calls are no-ops that neither throw
+            // nor re-dispose the infrastructure receiver.
+            sut.Dispose();
+            sut.Dispose();
+
+            infraReceiver.CallLog.Count(c => c == ReceiverCall.Dispose)
+                .Should().Be(1, "repeated teardown must remain idempotent and record Dispose exactly once");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenWorkerErrorLadderRuns.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenWorkerErrorLadderRuns.cs
@@ -1,0 +1,310 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    // INVARIANT: drives the per-worker generic-error recovery ladder in ProcessReceivedMessageWorkerAsync under the
+    // SNAPSHOTTED worker token. Covers the Nack (DeliveryCount < Max) and Deadletter + MaxReceivesExceededAction
+    // (DeliveryCount >= Max) branches, the settlement-probe failure that must be swallowed and critically logged
+    // (without leaking a slot or faulting the loop), and the cancellation-during-recovery swallow. NullLogger makes
+    // the critical-log no-op; gating primitives + 15s watchdog turn any leaked-slot/hang regression into a Timeout.
+    public class WhenWorkerErrorLadderRuns : Testing.Core.Context
+    {
+        private static MessageBrokerOptions BuildOptions(TransactionMode mode = TransactionMode.None)
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = mode;
+            return opts;
+        }
+
+        private static Mock<IRecoveryStrategy> PassThroughRecovery()
+        {
+            var mock = new Mock<IRecoveryStrategy>();
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+            return mock;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions(int maxReceiveAttempts = 10, int maxConcurrentCalls = 1)
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = maxReceiveAttempts,
+                MaxConcurrentCalls = maxConcurrentCalls,
+            };
+
+        private static MessageBrokerContext BuildContext()
+        {
+            var converter = new JsonBodyConverter();
+            var body = converter.Convert(new FakeMessage { Value = "hello" });
+            return new MessageBrokerContext(
+                messageId: Guid.NewGuid().ToString(),
+                body: body,
+                applicationProperties: new Dictionary<string, object>(),
+                messageReceiverPath: "test-queue",
+                receiverCancellationToken: CancellationToken.None,
+                bodyConverter: converter);
+        }
+
+        private BrokeredMessageReceiver<FakeMessage> CreateSut(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            Mock<IReceivedMessageDispatcher> dispatcher,
+            Mock<IMaxReceivesExceededAction> maxReceivesAction = null,
+            Mock<IRecoveryStrategy> recovery = null)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+            maxReceivesAction ??= new Mock<IMaxReceivesExceededAction>();
+            recovery ??= PassThroughRecovery();
+
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: maxReceivesAction.Object,
+                criticalFailureNotifier: new Mock<ICriticalFailureNotifier>().Object,
+                recoveryStrategy: recovery.Object,
+                receivedMessageDispatcher: dispatcher.Object);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken watchdog)
+        {
+            while (!predicate())
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------ (a) generic handler error + DeliveryCount < Max → Nack
+
+        [Fact]
+        public async Task MustNackWhenHandlerThrowsGenericAndDeliveryCountBelowMax()
+        {
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.DeliveryCount = 1; // below MaxReceiveAttempts
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("handler boom"));
+
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: 10), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await WaitUntilAsync(() => infraReceiver.CallLog.Contains(ReceiverCall.Nack), watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Nack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Ack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Deadletter);
+        }
+
+        // ------------------------------------------------------------------ (b) generic handler error + DeliveryCount >= Max → Deadletter + MaxReceivesExceededAction
+
+        [Fact]
+        public async Task MustDeadletterAndInvokeMaxReceivesActionWhenDeliveryCountAtMax()
+        {
+            const int maxAttempts = 3;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.DeliveryCount = maxAttempts; // >= Max
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("handler boom at max"));
+
+            var maxReceivesAction = new Mock<IMaxReceivesExceededAction>();
+            maxReceivesAction
+                .Setup(a => a.ExecuteAsync(It.IsAny<FailureContext>()))
+                .Returns(Task.CompletedTask);
+
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher, maxReceivesAction: maxReceivesAction);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: maxAttempts), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            await WaitUntilAsync(() => infraReceiver.CallLog.Contains(ReceiverCall.Deadletter), watchdog.Token);
+
+            cts.Cancel();
+            await loop;
+
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Deadletter);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Nack);
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Ack);
+            maxReceivesAction.Verify(a => a.ExecuteAsync(It.IsAny<FailureContext>()), Times.Once);
+        }
+
+        // ------------------------------------------------------------------ (c) settlement-probe failure → swallowed + critically logged, loop unaffected
+
+        [Fact]
+        public async Task MustSwallowSettlementProbeFailureWithoutLeakingSlotOrFaultingLoop()
+        {
+            const int messageCount = 2;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            infraReceiver.DeliveryCount = 1;
+
+            // The FIRST message's handler throws generic, then the settlement probe (MessageDeliveryCountAsync via the
+            // Func<Task<int>> recovery overload) throws an unexpected fault → the worker's catch(Exception recoveryError)
+            // swallows it and logs critically. The loop must be unaffected and not leak the slot: the SECOND message
+            // must still be received and acked. The first message's handler must NOT throw on the second message.
+            var firstHandlerThrew = new StrongBox<int>(0);
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns((FakeMessage _, MessageBrokerContext __, CancellationToken ___) =>
+                {
+                    if (Interlocked.Increment(ref firstHandlerThrew.Value) == 1)
+                    {
+                        throw new InvalidOperationException("handler boom");
+                    }
+                    return Task.CompletedTask;
+                });
+
+            // Recovery: receive + ack/nack delegate through; the int (delivery-count probe) overload throws ONCE for the
+            // first message's settlement probe, then delegates through for any later use.
+            var probeCalls = new StrongBox<int>(0);
+            var recovery = new Mock<IRecoveryStrategy>();
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) =>
+                {
+                    if (Interlocked.Increment(ref probeCalls.Value) == 1)
+                    {
+                        throw new Exception("settlement probe failed");
+                    }
+                    return action();
+                });
+
+            infraReceiver.Enqueue(BuildContext());
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher, recovery: recovery);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: 10), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            // The second message must be acked despite the first message's settlement-probe failure, proving the slot
+            // was not leaked and the loop kept running.
+            await WaitUntilAsync(() => infraReceiver.CallLog.Contains(ReceiverCall.Ack), watchdog.Token);
+
+            cts.Cancel();
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop, "the loop must be unaffected by the swallowed settlement-probe failure and cancel cleanly");
+            await loop;
+
+            infraReceiver.CallLog.Should().Contain(ReceiverCall.Ack, "a later message must still process, proving the slot was not leaked");
+            probeCalls.Value.Should().BeGreaterThan(0, "the settlement probe must have been invoked and thrown");
+        }
+
+        // ------------------------------------------------------------------ (d) cancellation during recovery swallowed under the snapshotted token
+
+        [Fact]
+        public async Task MustSwallowCancellationDuringRecoveryUnderSnapshottedToken()
+        {
+            const int messageCount = 1;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            infraReceiver.DeliveryCount = 1;
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("handler boom"));
+
+            // The worker enters its recovery ladder and awaits the delivery-count probe (Func<Task<int>>). Hold that
+            // probe on a gate that honors the worker token, signalling that the worker is mid-recovery. The test then
+            // cancels the loop token (linked to the worker token); the gated probe throws OCE which the worker's
+            // recovery catch swallows under workerToken.IsCancellationRequested. No fault must escape; the loop completes.
+            var midRecovery = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            using var probeGate = new SemaphoreSlim(0, 1);
+
+            var recovery = new Mock<IRecoveryStrategy>();
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>(async (action, token) =>
+                {
+                    midRecovery.TrySetResult(true);
+                    // Honor the worker token so cancellation unwinds the probe with an OperationCanceledException.
+                    await probeGate.WaitAsync(token);
+                    return await action();
+                });
+
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher, recovery: recovery);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: 10), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            var midCompleted = await Task.WhenAny(midRecovery.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            midCompleted.Should().BeSameAs(midRecovery.Task, "the worker must reach the recovery probe and gate mid-recovery");
+
+            // Cancel while the worker is mid-recovery: the linked worker token cancels the gated probe, whose OCE the
+            // worker recovery catch swallows.
+            cts.Cancel();
+
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop, "cancellation during recovery must be swallowed and the loop must complete without faulting");
+            await loop; // must not throw
+
+            infraReceiver.CallLog.Should().NotContain(ReceiverCall.Ack, "the handler threw, so no Ack is expected");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenWorkerReportsCriticalFault.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenWorkerReportsCriticalFault.cs
@@ -1,0 +1,301 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Exceptions;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    // INVARIANT: a CriticalReceiverException raised inside a worker's DispatchAsync is published to the loop-observed
+    // fault field, stops the loop, and routes through the notify-exactly-once epilogue. These tests prove the worker ->
+    // loop fault hand-off (_workerCriticalFault + SignalLoopCriticalFault), the FailureContext shape handed to
+    // ICriticalFailureNotifier.Notify, and — critically — that Notify fires BEFORE the worker drain (the #149 fail-fast
+    // ordering), so an unbounded drain can never starve the host's critical-failure notification.
+    public class WhenWorkerReportsCriticalFault : Testing.Core.Context
+    {
+        private static MessageBrokerOptions BuildOptions(TransactionMode mode = TransactionMode.None)
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = mode;
+            return opts;
+        }
+
+        // INVARIANT: pass-through IRecoveryStrategy invokes the delegate exactly once, no retry machinery. A
+        // CriticalReceiverException thrown by the dispatched action therefore propagates straight to the worker's
+        // critical-fault catch rather than being absorbed by retry.
+        private static Mock<IRecoveryStrategy> PassThroughRecovery()
+        {
+            var mock = new Mock<IRecoveryStrategy>();
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+            return mock;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions(int maxConcurrentCalls)
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = 10,
+                MaxConcurrentCalls = maxConcurrentCalls,
+            };
+
+        private static MessageBrokerContext BuildContext()
+        {
+            var converter = new JsonBodyConverter();
+            var body = converter.Convert(new FakeMessage { Value = "hello" });
+            return new MessageBrokerContext(
+                messageId: Guid.NewGuid().ToString(),
+                body: body,
+                applicationProperties: new Dictionary<string, object>(),
+                messageReceiverPath: "test-queue",
+                receiverCancellationToken: CancellationToken.None,
+                bodyConverter: converter);
+        }
+
+        private BrokeredMessageReceiver<FakeMessage> CreateSut(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            Mock<IReceivedMessageDispatcher> dispatcher,
+            Mock<ICriticalFailureNotifier> criticalNotifier)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: new Mock<IMaxReceivesExceededAction>().Object,
+                criticalFailureNotifier: criticalNotifier.Object,
+                recoveryStrategy: PassThroughRecovery().Object,
+                receivedMessageDispatcher: dispatcher.Object);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken watchdog)
+        {
+            while (!predicate())
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------ (a) Notify fired once with the thrown exception + error-queue name, (b) loop stops
+
+        [Fact]
+        public async Task MustNotifyOnceWithCriticalFaultAndStopLoop()
+        {
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.Enqueue(BuildContext());
+
+            var thrown = new CriticalReceiverException("boom");
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(thrown);
+
+            FailureContext observedContext = null;
+            var notified = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var criticalNotifier = new Mock<ICriticalFailureNotifier>();
+            criticalNotifier
+                .Setup(n => n.Notify(It.IsAny<FailureContext>()))
+                .Returns((FailureContext ctx) =>
+                {
+                    observedContext = ctx;
+                    notified.TrySetResult(true);
+                    return Task.CompletedTask;
+                });
+
+            var sut = CreateSut(infraReceiver, dispatcher, criticalNotifier);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls: 1), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            var completed = await Task.WhenAny(notified.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            completed.Should().BeSameAs(notified.Task, "the worker critical fault must drive ICriticalFailureNotifier.Notify");
+            await notified.Task;
+
+            // The loop must stop on the fault: awaiting the StartReceiver task completes (the fault is swallowed by the
+            // when(IsReceiving) catch in StartReceiver, never propagated to the caller of a running loop).
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop, "the loop must stop after the critical fault");
+            await loop;
+
+            criticalNotifier.Verify(n => n.Notify(It.IsAny<FailureContext>()), Times.Once,
+                "the critical fault must notify exactly once");
+            observedContext.Should().NotBeNull();
+            observedContext.Failure.Should().BeSameAs(thrown, "the FailureContext must carry the thrown CriticalReceiverException");
+            observedContext.ErrorQueueName.Should().Be("error-queue", "the FailureContext must carry the receiver's ErrorQueueName");
+        }
+
+        // ------------------------------------------------------------------ (c) notify-BEFORE-worker-drain (#149 fail-fast ordering)
+
+        [Fact]
+        public async Task MustNotifyBeforeDrainingSiblingWorkers()
+        {
+            const int maxConcurrentCalls = 2;
+            const int messageCount = 2;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            // One worker faults critically; the OTHER (sibling) worker blocks indefinitely on a gate that is released
+            // ONLY from inside the Notify callback. If the implementation drained BEFORE notifying, the drain's
+            // Task.WhenAll would block forever on the gated sibling, the gate would never open, and the 15s watchdog
+            // would fire. The test passing therefore PROVES notify precedes drain. This is an ordering proof, NOT a
+            // timestamp comparison.
+            using var siblingReleaseGate = new SemaphoreSlim(0, 1);
+            var siblingEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var faultArmed = new StrongBox<int>(0);
+            var thrown = new CriticalReceiverException("boom");
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(async (FakeMessage _, MessageBrokerContext __, CancellationToken token) =>
+                {
+                    // The FIRST dispatched message becomes the critical-faulting worker; the second becomes the gated
+                    // sibling. Interlocked makes the assignment race-free regardless of which worker runs first. The
+                    // faulter waits until the sibling has actually entered (and thus is in the in-flight set) BEFORE
+                    // throwing, so the loop genuinely has a gated sibling to drain when it handles the fault.
+                    if (Interlocked.Increment(ref faultArmed.Value) == 1)
+                    {
+                        await siblingEntered.Task;
+                        throw thrown;
+                    }
+
+                    siblingEntered.TrySetResult(true);
+                    // INVARIANT: wait WITHOUT the worker token so cancellation (SignalLoopCriticalFault cancels the loop
+                    // token) can NOT unblock the sibling. The ONLY release is the Notify callback. If the impl drained
+                    // before notifying, Task.WhenAll would block here forever and the watchdog fires — that is what makes
+                    // this an ordering proof rather than a timestamp comparison.
+                    await siblingReleaseGate.WaitAsync();
+                });
+
+            var criticalNotifier = new Mock<ICriticalFailureNotifier>();
+            criticalNotifier
+                .Setup(n => n.Notify(It.IsAny<FailureContext>()))
+                .Returns((FailureContext _) =>
+                {
+                    // Release the gated sibling EXCLUSIVELY here. The drain that runs AFTER this notify can then
+                    // complete; if notify ran after drain, the drain would already be stuck on the gated sibling.
+                    siblingReleaseGate.Release();
+                    return Task.CompletedTask;
+                });
+
+            var sut = CreateSut(infraReceiver, dispatcher, criticalNotifier);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            // Ensure the sibling is actually in-flight (so the drain has something to wait on) before relying on the
+            // ordering. The watchdog converts a never-entered sibling into a prompt failure.
+            var siblingCompleted = await Task.WhenAny(siblingEntered.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            siblingCompleted.Should().BeSameAs(siblingEntered.Task, "the sibling worker must enter DispatchAsync and gate in-flight");
+
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop,
+                "the loop must notify BEFORE draining; draining first would deadlock on the gated sibling and never complete");
+            await loop;
+
+            criticalNotifier.Verify(n => n.Notify(It.IsAny<FailureContext>()), Times.Once);
+        }
+
+        // ------------------------------------------------------------------ (d) fault published while loop parked in WaitAsync still wakes the loop
+
+        [Fact]
+        public async Task MustWakeLoopParkedInWaitAsyncWhenFaultPublishedWithSlotsFull()
+        {
+            const int maxConcurrentCalls = 1;
+            const int messageCount = 1;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: messageCount);
+            for (var i = 0; i < messageCount; i++)
+                infraReceiver.Enqueue(BuildContext());
+
+            // With MaxConcurrentCalls == 1, once the single worker is admitted the loop's next WaitAsync parks (the only
+            // slot is taken). The worker then faults; SignalLoopCriticalFault cancels the loop token, which is what wakes
+            // the parked WaitAsync. The fault still routes to Notify exactly once. The watchdog catches a regression
+            // where the parked loop never wakes.
+            var entered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var releaseFault = new SemaphoreSlim(0, 1);
+            var thrown = new CriticalReceiverException("boom");
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(async (FakeMessage _, MessageBrokerContext __, CancellationToken token) =>
+                {
+                    entered.TrySetResult(true);
+                    // Hold the worker (and thus the only slot) so the loop parks in its next WaitAsync, then fault.
+                    await releaseFault.WaitAsync(token);
+                    throw thrown;
+                });
+
+            var notified = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var criticalNotifier = new Mock<ICriticalFailureNotifier>();
+            criticalNotifier
+                .Setup(n => n.Notify(It.IsAny<FailureContext>()))
+                .Returns((FailureContext _) =>
+                {
+                    notified.TrySetResult(true);
+                    return Task.CompletedTask;
+                });
+
+            var sut = CreateSut(infraReceiver, dispatcher, criticalNotifier);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxConcurrentCalls), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            var enteredCompleted = await Task.WhenAny(entered.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            enteredCompleted.Should().BeSameAs(entered.Task, "the worker must occupy the only slot so the loop parks in WaitAsync");
+
+            // Give the loop a chance to reach its parked WaitAsync, then release the worker so it faults while the loop
+            // is parked.
+            await Task.Yield();
+            releaseFault.Release();
+
+            var notifiedCompleted = await Task.WhenAny(notified.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            notifiedCompleted.Should().BeSameAs(notified.Task,
+                "a fault published while the loop is parked in WaitAsync must still wake the loop and route to Notify");
+            await notified.Task;
+
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop, "the loop must complete after the parked-loop fault is handled");
+            await loop;
+
+            criticalNotifier.Verify(n => n.Notify(It.IsAny<FailureContext>()), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds **5 new unit-test files (16 tests)** to `Chatter.MessageBrokers.Tests` covering the previously-uncovered concurrency hot path of `Receiving/BrokeredMessageReceiver.cs` (was 57.6%, 175 lines uncovered — rewritten 4× recently for concurrency in #146–#149).

Closes #151.

## Coverage added
- **Parallel receive loop** honoring `MaxConcurrentCalls` (teardown/shutdown surface).
- **Critical-fault notification fires BEFORE worker drain** — the #149 race, proven by an ordering gate released only from inside the `Notify` callback (a drain-first regression deadlocks past a 15s watchdog; not a timestamp comparison).
- **Graceful shutdown / cancellation**: `StopReceiver()` drain, `DisposeAsync()` drain, synchronous `Dispose()` quiesce-without-deadlock (off any SynchronizationContext).
- **Faulted-loop belt-and-suspenders drain** — `StopReceiver` skips the faulted-loop await and runs the finally drain.
- **Per-worker error ladder** with snapshotted `CancellationToken`: Nack < Max, Deadletter + `MaxReceivesExceededAction` ≥ Max, settlement-probe failure critical-log path, cancellation-during-recovery swallowed.
- **`MaxConcurrentCalls < 1` startup guard** — `StartReceiver` throws `InvalidOperationException` (startup-fatal, not swallowed).

## Files
- `src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenShuttingDownGracefully.cs`
- `src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenWorkerReportsCriticalFault.cs`
- `src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiveLoopFaults.cs`
- `src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenWorkerErrorLadderRuns.cs`
- `src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenMisconfigured.cs`

**Test-only** — no production code change, no csproj edits.

## Validation
`dotnet test Chatter.sln` — **0 failures** across all 7 modules on net8.0 + net10.0. `Chatter.MessageBrokers.Tests` 489 → 505 (20 skipped are the pre-existing ASB emulator integration tests, unrelated).

## Follow-up note (observation only — no change in this PR)
Tests surfaced that `DisposeAsync()` is **not idempotent**: a second call throws `ObjectDisposedException` because it unconditionally cancels an already-disposed CTS, whereas synchronous `Dispose()` is `_disposedValue`-guarded. No production change made here; candidate for a follow-up guard symmetric to the sync path.
