### PR TITLE
test(messagebrokers): unit coverage for MessagingInfrastructureProvider (#156)

### DIFF
--- a/src/Chatter.MessageBrokers/tests/UsingMessagingInfrastructureProvider/WhenConstructing.cs
+++ b/src/Chatter.MessageBrokers/tests/UsingMessagingInfrastructureProvider/WhenConstructing.cs
@@ -1,0 +1,39 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.UsingMessagingInfrastructureProvider
+{
+    public class WhenConstructing : Testing.Core.Context
+    {
+        private readonly Mock<IMessagingInfrastructure> _firstInfrastructure = new Mock<IMessagingInfrastructure>();
+        private readonly Mock<IMessagingInfrastructure> _secondInfrastructure = new Mock<IMessagingInfrastructure>();
+        private readonly Mock<ILogger<MessagingInfrastructureProvider>> _logger = new Mock<ILogger<MessagingInfrastructureProvider>>();
+
+        public WhenConstructing()
+        {
+            _firstInfrastructure.SetupGet(i => i.Type).Returns("first");
+            _secondInfrastructure.SetupGet(i => i.Type).Returns("second");
+        }
+
+        [Fact]
+        public void MustThrowWhenLoggerIsNull()
+            => FluentActions.Invoking(() => new MessagingInfrastructureProvider(
+                    new[] { _firstInfrastructure.Object },
+                    null))
+                .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public void MustSetFirstInfrastructureAsDefault()
+        {
+            var sut = new MessagingInfrastructureProvider(
+                new List<IMessagingInfrastructure> { _firstInfrastructure.Object, _secondInfrastructure.Object },
+                _logger.Object);
+
+            sut.GetInfrastructure(null).Should().BeSameAs(_firstInfrastructure.Object);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/UsingMessagingInfrastructureProvider/WhenGettingInfrastructure.cs
+++ b/src/Chatter.MessageBrokers/tests/UsingMessagingInfrastructureProvider/WhenGettingInfrastructure.cs
@@ -1,0 +1,67 @@
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.UsingMessagingInfrastructureProvider
+{
+    public class WhenGettingInfrastructure : Testing.Core.Context
+    {
+        private readonly Mock<IMessagingInfrastructure> _firstInfrastructure = new Mock<IMessagingInfrastructure>();
+        private readonly Mock<IMessagingInfrastructure> _secondInfrastructure = new Mock<IMessagingInfrastructure>();
+        private readonly Mock<ILogger<MessagingInfrastructureProvider>> _logger = new Mock<ILogger<MessagingInfrastructureProvider>>();
+
+        public WhenGettingInfrastructure()
+        {
+            _firstInfrastructure.SetupGet(i => i.Type).Returns("first");
+            _secondInfrastructure.SetupGet(i => i.Type).Returns("second");
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        public void MustReturnDefaultWhenTypeIsNullOrWhitespace(string type)
+        {
+            var sut = new MessagingInfrastructureProvider(
+                new List<IMessagingInfrastructure> { _firstInfrastructure.Object, _secondInfrastructure.Object },
+                _logger.Object);
+
+            sut.GetInfrastructure(type).Should().BeSameAs(_firstInfrastructure.Object);
+        }
+
+        [Fact]
+        public void MustResolveInfrastructureByType()
+        {
+            var sut = new MessagingInfrastructureProvider(
+                new List<IMessagingInfrastructure> { _firstInfrastructure.Object, _secondInfrastructure.Object },
+                _logger.Object);
+
+            sut.GetInfrastructure("second").Should().BeSameAs(_secondInfrastructure.Object);
+        }
+
+        [Fact]
+        public void MustThrowKeyNotFoundWhenTypeIsUnknown()
+        {
+            var sut = new MessagingInfrastructureProvider(
+                new List<IMessagingInfrastructure> { _firstInfrastructure.Object },
+                _logger.Object);
+
+            FluentActions.Invoking(() => sut.GetInfrastructure("unknown"))
+                .Should().Throw<KeyNotFoundException>();
+        }
+
+        [Fact]
+        public void MustThrowInvalidOperationWhenNoInfrastructureRegistered()
+        {
+            var sut = new MessagingInfrastructureProvider(
+                new List<IMessagingInfrastructure>(),
+                _logger.Object);
+
+            FluentActions.Invoking(() => sut.GetInfrastructure("anything"))
+                .Should().Throw<InvalidOperationException>();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/UsingMessagingInfrastructureProvider/WhenGettingReceiverAndDispatcher.cs
+++ b/src/Chatter.MessageBrokers/tests/UsingMessagingInfrastructureProvider/WhenGettingReceiverAndDispatcher.cs
@@ -1,0 +1,38 @@
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.UsingMessagingInfrastructureProvider
+{
+    public class WhenGettingReceiverAndDispatcher : Testing.Core.Context
+    {
+        private readonly Mock<IMessagingInfrastructure> _infrastructure = new Mock<IMessagingInfrastructure>();
+        private readonly Mock<IMessagingInfrastructureReceiver> _receiver = new Mock<IMessagingInfrastructureReceiver>();
+        private readonly Mock<IMessagingInfrastructureDispatcher> _dispatcher = new Mock<IMessagingInfrastructureDispatcher>();
+        private readonly Mock<ILogger<MessagingInfrastructureProvider>> _logger = new Mock<ILogger<MessagingInfrastructureProvider>>();
+        private readonly MessagingInfrastructureProvider _sut;
+
+        public WhenGettingReceiverAndDispatcher()
+        {
+            _infrastructure.SetupGet(i => i.Type).Returns("test");
+            _infrastructure.SetupGet(i => i.ReceiveInfrastructure).Returns(_receiver.Object);
+            _infrastructure.SetupGet(i => i.DispatchInfrastructure).Returns(_dispatcher.Object);
+
+            _sut = new MessagingInfrastructureProvider(
+                new List<IMessagingInfrastructure> { _infrastructure.Object },
+                _logger.Object);
+        }
+
+        [Fact]
+        public void MustReturnReceiveInfrastructureForType()
+            => _sut.GetReceiver("test").Should().BeSameAs(_receiver.Object);
+
+        [Fact]
+        public void MustReturnDispatchInfrastructureForType()
+            => _sut.GetDispatcher("test").Should().BeSameAs(_dispatcher.Object);
+    }
+}


### PR DESCRIPTION
Closes #156.

## What

Adds unit-test coverage for `MessagingInfrastructureProvider` (previously 0%).

8 xUnit tests across 3 new classes under `src/Chatter.MessageBrokers/tests/UsingMessagingInfrastructureProvider/`:

- **WhenConstructing** — null-logger guard (`ArgumentNullException`); first-registered infrastructure becomes the default.
- **WhenGettingInfrastructure** — default fallback on null/whitespace type; resolve-by-type; unknown type → `KeyNotFoundException`; empty registry → `InvalidOperationException`.
- **WhenGettingReceiverAndDispatcher** — `GetReceiver`/`GetDispatcher` delegate to the resolved infrastructure's `ReceiveInfrastructure`/`DispatchInfrastructure` (receiver-vs-sender path).

## Notes

- Test-only. No production code change. No version bump.
- xUnit + FluentAssertions + Moq, matching existing `Using<Type>/When<Behavior>` conventions.
- `dotnet test` green on net8.0 and net10.0; no regressions.

Brood strain of `brood-25e091cb-bc88-4a50-9c2e-e18ce8c1cea4`.
