### PR TITLE
test(reliability-ef): cover UnitOfWork and PersistanceTransaction over SQLite (#157)

### DIFF
--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Chatter.MessageBrokers.Reliability.EntityFramework.Tests.csproj
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Chatter.MessageBrokers.Reliability.EntityFramework.Tests.csproj
@@ -7,12 +7,14 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.27" />
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
   </ItemGroup>

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Support/SqliteOutboxContext.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Support/SqliteOutboxContext.cs
@@ -1,0 +1,95 @@
+using Chatter.MessageBrokers.Reliability.Inbox;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Threading.Tasks;
+
+namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Support
+{
+    /// <summary>
+    /// A relational DbContext backed by a private in-memory SQLite database. Mirrors the model shape of
+    /// Testing.Core's FakeContext so the reliability adapter's real transaction behavior (BeginTransaction,
+    /// Commit, Rollback) can be exercised against a relational provider rather than the InMemory provider.
+    /// </summary>
+    public sealed class SqliteOutboxContext : DbContext
+    {
+        public SqliteOutboxContext(DbContextOptions<SqliteOutboxContext> options)
+            : base(options)
+        { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.Entity<OutboxMessage>(
+                b =>
+                {
+                    b.HasKey(t => t.MessageId);
+                    b.Property(t => t.MessageId).IsRequired();
+                    b.Property(t => t.ProcessedFromOutboxAtUtc);
+                    b.Property(t => t.SentToOutboxAtUtc).IsRequired();
+                    b.Property(t => t.MessageBody).IsRequired();
+                    b.Property(t => t.MessageContext).IsRequired();
+                    b.Property(t => t.MessageContentType).IsRequired();
+                    b.Property(t => t.Destination).IsRequired();
+                    b.Property(t => t.BatchId).IsRequired();
+                });
+
+            modelBuilder.Entity<InboxMessage>(
+                b =>
+                {
+                    b.HasKey(t => t.MessageId);
+                    b.Property(t => t.MessageId).IsRequired();
+                    b.Property(t => t.ReceivedByInboxAtUtc);
+                });
+        }
+    }
+
+    /// <summary>
+    /// Owns a single open <see cref="SqliteConnection"/> to "DataSource=:memory:" for its lifetime. The in-memory
+    /// SQLite database is destroyed when the last connection to it closes, so the connection is held open until the
+    /// harness is disposed. Each <see cref="CreateContext"/> call returns a fresh context over the same connection,
+    /// enabling commit/rollback assertions against reloaded state.
+    /// </summary>
+    public sealed class SqliteOutboxContextHarness : IDisposable, IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+
+        private SqliteOutboxContextHarness(SqliteConnection connection)
+            => _connection = connection;
+
+        public SqliteConnection Connection => _connection;
+
+        public static SqliteOutboxContextHarness Create()
+        {
+            var connection = new SqliteConnection("DataSource=:memory:");
+            connection.Open();
+
+            var harness = new SqliteOutboxContextHarness(connection);
+            using (var context = harness.CreateContext())
+            {
+                context.Database.EnsureCreated();
+            }
+
+            return harness;
+        }
+
+        public SqliteOutboxContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<SqliteOutboxContext>()
+                .UseSqlite(_connection)
+                .Options;
+
+            return new SqliteOutboxContext(options);
+        }
+
+        public void Dispose()
+        {
+            _connection.Dispose();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/UsingBrokeredMessageOutbox/WhenExecutingUnitOfWorkOverSqlite.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/UsingBrokeredMessageOutbox/WhenExecutingUnitOfWorkOverSqlite.cs
@@ -1,0 +1,138 @@
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Reliability;
+using Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Support;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using Chatter.Testing.Core.Creators.MessageBrokers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.UsingBrokeredMessageOutbox
+{
+    // INVARIANT: These tests exercise the reliability adapter against a real relational provider (SQLite),
+    // unlike WhenExecutingUnitOfWork.cs which documents the InMemory provider's transaction-rejecting behavior.
+    public class WhenExecutingUnitOfWorkOverSqlite : Testing.Core.Context, IAsyncDisposable
+    {
+        private readonly SqliteOutboxContextHarness _harness;
+        private readonly SqliteOutboxContext _context;
+        private readonly Mock<ILoggerFactory> _loggerFactory;
+        private readonly IUnitOfWork _sut;
+
+        public WhenExecutingUnitOfWorkOverSqlite()
+        {
+            _harness = SqliteOutboxContextHarness.Create();
+            _context = _harness.CreateContext();
+            _loggerFactory = new Mock<ILoggerFactory>();
+            _loggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+            _sut = new BrokeredMessageOutbox<SqliteOutboxContext>(_context, _loggerFactory.Object);
+        }
+
+        [Fact]
+        public async Task MustPersistOutboxMessageWhenOperationCommits()
+        {
+            OutboxMessage message = New.MessageBrokers().OutboxMessage().ThatIsNotProcessed();
+
+            await _sut.ExecuteAsync(async ct =>
+            {
+                await _context.Set<OutboxMessage>().AddAsync(message, ct);
+            }, null);
+
+            _sut.HasActiveTransaction.Should().BeFalse();
+
+            using var freshContext = _harness.CreateContext();
+            var persisted = await freshContext.Set<OutboxMessage>()
+                .SingleOrDefaultAsync(m => m.MessageId == message.MessageId);
+            persisted.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustDiscardOutboxMessageWhenOperationThrows()
+        {
+            OutboxMessage message = New.MessageBrokers().OutboxMessage().ThatIsNotProcessed();
+            var operationException = new InvalidOperationException("operation failed");
+
+            Func<Task> act = () => _sut.ExecuteAsync(async ct =>
+            {
+                await _context.Set<OutboxMessage>().AddAsync(message, ct);
+                throw operationException;
+            }, null);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+
+            _sut.HasActiveTransaction.Should().BeFalse();
+
+            using var freshContext = _harness.CreateContext();
+            var persisted = await freshContext.Set<OutboxMessage>()
+                .SingleOrDefaultAsync(m => m.MessageId == message.MessageId);
+            persisted.Should().BeNull();
+        }
+
+        // INVARIANT: under SQLite, BeginTransactionAsync succeeds and the default NonRetryingExecutionStrategy
+        // is used, so the operation's own exception propagates unchanged (same instance) - in contrast with the
+        // InMemory provider, which throws from BeginTransactionAsync before the operation runs.
+        [Fact]
+        public async Task MustRethrowSameOperationExceptionInstanceWhenOperationThrows()
+        {
+            var operationException = new InvalidOperationException("operation failed");
+
+            Func<Task> act = () => _sut.ExecuteAsync(_ => throw operationException, null);
+
+            (await act.Should().ThrowAsync<InvalidOperationException>())
+                .Which.Should().BeSameAs(operationException);
+        }
+
+        // INVARIANT: when a transaction is already open on the context, BeginAsync returns the existing
+        // CurrentTransaction rather than starting a second one. The operation therefore observes the
+        // pre-existing TransactionId. ExecuteAsync still commits and disposes that transaction on success,
+        // so HasActiveTransaction is false once it returns - the reuse evidence is the id seen inside the operation.
+        [Fact]
+        public async Task MustReuseExistingTransactionWhenOneIsAlreadyOpen()
+        {
+            await using var existingTransaction = await _context.Database.BeginTransactionAsync();
+            var existingTransactionId = existingTransaction.TransactionId;
+
+            Guid observedTransactionId = Guid.Empty;
+
+            await _sut.ExecuteAsync(_ =>
+            {
+                observedTransactionId = _sut.CurrentTransaction.TransactionId;
+                return Task.CompletedTask;
+            }, null);
+
+            observedTransactionId.Should().Be(existingTransactionId);
+            observedTransactionId.Should().NotBe(Guid.Empty);
+        }
+
+        [Fact]
+        public async Task MustPopulateTransactionContextContainerWhenContextProvided()
+        {
+            var transactionContext = new TransactionContext("receiver");
+
+            Guid transactionIdInsideOperation = Guid.Empty;
+
+            await _sut.ExecuteAsync(_ =>
+            {
+                transactionIdInsideOperation = _sut.CurrentTransaction.TransactionId;
+                return Task.CompletedTask;
+            }, transactionContext);
+
+            var containedTransaction = transactionContext.Container.GetOrDefault<IPersistanceTransaction>();
+            containedTransaction.Should().NotBeNull();
+
+            var containedTransactionId = transactionContext.Container.Get<Guid>("CurrentTransactionId");
+            containedTransactionId.Should().Be(transactionIdInsideOperation);
+            containedTransactionId.Should().NotBe(Guid.Empty);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _context.DisposeAsync();
+            await _harness.DisposeAsync();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/UsingPersistanceTransaction/WhenManagingTransactionLifecycle.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/UsingPersistanceTransaction/WhenManagingTransactionLifecycle.cs
@@ -1,0 +1,129 @@
+using Chatter.MessageBrokers.Reliability;
+using Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Support;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using Chatter.Testing.Core.Creators.MessageBrokers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.UsingPersistanceTransaction
+{
+    // INVARIANT: PersistanceTransaction is internal sealed with no [InternalsVisibleTo]; it is reachable only as
+    // IPersistanceTransaction via IUnitOfWork.CurrentTransaction. These tests exercise that public surface.
+    public class WhenManagingTransactionLifecycle : Testing.Core.Context, IAsyncDisposable
+    {
+        private readonly SqliteOutboxContextHarness _harness;
+        private readonly SqliteOutboxContext _context;
+        private readonly Mock<ILoggerFactory> _loggerFactory;
+        private readonly IUnitOfWork _sut;
+
+        public WhenManagingTransactionLifecycle()
+        {
+            _harness = SqliteOutboxContextHarness.Create();
+            _context = _harness.CreateContext();
+            _loggerFactory = new Mock<ILoggerFactory>();
+            _loggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+            _sut = new BrokeredMessageOutbox<SqliteOutboxContext>(_context, _loggerFactory.Object);
+        }
+
+        [Fact]
+        public void MustReportEmptyTransactionIdWhenNoTransactionActive()
+        {
+            _sut.CurrentTransaction.TransactionId.Should().Be(Guid.Empty);
+        }
+
+        [Fact]
+        public async Task MustReportUnderlyingTransactionIdWhenTransactionActive()
+        {
+            await using var dbTransaction = await _context.Database.BeginTransactionAsync();
+
+            _sut.CurrentTransaction.TransactionId.Should().Be(dbTransaction.TransactionId);
+            _sut.CurrentTransaction.TransactionId.Should().NotBe(Guid.Empty);
+        }
+
+        [Fact]
+        public async Task MustPersistWhenTransactionCommits()
+        {
+            OutboxMessage message = New.MessageBrokers().OutboxMessage().ThatIsNotProcessed();
+
+            await _context.Database.BeginTransactionAsync();
+            await _context.Set<OutboxMessage>().AddAsync(message);
+            await _context.SaveChangesAsync();
+            await _sut.CurrentTransaction.CommitAsync();
+
+            using var freshContext = _harness.CreateContext();
+            var persisted = await freshContext.Set<OutboxMessage>()
+                .SingleOrDefaultAsync(m => m.MessageId == message.MessageId);
+            persisted.Should().NotBeNull();
+        }
+
+        [Fact]
+        public async Task MustDiscardWhenTransactionRollsBack()
+        {
+            OutboxMessage message = New.MessageBrokers().OutboxMessage().ThatIsNotProcessed();
+
+            await _context.Database.BeginTransactionAsync();
+            await _context.Set<OutboxMessage>().AddAsync(message);
+            await _context.SaveChangesAsync();
+            await _sut.CurrentTransaction.RollbackAsync();
+
+            using var freshContext = _harness.CreateContext();
+            var persisted = await freshContext.Set<OutboxMessage>()
+                .SingleOrDefaultAsync(m => m.MessageId == message.MessageId);
+            persisted.Should().BeNull();
+        }
+
+        [Fact]
+        public void MustNotThrowFromDisposeWhenNoTransactionActive()
+        {
+            IPersistanceTransaction transaction = _sut.CurrentTransaction;
+
+            Action act = () => transaction.Dispose();
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public async Task MustNotThrowFromDisposeAsyncWhenNoTransactionActive()
+        {
+            IPersistanceTransaction transaction = _sut.CurrentTransaction;
+
+            Func<Task> act = async () => await transaction.DisposeAsync();
+
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task MustNotThrowFromDisposeWhenTransactionActive()
+        {
+            await using var dbTransaction = await _context.Database.BeginTransactionAsync();
+            IPersistanceTransaction transaction = _sut.CurrentTransaction;
+
+            Action act = () => transaction.Dispose();
+
+            act.Should().NotThrow();
+        }
+
+        [Fact]
+        public async Task MustNotThrowFromDisposeAsyncWhenTransactionActive()
+        {
+            await using var dbTransaction = await _context.Database.BeginTransactionAsync();
+            IPersistanceTransaction transaction = _sut.CurrentTransaction;
+
+            Func<Task> act = async () => await transaction.DisposeAsync();
+
+            await act.Should().NotThrowAsync();
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _context.DisposeAsync();
+            await _harness.DisposeAsync();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/packages.lock.json
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/packages.lock.json
@@ -17,6 +17,21 @@
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "nukHe+yBlhitLUUtkanay7zTbHwtcIh/U5PfmwzZJJTCqui9h2Mt+Gifc9ZjJR7QIuE0zgNQQJaI8+eFxkBaEQ==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "10.0.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.Extensions.Configuration.Abstractions": {
         "type": "Direct",
         "requested": "[10.0.8, )",
@@ -75,6 +90,14 @@
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "wPKG/Ym6tSMCo06UOZXzVfeFGzawnOZrTba/R3PfK+RhNuNELZ9I7nFns4WGTtv2kKlrlmmErgJ+kgTXHaNdHg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
         "resolved": "10.0.8",
@@ -115,6 +138,20 @@
           "Microsoft.Extensions.Caching.Memory": "10.0.0",
           "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
           "Microsoft.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "VThKv9UqVxFEuuHvjAgMwy6ZFCeKJXOH+ISAR4IMuwlkozv26ptZhr09+6YxWrWwSR/Sinp8BxQ7qePCJFSALQ==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "10.0.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "SQLitePCLRaw.core": "2.1.11"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
@@ -222,8 +259,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "/UlDKULIVkLQYn1BaHcy/rc91ApDxJb7T75HcCbGdqwvxhnRQRKM2di1E70iCPMF9zsr6f4EgQTotBGxFIfXmw=="
+        "resolved": "10.0.0",
+        "contentHash": "RFYJR7APio/BiqdQunRq6DB+nDB6nc2qhHr77mlvZ0q0BT8PubMXN7XicmfzCbrDE/dzhBnUKBRXLTcqUiZDGg=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -446,6 +483,33 @@
           "Microsoft.Extensions.DependencyModel": "3.1.6"
         }
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "DC4nA7yWnf4UZdgJDF+9Mus4/cb0Y3Sfgi3gDnAoKNAIBwzkskNAbNbyu+u4atT0ruVlZNJfwZmwiEwE5oz9LQ==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.11",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.11"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "PK0GLFkfhZzLQeR3PJf71FmhtHox+U3vcY6ZtswoMjrefkB9k6ErNJEnwXqc5KgXDSjige2XXrezqS39gkpQKA=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Ev2ytaXiOlWZ4b3R67GZBsemTINslLD1DCJr2xiacpn4tbapu0Q4dHEzSvZSMnVWeE5nlObU3VZN2p81q3XOYQ=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.11",
+        "contentHash": "Y/0ZkR+r0Cg3DQFuCl1RBnv/tmxpIZRU3HUvelPw6MVaKHwYYR8YNvgs0vuNuXCMvlyJ+Fh88U1D4tah1tt6qw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -541,17 +605,16 @@
       "chatter.messagebrokers": {
         "type": "Project",
         "dependencies": {
-          "Chatter.CQRS": "[0.8.0, )",
+          "Chatter.CQRS": "[0.8.1, )",
           "Microsoft.Extensions.Configuration.Abstractions": "[10.0.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )",
           "Scrutor": "[3.3.0, )"
         }
       },
       "chatter.messagebrokers.reliability.entityframework": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers": "[0.9.0, )",
+          "Chatter.MessageBrokers": "[0.13.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.0, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.0, )"
         }
@@ -559,7 +622,7 @@
       "chatter.testing.core": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.0, )",
+          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.EntityFrameworkCore.InMemory": "[10.0.8, )",
           "Moq": "[4.20.72, )"
@@ -580,6 +643,16 @@
         "contentHash": "B6FJmtTadaqtLXH5qfn9hlYF5ruNOAdtjA9+1V3fuYp/MZzj7lB3Ys5cdgy72uv7w1GE5Y9PEX369UD3N1sfHg==",
         "dependencies": {
           "System.Configuration.ConfigurationManager": "6.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite": {
+        "type": "Direct",
+        "requested": "[8.0.27, )",
+        "resolved": "8.0.27",
+        "contentHash": "jrikpJbWGdzrfU0yStS9HDT1Tko22Pc9fmFEtOzIehayGmKdJZCCoPYBygbMZLG357a7iXaP2jzL4pejxzDSSA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.27",
+          "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -640,6 +713,14 @@
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
       },
+      "Microsoft.Data.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "8.0.27",
+        "contentHash": "xdTCV/0Mmx1TV9O7gyvRtyQFBtoMVwVWUn6p4W++u2AENEOugIApAaCY6wYr894UPJBwIv3ChyVVOJ9joo9dXw==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.6"
+        }
+      },
       "Microsoft.EntityFrameworkCore": {
         "type": "Transitive",
         "resolved": "8.0.27",
@@ -676,6 +757,16 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore": "8.0.27",
           "Microsoft.Extensions.Configuration.Abstractions": "8.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Sqlite.Core": {
+        "type": "Transitive",
+        "resolved": "8.0.27",
+        "contentHash": "apFWpafmFXnZKPAZB4idQAOmYck/KSbUlGoacl3vQRGbYk5OAHFrg4fXgNDLVBS1Ovx/iELSkV1sNTCF9He0UQ==",
+        "dependencies": {
+          "Microsoft.Data.Sqlite.Core": "8.0.27",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.27",
+          "Microsoft.Extensions.DependencyModel": "8.0.2"
         }
       },
       "Microsoft.Extensions.Caching.Abstractions": {
@@ -782,8 +873,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "/UlDKULIVkLQYn1BaHcy/rc91ApDxJb7T75HcCbGdqwvxhnRQRKM2di1E70iCPMF9zsr6f4EgQTotBGxFIfXmw=="
+        "resolved": "8.0.2",
+        "contentHash": "mUBDZZRgZrSyFOsJ2qJJ9fXfqd/kXJwf3AiDoqLD9m6TjY5OO/vLNOb9fb4juC0487eq4hcGN/M2Rh/CKS7QYw=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -1006,6 +1097,33 @@
           "Microsoft.Extensions.DependencyModel": "3.1.6"
         }
       },
+      "SQLitePCLRaw.bundle_e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.6",
+        "contentHash": "BmAf6XWt4TqtowmiWe4/5rRot6GerAeklmOPfviOvwLoF5WwgxcJHAxZtySuyW9r9w+HLILnm8VfJFLCUJYW8A==",
+        "dependencies": {
+          "SQLitePCLRaw.lib.e_sqlite3": "2.1.6",
+          "SQLitePCLRaw.provider.e_sqlite3": "2.1.6"
+        }
+      },
+      "SQLitePCLRaw.core": {
+        "type": "Transitive",
+        "resolved": "2.1.6",
+        "contentHash": "wO6v9GeMx9CUngAet8hbO7xdm+M42p1XeJq47ogyRoYSvNSp0NGLI+MgC0bhrMk9C17MTVFlLiN6ylyExLCc5w=="
+      },
+      "SQLitePCLRaw.lib.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.6",
+        "contentHash": "2ObJJLkIUIxRpOUlZNGuD4rICpBnrBR5anjyfUFQep4hMOIeqW+XGQYzrNmHSVz5xSWZ3klSbh7sFR6UyDj68Q=="
+      },
+      "SQLitePCLRaw.provider.e_sqlite3": {
+        "type": "Transitive",
+        "resolved": "2.1.6",
+        "contentHash": "PQ2Oq3yepLY4P7ll145P3xtx2bX8xF4PzaKPRpw9jZlKvfe4LE/saAV82inND9usn1XRpmxXk7Lal3MTI+6CNg==",
+        "dependencies": {
+          "SQLitePCLRaw.core": "2.1.6"
+        }
+      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -1101,17 +1219,16 @@
       "chatter.messagebrokers": {
         "type": "Project",
         "dependencies": {
-          "Chatter.CQRS": "[0.8.0, )",
+          "Chatter.CQRS": "[0.8.1, )",
           "Microsoft.Extensions.Configuration.Abstractions": "[8.0.0, )",
           "Microsoft.Extensions.Hosting": "[8.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )",
           "Scrutor": "[3.3.0, )"
         }
       },
       "chatter.messagebrokers.reliability.entityframework": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers": "[0.9.0, )",
+          "Chatter.MessageBrokers": "[0.13.0, )",
           "Microsoft.EntityFrameworkCore": "[8.0.27, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.27, )"
         }
@@ -1119,7 +1236,7 @@
       "chatter.testing.core": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.0, )",
+          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.1, )",
           "Microsoft.EntityFrameworkCore": "[8.0.27, )",
           "Microsoft.EntityFrameworkCore.InMemory": "[8.0.27, )",
           "Moq": "[4.20.72, )"


### PR DESCRIPTION
Adds unit-test coverage per issue #157 for `Chatter.MessageBrokers.Reliability.EntityFramework`.

## What
- New tests exercise `UnitOfWork<TContext>` via the public `BrokeredMessageOutbox<T>` / `IUnitOfWork` surface over EF Core **SQLite in-memory with real transactions**:
  - commit persists; rollback discards (operation throws → no row, no active transaction after)
  - nested / already-open transaction reuse (no second transaction begun; observed `TransactionId` equals the pre-existing one)
  - `TransactionContext.Container` receives the transaction + `CurrentTransactionId`
- New tests cover `PersistanceTransaction` lifecycle via `IPersistanceTransaction`: begin/commit/rollback, `Dispose`/`DisposeAsync` null-safety, `TransactionId` active vs `Guid.Empty`.
- Added `Microsoft.EntityFrameworkCore.Sqlite` per-TFM (8.0.27 net8.0, 10.0.0 net10.0) + regenerated `packages.lock.json`.
- New `SqliteOutboxContext` test harness, local to the test project (not added to Testing.Core to avoid forcing a SQLite dep on other modules).

## Notable finding
Under SQLite, `BeginTransactionAsync` succeeds and the default `NonRetryingExecutionStrategy` is used, so the operation's own exception rethrows as the **same instance** — opposite the existing in-memory `NotBeSameAs` invariant (where the InMemory provider throws from `BeginTransactionAsync` before the operation runs). Both invariants are now documented in tests.

## Scope / impact
- Test-only: only the test project's csproj/lock and new test files changed. No production `src/` code touched; **no version bump**.

## Validation
- Full-solution `dotnet test` green.
- `Chatter.MessageBrokers.Reliability.EntityFramework.Tests`: **71 passed / 0 failed** on net8.0 and net10.0.

Brood strain `reliability-ef-coverage`.

Closes #157
