### PR TITLE
test(messagebrokers): routing-slip / saga-compensation coverage (#153)

### DIFF
--- a/src/Chatter.MessageBrokers/tests/Routing/Context/UsingCompensationRoutingContext/WhenConstructing.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Context/UsingCompensationRoutingContext/WhenConstructing.cs
@@ -1,0 +1,50 @@
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.Routing.Context;
+using FluentAssertions;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Context.UsingCompensationRoutingContext
+{
+    public class WhenConstructing : Testing.Core.Context
+    {
+        [Fact]
+        public void MustMapDestinationPathFromShortConstructor()
+            => new CompensationRoutingContext("destination").DestinationPath.Should().Be("destination");
+
+        [Fact]
+        public void MustCreateContainerFromShortConstructor()
+            => new CompensationRoutingContext("destination").Container.Should().NotBeNull();
+
+        [Fact]
+        public void MustDefaultCompensateDetailsAndDescriptionToEmptyFromShortConstructor()
+        {
+            var sut = new CompensationRoutingContext("destination");
+            sut.CompensateDetails.Should().BeEmpty();
+            sut.CompensateDescription.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void MustMapDestinationPathFromFullConstructor()
+            => new CompensationRoutingContext("destination", "details", "description").DestinationPath.Should().Be("destination");
+
+        [Fact]
+        public void MustMapDetailsAndDescriptionFromFullConstructor()
+        {
+            var sut = new CompensationRoutingContext("destination", "details", "description");
+            sut.CompensateDetails.Should().Be("details");
+            sut.CompensateDescription.Should().Be("description");
+        }
+
+        [Fact]
+        public void MustCreateContainerInheritingFromProvidedContext()
+        {
+            var inheritedContext = new ContextContainer();
+            inheritedContext.Include("inherited-value");
+
+            var sut = new CompensationRoutingContext("destination", "details", "description", inheritedContext);
+
+            sut.Container.TryGet<string>(out var inheritedValue).Should().BeTrue();
+            inheritedValue.Should().Be("inherited-value");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Context/UsingCompensationRoutingContext/WhenSettingDetailsAndDescription.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Context/UsingCompensationRoutingContext/WhenSettingDetailsAndDescription.cs
@@ -1,0 +1,58 @@
+using Chatter.MessageBrokers.Routing.Context;
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Context.UsingCompensationRoutingContext
+{
+    public class WhenSettingDetailsAndDescription : Testing.Core.Context
+    {
+        private static CompensationRoutingContext CreateSut()
+            => new CompensationRoutingContext("destination");
+
+        [Fact]
+        public void MustUpdateCompensateDetails()
+            => CreateSut().SetDetails("the-details").CompensateDetails.Should().Be("the-details");
+
+        [Fact]
+        public void MustReturnSameInstanceFromSetDetails()
+        {
+            var sut = CreateSut();
+            sut.SetDetails("the-details").Should().BeSameAs(sut);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void MustThrowArgumentExceptionWhenDetailsIsNullOrWhitespace(string details)
+            => FluentActions.Invoking(() => CreateSut().SetDetails(details))
+                .Should().Throw<ArgumentException>();
+
+        [Fact]
+        public void MustUpdateCompensateDescription()
+            => CreateSut().SetDescription("the-description").CompensateDescription.Should().Be("the-description");
+
+        [Fact]
+        public void MustReturnSameInstanceFromSetDescription()
+        {
+            var sut = CreateSut();
+            sut.SetDescription("the-description").Should().BeSameAs(sut);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void MustThrowArgumentExceptionWhenDescriptionIsNullOrWhitespace(string description)
+            => FluentActions.Invoking(() => CreateSut().SetDescription(description))
+                .Should().Throw<ArgumentException>();
+
+        [Fact]
+        public void MustFormatToStringAsDescriptionArrowDetails()
+        {
+            var sut = new CompensationRoutingContext("destination", "the-details", "the-description");
+            sut.ToString().Should().Be("the-description -> the-details");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/RoutingSlipDispatcherMock.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/RoutingSlipDispatcherMock.cs
@@ -1,0 +1,32 @@
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Routing.Options;
+using Chatter.MessageBrokers.Sending;
+using Moq;
+using System.Threading.Tasks;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Slips
+{
+    internal static class RoutingSlipDispatcherMock
+    {
+        // INVARIANT: Send<TMessage> is a strongly-typed generic overload, so Moq matches the setup per
+        // concrete TMessage. The factory MUST be generic over each fixture's FakeMessage type, otherwise
+        // the setup would not match the strongly-typed call and the routing-slip await would observe a
+        // null Task (NullReferenceException) before assertions run.
+        public static Mock<IBrokeredMessageDispatcher> Completed<TMessage>() where TMessage : ICommand
+        {
+            var dispatcher = new Mock<IBrokeredMessageDispatcher>();
+
+            dispatcher
+                .Setup(d => d.Send(It.IsAny<TMessage>(), It.IsAny<string>(), It.IsAny<TransactionContext>(), It.IsAny<SendOptions>()))
+                .Returns(Task.CompletedTask);
+
+            dispatcher
+                .Setup(d => d.Forward(It.IsAny<InboundBrokeredMessage>(), It.IsAny<string>(), It.IsAny<TransactionContext>()))
+                .Returns(Task.CompletedTask);
+
+            return dispatcher;
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenForwarding.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenForwarding.cs
@@ -16,7 +16,12 @@ namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingBrokeredMessageDispatc
         private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
 
         public WhenForwarding()
-            => _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+        {
+            _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+            _dispatcher
+                .Setup(d => d.Forward(It.IsAny<InboundBrokeredMessage>(), It.IsAny<string>(), It.IsAny<TransactionContext>()))
+                .Returns(Task.CompletedTask);
+        }
 
         private InboundBrokeredMessage CreateInbound()
             => new InboundBrokeredMessage("message-id", new byte[] { 1 }, new Dictionary<string, object>(), "receiver-path", _bodyConverter.Object);

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenForwarding.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenForwarding.cs
@@ -1,0 +1,66 @@
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Routing.Slips;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingBrokeredMessageDispatcherExtensions
+{
+    public class WhenForwarding : Testing.Core.Context
+    {
+        private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+
+        public WhenForwarding()
+            => _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+
+        private InboundBrokeredMessage CreateInbound()
+            => new InboundBrokeredMessage("message-id", new byte[] { 1 }, new Dictionary<string, object>(), "receiver-path", _bodyConverter.Object);
+
+        private static RoutingSlip CreateSlip()
+            => RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid())
+                .WithRoute("first")
+                .WithRoute("second")
+                .Build();
+
+        [Fact]
+        public async Task MustRouteSlipToNextStepShrinkingRouteAndGrowingVisited()
+        {
+            var slip = CreateSlip();
+
+            await _dispatcher.Object.Forward(CreateInbound(), slip, new TransactionContext());
+
+            slip.Route.Should().HaveCount(1);
+            slip.Route[0].DestinationPath.Should().Be("second");
+            slip.Visited.Should().HaveCount(1);
+            slip.Visited[0].DestinationPath.Should().Be("first");
+        }
+
+        [Fact]
+        public async Task MustForwardToHeadDestination()
+        {
+            var slip = CreateSlip();
+            var inbound = CreateInbound();
+            var transactionContext = new TransactionContext();
+
+            await _dispatcher.Object.Forward(inbound, slip, transactionContext);
+
+            _dispatcher.Verify(d => d.Forward(inbound, "first", transactionContext), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustAttachSlipToInboundBrokeredMessage()
+        {
+            var slip = CreateSlip();
+            var inbound = CreateInbound();
+
+            await _dispatcher.Object.Forward(inbound, slip, new TransactionContext());
+
+            inbound.MessageContext.Should().ContainKey(MessageContext.RoutingSlip);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenForwarding.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenForwarding.cs
@@ -1,3 +1,4 @@
+using Chatter.CQRS.Commands;
 using Chatter.MessageBrokers.Context;
 using Chatter.MessageBrokers.Receiving;
 using Chatter.MessageBrokers.Routing.Slips;
@@ -13,15 +14,10 @@ namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingBrokeredMessageDispatc
     public class WhenForwarding : Testing.Core.Context
     {
         private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
-        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = RoutingSlipDispatcherMock.Completed<FakeMessage>();
 
         public WhenForwarding()
-        {
-            _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
-            _dispatcher
-                .Setup(d => d.Forward(It.IsAny<InboundBrokeredMessage>(), It.IsAny<string>(), It.IsAny<TransactionContext>()))
-                .Returns(Task.CompletedTask);
-        }
+            => _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
 
         private InboundBrokeredMessage CreateInbound()
             => new InboundBrokeredMessage("message-id", new byte[] { 1 }, new Dictionary<string, object>(), "receiver-path", _bodyConverter.Object);
@@ -67,5 +63,7 @@ namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingBrokeredMessageDispatc
 
             inbound.MessageContext.Should().ContainKey(MessageContext.RoutingSlip);
         }
+
+        private class FakeMessage : ICommand { }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenSending.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenSending.cs
@@ -1,0 +1,82 @@
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Routing.Options;
+using Chatter.MessageBrokers.Routing.Slips;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingBrokeredMessageDispatcherExtensions
+{
+    public class WhenSending : Testing.Core.Context
+    {
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+        private readonly FakeMessage _message = new FakeMessage();
+
+        private static RoutingSlip CreateSlip()
+            => RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid())
+                .WithRoute("first")
+                .WithRoute("second")
+                .Build();
+
+        [Fact]
+        public async Task MustRouteSlipToNextStepShrinkingRouteAndGrowingVisited()
+        {
+            var slip = CreateSlip();
+
+            await _dispatcher.Object.Send(_message, slip);
+
+            slip.Route.Should().HaveCount(1);
+            slip.Route[0].DestinationPath.Should().Be("second");
+            slip.Visited.Should().HaveCount(1);
+            slip.Visited[0].DestinationPath.Should().Be("first");
+        }
+
+        [Fact]
+        public async Task MustDispatchToHeadDestination()
+        {
+            var slip = CreateSlip();
+
+            await _dispatcher.Object.Send(_message, slip);
+
+            _dispatcher.Verify(
+                d => d.Send(_message, "first", It.IsAny<TransactionContext>(), It.IsAny<SendOptions>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task MustAttachSlipToSendOptionsMessageContext()
+        {
+            var slip = CreateSlip();
+            SendOptions capturedOptions = null;
+            _dispatcher
+                .Setup(d => d.Send(_message, It.IsAny<string>(), It.IsAny<TransactionContext>(), It.IsAny<SendOptions>()))
+                .Callback<FakeMessage, string, TransactionContext, SendOptions>((_, _, _, options) => capturedOptions = options)
+                .Returns(Task.CompletedTask);
+
+            await _dispatcher.Object.Send(_message, slip);
+
+            capturedOptions.Should().NotBeNull();
+            capturedOptions.MessageContext.Should().ContainKey(MessageContext.RoutingSlip);
+        }
+
+        [Fact]
+        public async Task MustCreateDefaultSendOptionsWhenNullPassed()
+        {
+            var slip = CreateSlip();
+            SendOptions capturedOptions = null;
+            _dispatcher
+                .Setup(d => d.Send(_message, It.IsAny<string>(), It.IsAny<TransactionContext>(), It.IsAny<SendOptions>()))
+                .Callback<FakeMessage, string, TransactionContext, SendOptions>((_, _, _, options) => capturedOptions = options)
+                .Returns(Task.CompletedTask);
+
+            await _dispatcher.Object.Send(_message, slip, options: null);
+
+            capturedOptions.Should().NotBeNull();
+        }
+
+        private class FakeMessage : ICommand { }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenSending.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenSending.cs
@@ -12,13 +12,8 @@ namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingBrokeredMessageDispatc
 {
     public class WhenSending : Testing.Core.Context
     {
-        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = RoutingSlipDispatcherMock.Completed<FakeMessage>();
         private readonly FakeMessage _message = new FakeMessage();
-
-        public WhenSending()
-            => _dispatcher
-                .Setup(d => d.Send(It.IsAny<FakeMessage>(), It.IsAny<string>(), It.IsAny<TransactionContext>(), It.IsAny<SendOptions>()))
-                .Returns(Task.CompletedTask);
 
         private static RoutingSlip CreateSlip()
             => RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid())

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenSending.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingBrokeredMessageDispatcherExtensions/WhenSending.cs
@@ -15,6 +15,11 @@ namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingBrokeredMessageDispatc
         private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
         private readonly FakeMessage _message = new FakeMessage();
 
+        public WhenSending()
+            => _dispatcher
+                .Setup(d => d.Send(It.IsAny<FakeMessage>(), It.IsAny<string>(), It.IsAny<TransactionContext>(), It.IsAny<SendOptions>()))
+                .Returns(Task.CompletedTask);
+
         private static RoutingSlip CreateSlip()
             => RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid())
                 .WithRoute("first")

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingMessageHandlerContextExtensions/WhenAddingRoutingSlip.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingMessageHandlerContextExtensions/WhenAddingRoutingSlip.cs
@@ -1,0 +1,33 @@
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Routing.Slips;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingMessageHandlerContextExtensions
+{
+    public class WhenAddingRoutingSlip : Testing.Core.Context
+    {
+        private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+
+        public WhenAddingRoutingSlip()
+            => _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+
+        private MessageBrokerContext CreateContext()
+            => new MessageBrokerContext("message-id", new byte[] { 1 }, new Dictionary<string, object>(), "receiver-path", CancellationToken.None, _bodyConverter.Object);
+
+        [Fact]
+        public void MustIncludeSlipInContainer()
+        {
+            var context = CreateContext();
+            var slip = RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid()).Build();
+
+            context.AddRoutingSlip(slip);
+
+            context.Container.TryGet<RoutingSlip>(out var includedSlip).Should().BeTrue();
+            includedSlip.Should().BeSameAs(slip);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingMessageHandlerContextExtensions/WhenSendingAndForwarding.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingMessageHandlerContextExtensions/WhenSendingAndForwarding.cs
@@ -17,7 +17,7 @@ namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingMessageHandlerContextE
     public class WhenSendingAndForwarding : Testing.Core.Context
     {
         private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
-        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = RoutingSlipDispatcherMock.Completed<FakeMessage>();
         private readonly FakeMessage _message = new FakeMessage();
 
         public WhenSendingAndForwarding()

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingMessageHandlerContextExtensions/WhenSendingAndForwarding.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingMessageHandlerContextExtensions/WhenSendingAndForwarding.cs
@@ -1,0 +1,102 @@
+using Chatter.CQRS;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Routing.Options;
+using Chatter.MessageBrokers.Routing.Slips;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingMessageHandlerContextExtensions
+{
+    public class WhenSendingAndForwarding : Testing.Core.Context
+    {
+        private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+        private readonly FakeMessage _message = new FakeMessage();
+
+        public WhenSendingAndForwarding()
+            => _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+
+        private MessageBrokerContext CreateContext()
+            => new MessageBrokerContext("message-id", new byte[] { 1 }, new Dictionary<string, object>(), "receiver-path", CancellationToken.None, _bodyConverter.Object);
+
+        private void IncludeDispatcher(MessageBrokerContext context)
+            => context.Container.Include<IExternalDispatcher>(_dispatcher.Object);
+
+        private static RoutingSlip CreateSlip()
+            => RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid())
+                .WithRoute("first")
+                .WithRoute("second")
+                .Build();
+
+        [Fact]
+        public async Task MustDelegateSendToDispatcherWhenPresent()
+        {
+            var context = CreateContext();
+            IncludeDispatcher(context);
+            var slip = CreateSlip();
+
+            await context.Send(_message, slip);
+
+            _dispatcher.Verify(
+                d => d.Send(_message, "first", It.IsAny<TransactionContext>(), It.IsAny<SendOptions>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task MustReturnCompletedTaskWithoutDispatchingSendWhenNoDispatcherPresent()
+        {
+            var context = CreateContext();
+            var slip = CreateSlip();
+
+            await context.Send(_message, slip);
+
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task MustForwardThroughDispatcherWhenPresentAndHeadIsNonEmpty()
+        {
+            var context = CreateContext();
+            IncludeDispatcher(context);
+            var slip = CreateSlip();
+
+            await context.Forward(slip);
+
+            _dispatcher.Verify(
+                d => d.Forward(It.IsAny<InboundBrokeredMessage>(), "first", It.IsAny<TransactionContext>()),
+                Times.Once);
+        }
+
+        [Fact]
+        public async Task MustNotForwardWhenRouteIsEmpty()
+        {
+            var context = CreateContext();
+            IncludeDispatcher(context);
+            var slip = RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid()).Build();
+
+            await context.Forward(slip);
+
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task MustNotForwardWhenNoDispatcherPresent()
+        {
+            var context = CreateContext();
+            var slip = CreateSlip();
+
+            await context.Forward(slip);
+
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        private class FakeMessage : ICommand { }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingMessageHandlerContextExtensions/WhenTryingToGetRoutingSlip.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingMessageHandlerContextExtensions/WhenTryingToGetRoutingSlip.cs
@@ -1,0 +1,80 @@
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Routing.Slips;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingMessageHandlerContextExtensions
+{
+    public class WhenTryingToGetRoutingSlip : Testing.Core.Context
+    {
+        private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+
+        public WhenTryingToGetRoutingSlip()
+            => _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+
+        private MessageBrokerContext CreateContext(IDictionary<string, object> messageContext)
+            => new MessageBrokerContext("message-id", new byte[] { 1 }, messageContext, "receiver-path", CancellationToken.None, _bodyConverter.Object);
+
+        [Fact]
+        public void MustReturnTrueAndSlipWhenBrokerContextCarriesSerializedSlip()
+        {
+            var slip = RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid())
+                .WithRoute("first")
+                .Build();
+            var context = CreateContext(new Dictionary<string, object>());
+            context.BrokeredMessage.WithRoutingSlip(slip);
+
+            IMessageHandlerContext asHandlerContext = context;
+            var found = asHandlerContext.TryGetRoutingSlip(out var foundSlip);
+
+            found.Should().BeTrue();
+            foundSlip.Should().NotBeNull();
+            foundSlip.Route[0].DestinationPath.Should().Be("first");
+        }
+
+        [Fact]
+        public void MustReturnFalseWhenContextIsNotBrokerContext()
+        {
+            var nonBrokerContext = new Mock<IMessageHandlerContext>().Object;
+
+            var found = nonBrokerContext.TryGetRoutingSlip(out var foundSlip);
+
+            found.Should().BeFalse();
+            foundSlip.Should().BeNull();
+        }
+
+        [Fact]
+        public void MustReturnFalseWhenNoSlipPresent()
+        {
+            var context = CreateContext(new Dictionary<string, object>());
+
+            IMessageHandlerContext asHandlerContext = context;
+            var found = asHandlerContext.TryGetRoutingSlip(out var foundSlip);
+
+            found.Should().BeFalse();
+            foundSlip.Should().BeNull();
+        }
+
+        [Fact]
+        public void MustReturnFalseInsteadOfThrowingOnMalformedSlipValue()
+        {
+            // INVARIANT: TryGetRoutingSlip swallows deserialize exceptions. A non-string value under the
+            // RoutingSlip key makes the (string) cast / deserialize throw, which must surface as false.
+            var messageContext = new Dictionary<string, object>
+            {
+                [MessageContext.RoutingSlip] = 12345
+            };
+            var context = CreateContext(messageContext);
+
+            IMessageHandlerContext asHandlerContext = context;
+            var found = asHandlerContext.TryGetRoutingSlip(out var foundSlip);
+
+            found.Should().BeFalse();
+            foundSlip.Should().BeNull();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingRoutingSlipBehavior/WhenHandling.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingRoutingSlipBehavior/WhenHandling.cs
@@ -19,7 +19,7 @@ namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingRoutingSlipBehavior
     public class WhenHandling : Testing.Core.Context
     {
         private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
-        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = RoutingSlipDispatcherMock.Completed<FakeMessage>();
         private readonly RoutingSlipBehavior<FakeMessage> _sut
             = new RoutingSlipBehavior<FakeMessage>(NullLogger<RoutingSlipBehavior<FakeMessage>>.Instance);
         private readonly FakeMessage _message = new FakeMessage();

--- a/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingRoutingSlipBehavior/WhenHandling.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Slips/UsingRoutingSlipBehavior/WhenHandling.cs
@@ -1,0 +1,114 @@
+using Chatter.CQRS;
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.CQRS.Pipeline;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Routing.Options;
+using Chatter.MessageBrokers.Routing.Slips;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Slips.UsingRoutingSlipBehavior
+{
+    public class WhenHandling : Testing.Core.Context
+    {
+        private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+        private readonly RoutingSlipBehavior<FakeMessage> _sut
+            = new RoutingSlipBehavior<FakeMessage>(NullLogger<RoutingSlipBehavior<FakeMessage>>.Instance);
+        private readonly FakeMessage _message = new FakeMessage();
+
+        public WhenHandling()
+            => _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+
+        // The behavior reads the slip via a FRESH deserialize from the message context, so the slip
+        // that gets advanced and sent is NOT the builder instance. Seed the serialized slip into the
+        // message-context dictionary through the production WithRoutingSlip serialize seam.
+        private MessageBrokerContext CreateBrokerContextWithSerializedSlip(RoutingSlip slip)
+        {
+            var messageContext = new Dictionary<string, object>();
+            var context = CreateBrokerContext(messageContext);
+            context.BrokeredMessage.WithRoutingSlip(slip);
+            return context;
+        }
+
+        private MessageBrokerContext CreateBrokerContext(IDictionary<string, object> messageContext)
+            => new MessageBrokerContext("message-id", new byte[] { 1 }, messageContext, "receiver-path", CancellationToken.None, _bodyConverter.Object);
+
+        private void IncludeDispatcher(MessageBrokerContext context)
+            => context.Container.Include<IExternalDispatcher>(_dispatcher.Object);
+
+        [Fact]
+        public async Task MustInvokeNextOnceWithoutSendingWhenContextIsNotMessageBrokerContext()
+        {
+            var nonBrokerContext = new Mock<IMessageHandlerContext>().Object;
+            var nextCount = 0;
+            CommandHandlerDelegate next = () => { nextCount++; return Task.CompletedTask; };
+
+            await _sut.Handle(_message, nonBrokerContext, next);
+
+            nextCount.Should().Be(1);
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task MustInvokeNextOnceWithoutSendingWhenNoRoutingSlipPresent()
+        {
+            var context = CreateBrokerContext(new Dictionary<string, object>());
+            IncludeDispatcher(context);
+            var nextCount = 0;
+            CommandHandlerDelegate next = () => { nextCount++; return Task.CompletedTask; };
+
+            await _sut.Handle(_message, context, next);
+
+            nextCount.Should().Be(1);
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task MustInvokeNextOnceAndIncludeSlipInContainerWithoutSendingWhenRouteIsEmpty()
+        {
+            var slip = RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid()).Build();
+            var context = CreateBrokerContextWithSerializedSlip(slip);
+            IncludeDispatcher(context);
+            var nextCount = 0;
+            CommandHandlerDelegate next = () => { nextCount++; return Task.CompletedTask; };
+
+            await _sut.Handle(_message, context, next);
+
+            nextCount.Should().Be(1);
+            context.Container.TryGet<RoutingSlip>(out _).Should().BeTrue();
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task MustInvokeNextOnceAndForwardMessageToNextDestinationWhenRouteIsNonEmpty()
+        {
+            var slip = RoutingSlipBuilder.NewRoutingSlip(System.Guid.NewGuid())
+                .WithRoute("first")
+                .WithRoute("second")
+                .Build();
+            var context = CreateBrokerContextWithSerializedSlip(slip);
+            IncludeDispatcher(context);
+            var nextCount = 0;
+            CommandHandlerDelegate next = () => { nextCount++; return Task.CompletedTask; };
+
+            await _sut.Handle(_message, context, next);
+
+            nextCount.Should().Be(1);
+            // The slip path routes via the IBrokeredMessageDispatcher.Send(TMessage, string, TransactionContext, SendOptions)
+            // overload to the head destination. Verify THAT specific overload (4 overloads exist).
+            _dispatcher.Verify(
+                d => d.Send(_message, "first", It.IsAny<TransactionContext>(), It.IsAny<SendOptions>()),
+                Times.Once);
+        }
+
+        private class FakeMessage : ICommand { }
+    }
+}


### PR DESCRIPTION
Adds unit-test coverage for the routing-slip / saga-compensation feature (previously 0%), per issue #153. The feature is a confirmed shipped public opt-in API (`WithRoutingSlipBehavior`, `WithRoutingSlip`, `AddRoutingSlip`) with serializer support — tested, not removed.

## What

7 new test files (34 test methods) in `Chatter.MessageBrokers.Tests`:

- **RoutingSlipBehavior.Handle** — non-broker context, no-slip, empty-route (slip in container), non-empty route forwards to next destination via the `Send(msg, dest, TransactionContext, SendOptions)` overload.
- **BrokeredMessageDispatcherExtensions** — `Send`/`Forward` advance the slip via `RouteToNextStep()` (Route shrinks / Visited grows), attach the slip to the message context, dispatch to the head destination; default `SendOptions` when null.
- **Slips MessageHandlerContextExtensions** — `AddRoutingSlip` includes slip in container; `TryGetRoutingSlip` true/false (and false-not-throw on malformed value); `Send`/`Forward` delegate when a dispatcher is present, no-op otherwise.
- **CompensationRoutingContext** — both constructors set `DestinationPath`/`Container` and default details/description empty; `SetDetails`/`SetDescription` mutate, return same instance, throw `ArgumentException` on null/whitespace; `ToString()` format.

## Notes

- Test-only, additive. No production code changed. Test csproj globs `*.cs`; no csproj edit.
- "Compensation unwinds in reverse order" maps to `RoutingSlip.Visited` forward-ordering + `CompensationRoutingContext` state — there is no production reverse-iteration construct, so none is asserted.

## Validation

`dotnet test Chatter.sln` — 0 failures. `Chatter.MessageBrokers.Tests` 527/527 on net8.0 and net10.0.

Closes #153.