### PR TITLE
test(ssb): live-SQL integration-test harness + nightly CI (#175)

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -1,0 +1,34 @@
+name: Integration (nightly)
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ssb-integration:
+    name: integration (sqlservicebroker)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+      - name: Restore
+        run: dotnet restore 'src/Chatter.MessageBrokers.SqlServiceBroker/tests/Chatter.MessageBrokers.SqlServiceBroker.Tests.csproj' --locked-mode
+      - name: Build
+        run: dotnet build 'src/Chatter.MessageBrokers.SqlServiceBroker/tests/Chatter.MessageBrokers.SqlServiceBroker.Tests.csproj' -c Release --no-restore
+      - name: Integration test (SQL Service Broker)
+        run: dotnet test 'src/Chatter.MessageBrokers.SqlServiceBroker/tests/Chatter.MessageBrokers.SqlServiceBroker.Tests.csproj' -c Release --no-build --filter 'Category=Integration'
+
+  # Future sibling integration jobs (#176, #177) go here, following the same
+  # checkout + setup-dotnet + restore/build/test (Category=Integration) shape as ssb-integration above.

--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -12,6 +12,7 @@ jobs:
   ssb-integration:
     name: integration (sqlservicebroker)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
       - name: Setup .NET

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Chatter.MessageBrokers.SqlServiceBroker.Tests.csproj
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Chatter.MessageBrokers.SqlServiceBroker.Tests.csproj
@@ -25,6 +25,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.Routing.Options;
+using Chatter.MessageBrokers.Sending;
+using Chatter.MessageBrokers.SqlServiceBroker.Configuration;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // The reusable end-to-end harness that boots Chatter's REAL DI graph and receiver pump against a SQL
+    // Service Broker database (the SqlServiceBrokerFixture container) and routes messages through Chatter's own
+    // dispatcher/handler path — NOT raw ADO.NET. Tests Send via the resolved IBrokeredMessageDispatcher and
+    // await a RecordingMessageHandler<TMessage> invocation. Mirrors the Azure Service Bus ChatterPipelineHarness.
+    //
+    // Composition mirrors how a real Chatter app wires SQL Service Broker:
+    //   AddChatterCqrs(config) -> AddMessageBrokers(...) -> AddSqlServiceBroker(ssb => <caller delegate>)
+    // The caller delegate registers the receivers under test (AddQueueReceiver<T>); Build layers a FINITE
+    // receiver timeout and the fixture's app connection string onto the SqlServiceBrokerOptionsBuilder before
+    // invoking it.
+    //
+    // WAITFOR-HANG GUARD: production defaults ReceiverTimeoutInMilliseconds to -1, which makes the receiver's
+    // WAITFOR(RECEIVE) block forever, and SqlServiceBrokerReceiver.StopReceiver()/Cancel() is a NO-OP. So this
+    // harness (a) sets a FINITE ReceiverTimeoutInMilliseconds so each RECEIVE returns promptly and the pump
+    // loops on a cancellable token, (b) exposes ONLY bounded wait helpers that throw on timeout, and (c) on
+    // teardown cancels the pump CancellationTokenSource BEFORE stopping the host so a blocked/looping RECEIVE
+    // unwinds via token cancellation (the only teardown signal that works).
+    public sealed class ChatterSsbPipelineHarness : IAsyncDisposable
+    {
+        // Finite receiver timeout (milliseconds) handed to the production receiver. Small and finite so a
+        // RECEIVE with no message returns an empty result set quickly and the pump loops on the pump token
+        // rather than blocking forever (the -1 production default). Kept finite under BOTH the millisecond name
+        // and any seconds-interpretation of the SQL WAITFOR parameter.
+        private const int FiniteReceiverTimeoutInMilliseconds = 5;
+
+        private readonly ServiceProvider _provider;
+        private readonly IReadOnlyList<IHostedService> _hostedServices;
+        private readonly CancellationTokenSource _pumpCts;
+        private bool _started;
+
+        private ChatterSsbPipelineHarness(
+            ServiceProvider provider,
+            IReadOnlyList<IHostedService> hostedServices,
+            CancellationTokenSource pumpCts)
+        {
+            _provider = provider;
+            _hostedServices = hostedServices;
+            _pumpCts = pumpCts;
+        }
+
+        // The shared per-message-type signal registry. Tests call GetSignal<TMessage>() to obtain the same
+        // HandlerSignal<TMessage> the DI-resolved RecordingMessageHandler<TMessage> reports through.
+        public HandlerSignalRegistry Signals { get; private set; }
+
+        // Builds the harness. configureReceivers registers the receivers under test on the
+        // SqlServiceBrokerOptionsBuilder (e.g. ssb.AddQueueReceiver<MyCommand>("[chatter_ssb_it_target_queue]",
+        // deadLetterServicePath: "chatter_ssb_it_deadletter_service")). messageTypes are the IMessage types
+        // whose RecordingMessageHandler<TMessage> should be wired into Chatter's handler resolution; a closed
+        // IMessageHandler<TMessage> is registered for each so Chatter's dispatcher resolves and invokes it on
+        // the real receive path.
+        public static ChatterSsbPipelineHarness Build(
+            string connectionString,
+            Action<SqlServiceBrokerOptionsBuilder> configureReceivers,
+            params Type[] messageTypes)
+        {
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                throw new ArgumentException("A connection string is required.", nameof(connectionString));
+            }
+            if (configureReceivers is null)
+            {
+                throw new ArgumentNullException(nameof(configureReceivers));
+            }
+
+            var configuration = new ConfigurationBuilder().Build();
+            var services = new ServiceCollection();
+
+            // A real host registers logging automatically; this bare ServiceCollection does not. Chatter's
+            // receiver graph (the BrokeredMessageReceiverBackgroundService<T> hosted services) depends on
+            // ILogger<T>, so register it up front or the hosted-service activation throws.
+            services.AddLogging();
+
+            var registry = new HandlerSignalRegistry();
+            services.AddSingleton(registry);
+
+            // Point the handler/receiver assembly scan at THIS test assembly so any concrete test handlers are
+            // discovered. RecordingMessageHandler<> is open-generic and excluded by Chatter's
+            // IsValidMessageHandler scan filter, so it is registered explicitly below.
+            var testAssembly = typeof(ChatterSsbPipelineHarness).Assembly;
+
+            services
+                .AddChatterCqrs(configuration, testAssembly)
+                .AddMessageBrokers(receiverAssemblies: testAssembly)
+                .AddSqlServiceBroker(ssb =>
+                {
+                    // Seed the options with the fixture's app connection string and a FINITE receiver timeout
+                    // (the WAITFOR-hang guard), then let the caller register the receivers under test.
+                    ssb.AddSqlServiceBrokerOptions(
+                        connectionString,
+                        receiverTimeoutInMilliseconds: FiniteReceiverTimeoutInMilliseconds);
+                    configureReceivers(ssb);
+                });
+
+            // Register a closed RecordingMessageHandler<TMessage> as the IMessageHandler<TMessage> Chatter's
+            // dispatcher resolves for each message type under test.
+            foreach (var messageType in messageTypes ?? Array.Empty<Type>())
+            {
+                var handlerInterface = typeof(IMessageHandler<>).MakeGenericType(messageType);
+                var handlerImplementation = typeof(RecordingMessageHandler<>).MakeGenericType(messageType);
+                services.AddTransient(handlerInterface, handlerImplementation);
+            }
+
+            var provider = services.BuildServiceProvider();
+
+            var hostedServices = new List<IHostedService>(provider.GetServices<IHostedService>());
+            var pumpCts = new CancellationTokenSource();
+
+            return new ChatterSsbPipelineHarness(provider, hostedServices, pumpCts)
+            {
+                Signals = registry,
+            };
+        }
+
+        // Starts the receiver pump in-process. Each receiver's BackgroundService.ExecuteAsync drives the receive
+        // loop for the receiver lifetime, but StartAsync returns once ExecuteAsync yields at its first await,
+        // returning control to the test. The pump token is passed so DisposeAsync can stop the loop.
+        // INVARIANT: idempotent — starting twice is a no-op.
+        public async Task StartAsync()
+        {
+            if (_started)
+            {
+                return;
+            }
+
+            foreach (var hostedService in _hostedServices)
+            {
+                await hostedService.StartAsync(_pumpCts.Token).ConfigureAwait(false);
+            }
+
+            _started = true;
+        }
+
+        // Resolves the IBrokeredMessageDispatcher tests use to Send through Chatter. Resolved from a fresh scope
+        // each call (the dispatcher is scoped), mirroring how Chatter resolves it per receive.
+        public IBrokeredMessageDispatcher CreateDispatcher(out IServiceScope scope)
+        {
+            scope = _provider.CreateScope();
+            return scope.ServiceProvider.GetRequiredService<IBrokeredMessageDispatcher>();
+        }
+
+        // Sends a command through Chatter's dispatcher to the provisioned target service, stamping the
+        // SSBMessageContext headers the SqlServiceBrokerSender reads to BEGIN DIALOG / SEND on the provisioned
+        // initiator service + //Chatter contract + //Chatter/BrokeredMessage message type. destinationPath is
+        // the BARE target service name (ServiceBrokerProvisioning.TargetServiceName): BeginDialogConversationCommand
+        // strips brackets from the target and uses it as "TO SERVICE", so the destination must name the target
+        // SERVICE, not the queue. Opens and disposes its own scope around the send.
+        public async Task SendAsync<TMessage>(TMessage message) where TMessage : ICommand
+        {
+            var options = new SendOptions();
+            options.WithMessageContext(SSBMessageContext.ServiceName, ServiceBrokerProvisioning.InitiatorServiceName);
+            options.WithMessageContext(SSBMessageContext.ServiceContractName, ServiceBrokerProvisioning.ContractName);
+            options.WithMessageContext(SSBMessageContext.MessageTypeName, ServiceBrokerProvisioning.MessageTypeName);
+
+            var dispatcher = CreateDispatcher(out var scope);
+            using (scope)
+            {
+                await dispatcher.Send(message, ServiceBrokerProvisioning.TargetServiceName, options: options)
+                    .ConfigureAwait(false);
+            }
+        }
+
+        // The shared signal for TMessage. Configure ThrowOnHandle BEFORE the message is received to exercise
+        // Chatter's deadletter path; await Signal.Handled (bounded via WaitForHandledAsync) to observe the
+        // handler invocation.
+        public HandlerSignal<TMessage> GetSignal<TMessage>() where TMessage : IMessage
+            => Signals.GetOrAdd<TMessage>();
+
+        // Bounded wait for a RecordingMessageHandler<TMessage> invocation: returns the captured payload +
+        // broker context, or throws TimeoutException so a stalled receive fails fast instead of hanging CI.
+        // NEVER an unbounded wait (WAITFOR-hang guard).
+        public async Task<HandledRecord<TMessage>> WaitForHandledAsync<TMessage>(TimeSpan timeout)
+            where TMessage : IMessage
+        {
+            var handled = GetSignal<TMessage>().Handled;
+            var completed = await Task.WhenAny(handled, Task.Delay(timeout)).ConfigureAwait(false);
+            if (completed != handled)
+            {
+                throw new TimeoutException(
+                    $"Timed out after {timeout} waiting for a handler invocation of '{typeof(TMessage).Name}'.");
+            }
+
+            return await handled.ConfigureAwait(false);
+        }
+
+        // Bounded poll until the handler for TMessage has been invoked at least minCount times, returning the
+        // observed count. Returns the last observed count (which may be below minCount) if the timeout elapses
+        // first — callers assert on the returned count so a never-reached threshold fails fast instead of
+        // hanging. NEVER an unbounded wait (WAITFOR-hang guard).
+        public async Task<int> WaitForInvocationCountAsync<TMessage>(int minCount, TimeSpan timeout)
+            where TMessage : IMessage
+        {
+            var signal = GetSignal<TMessage>();
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (signal.InvocationCount >= minCount)
+                {
+                    return signal.InvocationCount;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+            }
+
+            return signal.InvocationCount;
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            // WAITFOR-hang guard: StopReceiver()/Cancel() is a NO-OP, so token cancellation is the ONLY teardown
+            // that unwinds a blocked/looping RECEIVE. Cancel the pump token BEFORE stopping the host.
+            _pumpCts.Cancel();
+
+            if (_started)
+            {
+                foreach (var hostedService in _hostedServices)
+                {
+                    try
+                    {
+                        await hostedService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch (Exception)
+                    {
+                        // Best-effort drain on teardown: a receiver already faulted/cancelled must not mask
+                        // disposal of the provider below.
+                    }
+                }
+            }
+
+            await _provider.DisposeAsync().ConfigureAwait(false);
+            _pumpCts.Dispose();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
@@ -30,7 +30,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
     // loops on a cancellable token, (b) exposes ONLY bounded wait helpers that throw on timeout, and (c) on
     // teardown cancels the pump CancellationTokenSource BEFORE stopping the host so a blocked/looping RECEIVE
     // unwinds via token cancellation (the only teardown signal that works).
-    public sealed class ChatterSsbPipelineHarness : IAsyncDisposable
+    internal sealed class ChatterSsbPipelineHarness : IAsyncDisposable
     {
         // Finite receiver timeout (milliseconds) handed to the production receiver. Small and finite so a
         // RECEIVE with no message returns an empty result set quickly and the pump loops on the pump token
@@ -41,30 +41,37 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         private readonly ServiceProvider _provider;
         private readonly IReadOnlyList<IHostedService> _hostedServices;
         private readonly CancellationTokenSource _pumpCts;
+        private readonly ServiceBrokerProvisioning.ObjectSet _objectSet;
         private bool _started;
 
         private ChatterSsbPipelineHarness(
             ServiceProvider provider,
             IReadOnlyList<IHostedService> hostedServices,
-            CancellationTokenSource pumpCts)
+            CancellationTokenSource pumpCts,
+            ServiceBrokerProvisioning.ObjectSet objectSet)
         {
             _provider = provider;
             _hostedServices = hostedServices;
             _pumpCts = pumpCts;
+            _objectSet = objectSet;
         }
 
         // The shared per-message-type signal registry. Tests call GetSignal<TMessage>() to obtain the same
         // HandlerSignal<TMessage> the DI-resolved RecordingMessageHandler<TMessage> reports through.
         public HandlerSignalRegistry Signals { get; private set; }
 
-        // Builds the harness. configureReceivers registers the receivers under test on the
-        // SqlServiceBrokerOptionsBuilder (e.g. ssb.AddQueueReceiver<MyCommand>("[chatter_ssb_it_target_queue]",
-        // deadLetterServicePath: "chatter_ssb_it_deadletter_service")). messageTypes are the IMessage types
-        // whose RecordingMessageHandler<TMessage> should be wired into Chatter's handler resolution; a closed
+        // Builds the harness. objectSet is the owning test class's RECEIVE-side Service Broker object set;
+        // SendAsync routes every dispatch to objectSet.TargetServiceName so each test class sends to / receives
+        // from its OWN target service and cross-test queue poisoning is impossible. configureReceivers registers
+        // the receivers under test on the SqlServiceBrokerOptionsBuilder (e.g.
+        // ssb.AddQueueReceiver<MyCommand>(objectSet.TargetQueuePathBracketed,
+        // deadLetterServicePath: objectSet.DeadLetterServiceName)). messageTypes are the IMessage types whose
+        // RecordingMessageHandler<TMessage> should be wired into Chatter's handler resolution; a closed
         // IMessageHandler<TMessage> is registered for each so Chatter's dispatcher resolves and invokes it on
         // the real receive path.
         public static ChatterSsbPipelineHarness Build(
             string connectionString,
+            ServiceBrokerProvisioning.ObjectSet objectSet,
             Action<SqlServiceBrokerOptionsBuilder> configureReceivers,
             params Type[] messageTypes)
         {
@@ -120,7 +127,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             var hostedServices = new List<IHostedService>(provider.GetServices<IHostedService>());
             var pumpCts = new CancellationTokenSource();
 
-            return new ChatterSsbPipelineHarness(provider, hostedServices, pumpCts)
+            return new ChatterSsbPipelineHarness(provider, hostedServices, pumpCts, objectSet)
             {
                 Signals = registry,
             };
@@ -153,12 +160,15 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             return scope.ServiceProvider.GetRequiredService<IBrokeredMessageDispatcher>();
         }
 
-        // Sends a command through Chatter's dispatcher to the provisioned target service, stamping the
-        // SSBMessageContext headers the SqlServiceBrokerSender reads to BEGIN DIALOG / SEND on the provisioned
+        // Sends a command through Chatter's dispatcher to the OWNING object set's target service, stamping the
+        // SSBMessageContext headers the SqlServiceBrokerSender reads to BEGIN DIALOG / SEND on the SHARED
         // initiator service + //Chatter contract + //Chatter/BrokeredMessage message type. destinationPath is
-        // the BARE target service name (ServiceBrokerProvisioning.TargetServiceName): BeginDialogConversationCommand
-        // strips brackets from the target and uses it as "TO SERVICE", so the destination must name the target
-        // SERVICE, not the queue. Opens and disposes its own scope around the send.
+        // the BARE target service name (_objectSet.TargetServiceName): BeginDialogConversationCommand strips
+        // brackets from the target and uses it as "TO SERVICE", so the destination must name the target SERVICE,
+        // not the queue. Routing to the per-class target service is what makes cross-test isolation real — each
+        // class sends to its own service so a stale message can never bleed into another class's queue. The
+        // initiator stamp + contract + message type stay shared (the send side is common across all classes).
+        // Opens and disposes its own scope around the send.
         public async Task SendAsync<TMessage>(TMessage message) where TMessage : ICommand
         {
             var options = new SendOptions();
@@ -169,7 +179,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             var dispatcher = CreateDispatcher(out var scope);
             using (scope)
             {
-                await dispatcher.Send(message, ServiceBrokerProvisioning.TargetServiceName, options: options)
+                await dispatcher.Send(message, _objectSet.TargetServiceName, options: options)
                     .ConfigureAwait(false);
             }
         }

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
@@ -38,6 +38,13 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         // and any seconds-interpretation of the SQL WAITFOR parameter.
         private const int FiniteReceiverTimeoutInMilliseconds = 5;
 
+        // Bounds every residual teardown/send await that would otherwise pass CancellationToken.None, so a wedged
+        // host-stop or dispatcher send fails fast instead of hanging CI. Matches the 30s operation waits the
+        // tests already use (DeadLetterWait et al). This does NOT replace the WAITFOR-hang guard: the pump token
+        // cancellation in DisposeAsync is still what unwinds a blocked RECEIVE; this is a finite ceiling on the
+        // best-effort StopAsync drain and on the dispatcher send.
+        private static readonly TimeSpan TeardownTimeout = TimeSpan.FromSeconds(30);
+
         private readonly ServiceProvider _provider;
         private readonly IReadOnlyList<IHostedService> _hostedServices;
         private readonly CancellationTokenSource _pumpCts;
@@ -178,9 +185,21 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
 
             var dispatcher = CreateDispatcher(out var scope);
             using (scope)
+            using (var sendCts = new CancellationTokenSource(TeardownTimeout))
             {
-                await dispatcher.Send(message, _objectSet.TargetServiceName, options: options)
+                // Bound the dispatcher send so a wedged BEGIN DIALOG / SEND fails fast. The dispatcher Send
+                // overload takes no token, so race it against a finite delay rather than passing CancellationToken
+                // .None to an unbounded await.
+                var send = dispatcher.Send(message, _objectSet.TargetServiceName, options: options);
+                var completed = await Task.WhenAny(send, Task.Delay(Timeout.Infinite, sendCts.Token))
                     .ConfigureAwait(false);
+                if (completed != send)
+                {
+                    throw new TimeoutException(
+                        $"Timed out after {TeardownTimeout} sending a '{typeof(TMessage).Name}' through the dispatcher.");
+                }
+
+                await send.ConfigureAwait(false);
             }
         }
 
@@ -237,20 +256,22 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
 
             if (_started)
             {
+                using var stopCts = new CancellationTokenSource(TeardownTimeout);
                 foreach (var hostedService in _hostedServices)
                 {
                     try
                     {
-                        await hostedService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+                        await hostedService.StopAsync(stopCts.Token).ConfigureAwait(false);
                     }
                     catch (Exception)
                     {
-                        // Best-effort drain on teardown: a receiver already faulted/cancelled must not mask
-                        // disposal of the provider below.
+                        // Best-effort drain on teardown: a receiver already faulted/cancelled (or a stop that
+                        // exceeded TeardownTimeout) must not mask disposal of the provider below.
                     }
                 }
             }
 
+            // _provider.DisposeAsync() takes no CancellationToken, so it is left unbounded here (not cancelable).
             await _provider.DisposeAsync().ConfigureAwait(false);
             _pumpCts.Dispose();
         }

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/DockerEnvironment.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/DockerEnvironment.cs
@@ -1,0 +1,115 @@
+using System;
+using System.IO;
+using System.Net.Http;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Discovery-time Docker reachability probe. The integration fixture needs Docker to start the SQL
+    // Server Service Broker container; when Docker is absent OR the daemon is not actually responding, the
+    // integration facts are SKIPPED (never failed) so a plain `dotnet test` on a Docker-free machine stays
+    // green. The probe issues a real Docker `/_ping` over the resolved endpoint — a connectable socket file
+    // is NOT sufficient (e.g. a WSL /var/run/docker.sock accepts connections even when no daemon serves it),
+    // so only a successful daemon ping reports available. The result is cached for the test assembly.
+    internal static class DockerEnvironment
+    {
+        private static readonly TimeSpan ProbeTimeout = TimeSpan.FromSeconds(3);
+
+        private static readonly Lazy<bool> _isAvailable = new Lazy<bool>(Probe);
+
+        public static bool IsAvailable => _isAvailable.Value;
+
+        public const string SkipReason =
+            "Docker is not available (daemon not reachable); the SQL Server Service Broker container cannot be " +
+            "started. Run with a working Docker daemon to execute the Category=Integration tests.";
+
+        // Resolves the Docker endpoint (DOCKER_HOST wins; otherwise the default unix socket) and pings the
+        // daemon. Any failure — missing socket, refused connection, non-success status, timeout — reports
+        // unavailable so the tests skip rather than fail.
+        private static bool Probe()
+        {
+            try
+            {
+                var dockerHost = Environment.GetEnvironmentVariable("DOCKER_HOST");
+
+                if (string.IsNullOrWhiteSpace(dockerHost))
+                {
+                    return PingUnixSocket("/var/run/docker.sock");
+                }
+
+                if (!Uri.TryCreate(dockerHost, UriKind.Absolute, out var uri))
+                {
+                    return false;
+                }
+
+                return uri.Scheme switch
+                {
+                    "unix" => PingUnixSocket(uri.LocalPath),
+                    "tcp" => PingTcp(uri.Host, uri.Port > 0 ? uri.Port : 2375),
+                    "http" => PingTcp(uri.Host, uri.Port > 0 ? uri.Port : 80),
+                    "https" => PingTcp(uri.Host, uri.Port > 0 ? uri.Port : 443),
+                    // Named-pipe endpoints (Windows) are not probed here; report available and let the
+                    // fixture surface any failure rather than skip a working Windows daemon.
+                    "npipe" => true,
+                    _ => false,
+                };
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        private static bool PingUnixSocket(string socketPath)
+        {
+            if (!File.Exists(socketPath))
+            {
+                return false;
+            }
+
+            using var handler = new SocketsHttpHandler
+            {
+                ConnectCallback = async (_, cancellationToken) =>
+                {
+                    var socket = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
+                    try
+                    {
+                        await socket.ConnectAsync(new UnixDomainSocketEndPoint(socketPath), cancellationToken);
+                        return new NetworkStream(socket, ownsSocket: true);
+                    }
+                    catch
+                    {
+                        socket.Dispose();
+                        throw;
+                    }
+                },
+            };
+
+            // The host segment is ignored for unix-socket transport but is required to form a valid URI.
+            return Ping(handler, "http://localhost/_ping");
+        }
+
+        private static bool PingTcp(string host, int port)
+        {
+            using var handler = new SocketsHttpHandler();
+            return Ping(handler, $"http://{host}:{port}/_ping");
+        }
+
+        private static bool Ping(SocketsHttpHandler handler, string pingUrl)
+        {
+            try
+            {
+                using var client = new HttpClient(handler, disposeHandler: false) { Timeout = ProbeTimeout };
+                using var cts = new CancellationTokenSource(ProbeTimeout);
+                using var response = client.GetAsync(pingUrl, cts.Token).GetAwaiter().GetResult();
+                return response.IsSuccessStatusCode;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/RecordingMessageHandler.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/RecordingMessageHandler.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS;
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.Context;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // What a RecordingMessageHandler<TMessage> captured when Chatter's pipeline invoked it: the deserialized
+    // payload and the IMessageBrokerContext the receive path passed to the handler. WaitForHandledAsync
+    // returns this so a test can assert on both the message that round-tripped through SQL Service Broker and
+    // the broker context Chatter built for it. Broker-agnostic — mirrors the Azure Service Bus harness's
+    // recorder so the SSB integration tests read the same way.
+    public sealed class HandledRecord<TMessage>
+    {
+        public HandledRecord(TMessage message, IMessageBrokerContext context)
+        {
+            Message = message;
+            Context = context;
+        }
+
+        public TMessage Message { get; }
+        public IMessageBrokerContext Context { get; }
+    }
+
+    // Shared, harness-owned signal for one message type. Registered as a singleton so the single instance is
+    // visible to BOTH the test (which awaits Handled) and the DI-resolved RecordingMessageHandler<TMessage>
+    // (which Chatter constructs transiently per receive scope and which signals through this registry).
+    //
+    // ThrowOnHandle drives the deadletter scenario: when set, the handler throws after recording, so Chatter's
+    // receiver loop runs its retry/deadletter path. Handled is still completed in that case so a test can
+    // observe that the handler WAS invoked even though it then threw.
+    public sealed class HandlerSignal<TMessage>
+    {
+        private readonly TaskCompletionSource<HandledRecord<TMessage>> _handled =
+            new TaskCompletionSource<HandledRecord<TMessage>>(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly ConcurrentQueue<HandledRecord<TMessage>> _records =
+            new ConcurrentQueue<HandledRecord<TMessage>>();
+        private int _invocationCount;
+
+        // When non-null, the handler throws this (a fresh instance per invocation) after recording the
+        // message, exercising Chatter's receiver retry/deadletter path.
+        public Func<Exception> ThrowOnHandle { get; set; }
+
+        public Task<HandledRecord<TMessage>> Handled => _handled.Task;
+
+        // The total number of times Chatter's pipeline has invoked the handler for TMessage. Lets a test
+        // observe redelivery vs a single delivery without holding the transiently-constructed handler instance.
+        public int InvocationCount => Volatile.Read(ref _invocationCount);
+
+        // Every captured invocation in arrival order. Unlike Handled (which holds only the FIRST invocation),
+        // this lets a test assert on the PAYLOAD of a later delivery rather than inferring it from the
+        // invocation count alone.
+        public IReadOnlyCollection<HandledRecord<TMessage>> Records => _records;
+
+        internal void Record(HandledRecord<TMessage> record)
+        {
+            Interlocked.Increment(ref _invocationCount);
+            _records.Enqueue(record);
+            _handled.TrySetResult(record);
+        }
+    }
+
+    // Registry of per-message-type signals, registered as a singleton. The harness creates/looks up the
+    // HandlerSignal<TMessage> for a message type; the DI-resolved RecordingMessageHandler<TMessage> resolves
+    // this same registry and reports its capture through it. Keying by Type keeps the test's expectation and
+    // the handler instance pointed at one shared signal without the test holding the handler instance
+    // (Chatter owns construction).
+    public sealed class HandlerSignalRegistry
+    {
+        private readonly ConcurrentDictionary<Type, object> _signals = new ConcurrentDictionary<Type, object>();
+
+        public HandlerSignal<TMessage> GetOrAdd<TMessage>()
+            => (HandlerSignal<TMessage>)_signals.GetOrAdd(typeof(TMessage), _ => new HandlerSignal<TMessage>());
+    }
+
+    // A Chatter IMessageHandler<TMessage> that records the payload + broker context and signals the shared
+    // HandlerSignal<TMessage> from the registry. Registered explicitly by ChatterSsbPipelineHarness as a closed
+    // IMessageHandler<TMessage> (not discovered by Chatter's assembly scan, whose IsValidMessageHandler
+    // filter excludes open generics), so it participates in the real receive path Chatter drives.
+    public sealed class RecordingMessageHandler<TMessage> : IMessageHandler<TMessage> where TMessage : IMessage
+    {
+        private readonly HandlerSignalRegistry _registry;
+
+        public RecordingMessageHandler(HandlerSignalRegistry registry)
+            => _registry = registry ?? throw new ArgumentNullException(nameof(registry));
+
+        public Task Handle(TMessage message, IMessageHandlerContext context)
+        {
+            var signal = _registry.GetOrAdd<TMessage>();
+            signal.Record(new HandledRecord<TMessage>(message, context as IMessageBrokerContext));
+
+            var thrower = signal.ThrowOnHandle;
+            if (thrower != null)
+            {
+                throw thrower();
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/RequiresDockerFactAttribute.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/RequiresDockerFactAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // A [Fact] that runs only when Docker is reachable. When Docker is absent the fact is SKIPPED at
+    // discovery time (Skip is set before the test runs) so a plain `dotnet test` on a Docker-free machine
+    // reports these as skipped, never failed. The Category=Integration trait is applied at the test-class
+    // level (see CrossEntityTransactionTests) so CI can include/exclude with `--filter Category=Integration`.
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+    public sealed class RequiresDockerFactAttribute : FactAttribute
+    {
+        public RequiresDockerFactAttribute()
+        {
+            if (!DockerEnvironment.IsAvailable)
+            {
+                Skip = DockerEnvironment.SkipReason;
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
@@ -75,15 +75,6 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             DialogSet,
         };
 
-        // TEMPORARY back-compat aliases for the historic single-set constant names. STEP-002 migrates each
-        // consumer onto its owning set member and removes these. Aliased to RoundTripSet as a representative set;
-        // consumers that still reference these names are NOT yet isolated per-class.
-        public static readonly string TargetServiceName = RoundTripSet.TargetServiceName;
-        public static readonly string TargetQueueName = RoundTripSet.TargetQueueName;
-        public static readonly string DeadLetterServiceName = RoundTripSet.DeadLetterServiceName;
-        public static readonly string DeadLetterQueueName = RoundTripSet.DeadLetterQueueName;
-        public static readonly string TargetQueuePathBracketed = RoundTripSet.TargetQueuePathBracketed;
-
         // Bounded readiness retry. A freshly started SQL Server container can refuse connections or report the
         // broker not-yet-enabled for a brief window; these caps keep the retry short and finite.
         private const int MaxConnectAttempts = 10;

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,23 +29,60 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         public const string MessageTypeName = "//Chatter/BrokeredMessage";
         public const string ContractName = "//Chatter";
 
-        // Harness-chosen Service Broker SERVICE names. All three sit ON the //Chatter contract: the sender
-        // begins a dialog FROM the initiator TO the target ON CONTRACT, and the deadletter path begins a dialog
-        // TO the DLQ service ON the same contract, so every service must be contract-bound to be a valid target.
+        // Harness-chosen SHARED Service Broker objects. The initiator service+queue are the SEND side: the sender
+        // begins every dialog FROM this one initiator regardless of which test class is running, so they stay
+        // shared (and the message type + contract above stay shared) — only the RECEIVE side is partitioned.
         public const string InitiatorServiceName = "chatter_ssb_it_initiator_service";
-        public const string TargetServiceName = "chatter_ssb_it_target_service";
-        public const string DeadLetterServiceName = "chatter_ssb_it_deadletter_service";
-
-        // Harness-chosen Service Broker QUEUE names. The target queue is the one the receiver pump RECEIVEs
-        // from. ReceiveMessageFromQueueCommand interpolates the queue name directly into "FROM {queue}", so the
-        // STEP-004 fixture must hand the receiver the bracket-quoted form (TargetQueuePathBracketed).
         public const string InitiatorQueueName = "chatter_ssb_it_initiator_queue";
-        public const string TargetQueueName = "chatter_ssb_it_target_queue";
-        public const string DeadLetterQueueName = "chatter_ssb_it_deadletter_queue";
 
-        // Bracket-quoted target queue identifier suitable for direct interpolation into the receiver's
-        // "FROM {queue}" RECEIVE statement. STEP-004 sets ReceiverOptions.MessageReceiverPath to this value.
-        public const string TargetQueuePathBracketed = "[" + TargetQueueName + "]";
+        // An immutable per-test-class set of RECEIVE-side Service Broker objects. SSB queues are not partitioned by
+        // message type, so a stale message left by a failed prior scenario would otherwise be RECEIVEd by a later
+        // test sharing the same target queue. Each test class gets its OWN target queue+service and deadletter
+        // queue+service (all ON the shared //Chatter contract) so cross-test poisoning is impossible.
+        public readonly record struct ObjectSet(
+            string TargetQueueName,
+            string TargetServiceName,
+            string DeadLetterQueueName,
+            string DeadLetterServiceName)
+        {
+            // Bracket-quoted target queue identifier suitable for direct interpolation into the receiver's
+            // "FROM {queue}" RECEIVE statement. The STEP-004 fixture sets ReceiverOptions.MessageReceiverPath to
+            // this value for the owning test class.
+            public string TargetQueuePathBracketed => "[" + TargetQueueName + "]";
+        }
+
+        // Mints a per-class object set from a suffix, e.g. "roundtrip" yields chatter_ssb_it_target_queue_roundtrip
+        // / _target_service_roundtrip / _deadletter_queue_roundtrip / _deadletter_service_roundtrip.
+        private static ObjectSet CreateSet(string suffix)
+            => new ObjectSet(
+                TargetQueueName: $"chatter_ssb_it_target_queue_{suffix}",
+                TargetServiceName: $"chatter_ssb_it_target_service_{suffix}",
+                DeadLetterQueueName: $"chatter_ssb_it_deadletter_queue_{suffix}",
+                DeadLetterServiceName: $"chatter_ssb_it_deadletter_service_{suffix}");
+
+        // The four well-known per-test-class object sets, one per integration test class.
+        public static readonly ObjectSet RoundTripSet = CreateSet("roundtrip");
+        public static readonly ObjectSet NackSet = CreateSet("nack");
+        public static readonly ObjectSet DeadLetterSet = CreateSet("deadletter");
+        public static readonly ObjectSet DialogSet = CreateSet("dialog");
+
+        // Every object set, driving BOTH provisioning and teardown so the two loops can never diverge and leak.
+        public static readonly IReadOnlyList<ObjectSet> AllSets = new[]
+        {
+            RoundTripSet,
+            NackSet,
+            DeadLetterSet,
+            DialogSet,
+        };
+
+        // TEMPORARY back-compat aliases for the historic single-set constant names. STEP-002 migrates each
+        // consumer onto its owning set member and removes these. Aliased to RoundTripSet as a representative set;
+        // consumers that still reference these names are NOT yet isolated per-class.
+        public static readonly string TargetServiceName = RoundTripSet.TargetServiceName;
+        public static readonly string TargetQueueName = RoundTripSet.TargetQueueName;
+        public static readonly string DeadLetterServiceName = RoundTripSet.DeadLetterServiceName;
+        public static readonly string DeadLetterQueueName = RoundTripSet.DeadLetterQueueName;
+        public static readonly string TargetQueuePathBracketed = RoundTripSet.TargetQueuePathBracketed;
 
         // Bounded readiness retry. A freshly started SQL Server container can refuse connections or report the
         // broker not-yet-enabled for a brief window; these caps keep the retry short and finite.
@@ -68,16 +106,22 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             await using var connection = new SqlConnection(appConnectionString);
             await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
+            // Shared objects provisioned ONCE: message type, contract, and the single initiator queue+service.
             await ProvisionMessageTypeAsync(connection, cancellationToken).ConfigureAwait(false);
             await ProvisionContractAsync(connection, cancellationToken).ConfigureAwait(false);
-
             await ProvisionQueueAsync(connection, InitiatorQueueName, cancellationToken).ConfigureAwait(false);
-            await ProvisionQueueAsync(connection, TargetQueueName, cancellationToken).ConfigureAwait(false);
-            await ProvisionQueueAsync(connection, DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
-
             await ProvisionServiceAsync(connection, InitiatorServiceName, InitiatorQueueName, cancellationToken).ConfigureAwait(false);
-            await ProvisionServiceAsync(connection, TargetServiceName, TargetQueueName, cancellationToken).ConfigureAwait(false);
-            await ProvisionServiceAsync(connection, DeadLetterServiceName, DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
+
+            // Per-class RECEIVE-side objects: each set's target queue+service and deadletter queue+service, all ON
+            // the shared contract. Driven by AllSets so teardown drops exactly what provisioning created.
+            foreach (var set in AllSets)
+            {
+                await ProvisionQueueAsync(connection, set.TargetQueueName, cancellationToken).ConfigureAwait(false);
+                await ProvisionQueueAsync(connection, set.DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
+
+                await ProvisionServiceAsync(connection, set.TargetServiceName, set.TargetQueueName, cancellationToken).ConfigureAwait(false);
+                await ProvisionServiceAsync(connection, set.DeadLetterServiceName, set.DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
+            }
         }
 
         // Drops every provisioned Service Broker object (services, queues, contract, message type) and the
@@ -102,13 +146,20 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                 await using var connection = new SqlConnection(appConnectionString);
                 await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-                await DropServiceAsync(connection, InitiatorServiceName, cancellationToken).ConfigureAwait(false);
-                await DropServiceAsync(connection, TargetServiceName, cancellationToken).ConfigureAwait(false);
-                await DropServiceAsync(connection, DeadLetterServiceName, cancellationToken).ConfigureAwait(false);
+                // Per-class objects first: drop each set's services then its queues (services reference queues so
+                // services must go first). Driven by the SAME AllSets enumerable provisioning used, so nothing leaks.
+                foreach (var set in AllSets)
+                {
+                    await DropServiceAsync(connection, set.TargetServiceName, cancellationToken).ConfigureAwait(false);
+                    await DropServiceAsync(connection, set.DeadLetterServiceName, cancellationToken).ConfigureAwait(false);
 
+                    await DropQueueAsync(connection, set.TargetQueueName, cancellationToken).ConfigureAwait(false);
+                    await DropQueueAsync(connection, set.DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
+                }
+
+                // Shared objects last, in reverse dependency order: initiator service+queue, then contract+type.
+                await DropServiceAsync(connection, InitiatorServiceName, cancellationToken).ConfigureAwait(false);
                 await DropQueueAsync(connection, InitiatorQueueName, cancellationToken).ConfigureAwait(false);
-                await DropQueueAsync(connection, TargetQueueName, cancellationToken).ConfigureAwait(false);
-                await DropQueueAsync(connection, DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
 
                 await DropContractAsync(connection, cancellationToken).ConfigureAwait(false);
                 await DropMessageTypeAsync(connection, cancellationToken).ConfigureAwait(false);

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Service Broker provisioning + teardown helper for the SSB integration harness (STEP-003).
+    //
+    // The production receiver (SqlServiceBrokerReceiver) and sender (SqlServiceBrokerSender) HARD-REFERENCE
+    // the Chatter message type "//Chatter/BrokeredMessage" (ServicesMessageTypes.ChatterBrokeredMessageType)
+    // and the contract "//Chatter" (ServicesMessageTypes.ChatterServiceContract) for the Chatter-brokered
+    // path, so this harness provisions EXACTLY those names. Everything else (DB, service, queue names) is
+    // harness-chosen but exposed as reusable constants so the STEP-004 fixture wires the same identifiers into
+    // ReceiverOptions.MessageReceiverPath / DeadLetterQueuePath and the stamped SSBMessageContext headers.
+    //
+    // All CREATE/DROP statements are idempotent (guarded against sys.* catalog views) so re-runs never throw.
+    // The initial connect + ENABLE_BROKER is wrapped in a SHORT bounded retry to absorb container-readiness
+    // races; it never loops unbounded.
+    internal static class ServiceBrokerProvisioning
+    {
+        // Dedicated application database the harness provisions Service Broker objects in. Kept distinct from
+        // any database the SQL container ships with so teardown can drop it wholesale.
+        public const string DatabaseName = "chatter_ssb_it";
+
+        // Production-pinned Service Broker object names. The receiver only accepts (and the sender only stamps)
+        // these exact strings on the Chatter-brokered path, so they MUST match ServicesMessageTypes.
+        public const string MessageTypeName = "//Chatter/BrokeredMessage";
+        public const string ContractName = "//Chatter";
+
+        // Harness-chosen Service Broker SERVICE names. All three sit ON the //Chatter contract: the sender
+        // begins a dialog FROM the initiator TO the target ON CONTRACT, and the deadletter path begins a dialog
+        // TO the DLQ service ON the same contract, so every service must be contract-bound to be a valid target.
+        public const string InitiatorServiceName = "chatter_ssb_it_initiator_service";
+        public const string TargetServiceName = "chatter_ssb_it_target_service";
+        public const string DeadLetterServiceName = "chatter_ssb_it_deadletter_service";
+
+        // Harness-chosen Service Broker QUEUE names. The target queue is the one the receiver pump RECEIVEs
+        // from. ReceiveMessageFromQueueCommand interpolates the queue name directly into "FROM {queue}", so the
+        // STEP-004 fixture must hand the receiver the bracket-quoted form (TargetQueuePathBracketed).
+        public const string InitiatorQueueName = "chatter_ssb_it_initiator_queue";
+        public const string TargetQueueName = "chatter_ssb_it_target_queue";
+        public const string DeadLetterQueueName = "chatter_ssb_it_deadletter_queue";
+
+        // Bracket-quoted target queue identifier suitable for direct interpolation into the receiver's
+        // "FROM {queue}" RECEIVE statement. STEP-004 sets ReceiverOptions.MessageReceiverPath to this value.
+        public const string TargetQueuePathBracketed = "[" + TargetQueueName + "]";
+
+        // Bounded readiness retry. A freshly started SQL Server container can refuse connections or report the
+        // broker not-yet-enabled for a brief window; these caps keep the retry short and finite.
+        private const int MaxConnectAttempts = 10;
+        private static readonly TimeSpan ConnectRetryDelay = TimeSpan.FromSeconds(2);
+
+        // Creates the dedicated database, enables Service Broker on it, and idempotently provisions the message
+        // type, contract, queues, and services. Safe to call repeatedly. The connect + database/broker setup is
+        // retried a bounded number of times to absorb container-readiness races; provisioning DDL is not retried
+        // because by then the server is known-reachable.
+        public static async Task SetupAsync(string masterConnectionString, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(masterConnectionString))
+            {
+                throw new ArgumentException("A connection string to the 'master' database is required.", nameof(masterConnectionString));
+            }
+
+            await EnsureDatabaseAndBrokerAsync(masterConnectionString, cancellationToken).ConfigureAwait(false);
+
+            var appConnectionString = BuildAppConnectionString(masterConnectionString);
+            await using var connection = new SqlConnection(appConnectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await ProvisionMessageTypeAsync(connection, cancellationToken).ConfigureAwait(false);
+            await ProvisionContractAsync(connection, cancellationToken).ConfigureAwait(false);
+
+            await ProvisionQueueAsync(connection, InitiatorQueueName, cancellationToken).ConfigureAwait(false);
+            await ProvisionQueueAsync(connection, TargetQueueName, cancellationToken).ConfigureAwait(false);
+            await ProvisionQueueAsync(connection, DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
+
+            await ProvisionServiceAsync(connection, InitiatorServiceName, InitiatorQueueName, cancellationToken).ConfigureAwait(false);
+            await ProvisionServiceAsync(connection, TargetServiceName, TargetQueueName, cancellationToken).ConfigureAwait(false);
+            await ProvisionServiceAsync(connection, DeadLetterServiceName, DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Drops every provisioned Service Broker object (services, queues, contract, message type) and the
+        // dedicated database. Idempotent: each drop is guarded so missing objects never throw. The database drop
+        // forces SINGLE_USER WITH ROLLBACK IMMEDIATE first so lingering harness connections cannot block it.
+        public static async Task TeardownAsync(string masterConnectionString, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrWhiteSpace(masterConnectionString))
+            {
+                throw new ArgumentException("A connection string to the 'master' database is required.", nameof(masterConnectionString));
+            }
+
+            if (!await DatabaseExistsAsync(masterConnectionString, cancellationToken).ConfigureAwait(false))
+            {
+                return;
+            }
+
+            var appConnectionString = BuildAppConnectionString(masterConnectionString);
+
+            try
+            {
+                await using var connection = new SqlConnection(appConnectionString);
+                await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                await DropServiceAsync(connection, InitiatorServiceName, cancellationToken).ConfigureAwait(false);
+                await DropServiceAsync(connection, TargetServiceName, cancellationToken).ConfigureAwait(false);
+                await DropServiceAsync(connection, DeadLetterServiceName, cancellationToken).ConfigureAwait(false);
+
+                await DropQueueAsync(connection, InitiatorQueueName, cancellationToken).ConfigureAwait(false);
+                await DropQueueAsync(connection, TargetQueueName, cancellationToken).ConfigureAwait(false);
+                await DropQueueAsync(connection, DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
+
+                await DropContractAsync(connection, cancellationToken).ConfigureAwait(false);
+                await DropMessageTypeAsync(connection, cancellationToken).ConfigureAwait(false);
+            }
+            catch (SqlException)
+            {
+                // The database is about to be dropped wholesale; an object-level drop failure (e.g. the broker
+                // tore objects down already) must not mask teardown. The DROP DATABASE below is authoritative.
+            }
+
+            await DropDatabaseAsync(masterConnectionString, cancellationToken).ConfigureAwait(false);
+        }
+
+        // Connects to 'master', creates the app database if absent, and enables Service Broker on it. Wrapped in
+        // a bounded retry so a not-yet-ready container surfaces as a retry rather than a hard failure.
+        private static async Task EnsureDatabaseAndBrokerAsync(string masterConnectionString, CancellationToken cancellationToken)
+        {
+            var attempt = 0;
+            while (true)
+            {
+                attempt++;
+                try
+                {
+                    await using var connection = new SqlConnection(masterConnectionString);
+                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                    await ExecuteNonQueryAsync(connection,
+                        $"IF DB_ID('{DatabaseName}') IS NULL CREATE DATABASE [{DatabaseName}];",
+                        cancellationToken).ConfigureAwait(false);
+
+                    // ROLLBACK IMMEDIATE evicts any other session holding the database so the broker can be
+                    // enabled deterministically. Guarded so an already-enabled broker is left untouched.
+                    await ExecuteNonQueryAsync(connection,
+                        "IF NOT EXISTS (SELECT 1 FROM sys.databases " +
+                        $"WHERE name = '{DatabaseName}' AND is_broker_enabled = 1) " +
+                        $"ALTER DATABASE [{DatabaseName}] SET ENABLE_BROKER WITH ROLLBACK IMMEDIATE;",
+                        cancellationToken).ConfigureAwait(false);
+
+                    return;
+                }
+                catch (SqlException) when (attempt < MaxConnectAttempts)
+                {
+                    await Task.Delay(ConnectRetryDelay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        private static async Task ProvisionMessageTypeAsync(SqlConnection connection, CancellationToken cancellationToken)
+            => await ExecuteNonQueryAsync(connection,
+                "IF NOT EXISTS (SELECT 1 FROM sys.service_message_types WHERE name = @name) " +
+                $"CREATE MESSAGE TYPE [{MessageTypeName}] VALIDATION = NONE;",
+                cancellationToken,
+                ("@name", MessageTypeName)).ConfigureAwait(false);
+
+        private static async Task ProvisionContractAsync(SqlConnection connection, CancellationToken cancellationToken)
+            => await ExecuteNonQueryAsync(connection,
+                "IF NOT EXISTS (SELECT 1 FROM sys.service_contracts WHERE name = @name) " +
+                $"CREATE CONTRACT [{ContractName}] ([{MessageTypeName}] SENT BY ANY);",
+                cancellationToken,
+                ("@name", ContractName)).ConfigureAwait(false);
+
+        private static async Task ProvisionQueueAsync(SqlConnection connection, string queueName, CancellationToken cancellationToken)
+            => await ExecuteNonQueryAsync(connection,
+                "IF NOT EXISTS (SELECT 1 FROM sys.service_queues WHERE name = @name) " +
+                $"CREATE QUEUE [{queueName}];",
+                cancellationToken,
+                ("@name", queueName)).ConfigureAwait(false);
+
+        private static async Task ProvisionServiceAsync(SqlConnection connection, string serviceName, string queueName, CancellationToken cancellationToken)
+            => await ExecuteNonQueryAsync(connection,
+                "IF NOT EXISTS (SELECT 1 FROM sys.services WHERE name = @name) " +
+                $"CREATE SERVICE [{serviceName}] ON QUEUE [{queueName}] ([{ContractName}]);",
+                cancellationToken,
+                ("@name", serviceName)).ConfigureAwait(false);
+
+        private static async Task DropServiceAsync(SqlConnection connection, string serviceName, CancellationToken cancellationToken)
+            => await ExecuteNonQueryAsync(connection,
+                "IF EXISTS (SELECT 1 FROM sys.services WHERE name = @name) " +
+                $"DROP SERVICE [{serviceName}];",
+                cancellationToken,
+                ("@name", serviceName)).ConfigureAwait(false);
+
+        private static async Task DropQueueAsync(SqlConnection connection, string queueName, CancellationToken cancellationToken)
+            => await ExecuteNonQueryAsync(connection,
+                "IF EXISTS (SELECT 1 FROM sys.service_queues WHERE name = @name) " +
+                $"DROP QUEUE [{queueName}];",
+                cancellationToken,
+                ("@name", queueName)).ConfigureAwait(false);
+
+        private static async Task DropContractAsync(SqlConnection connection, CancellationToken cancellationToken)
+            => await ExecuteNonQueryAsync(connection,
+                "IF EXISTS (SELECT 1 FROM sys.service_contracts WHERE name = @name) " +
+                $"DROP CONTRACT [{ContractName}];",
+                cancellationToken,
+                ("@name", ContractName)).ConfigureAwait(false);
+
+        private static async Task DropMessageTypeAsync(SqlConnection connection, CancellationToken cancellationToken)
+            => await ExecuteNonQueryAsync(connection,
+                "IF EXISTS (SELECT 1 FROM sys.service_message_types WHERE name = @name) " +
+                $"DROP MESSAGE TYPE [{MessageTypeName}];",
+                cancellationToken,
+                ("@name", MessageTypeName)).ConfigureAwait(false);
+
+        private static async Task<bool> DatabaseExistsAsync(string masterConnectionString, CancellationToken cancellationToken)
+        {
+            await using var connection = new SqlConnection(masterConnectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await using var command = connection.CreateCommand();
+            command.CommandText = $"SELECT DB_ID('{DatabaseName}');";
+            var result = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            return result != null && result != DBNull.Value;
+        }
+
+        private static async Task DropDatabaseAsync(string masterConnectionString, CancellationToken cancellationToken)
+        {
+            await using var connection = new SqlConnection(masterConnectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await ExecuteNonQueryAsync(connection,
+                $"IF DB_ID('{DatabaseName}') IS NOT NULL " +
+                "BEGIN " +
+                $"ALTER DATABASE [{DatabaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; " +
+                $"DROP DATABASE [{DatabaseName}]; " +
+                "END;",
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // Returns the supplied master connection string repointed at the app database, preserving every other
+        // setting (credentials, encryption, trust flags) the harness configured for the container.
+        private static string BuildAppConnectionString(string masterConnectionString)
+        {
+            var builder = new SqlConnectionStringBuilder(masterConnectionString)
+            {
+                InitialCatalog = DatabaseName,
+            };
+            return builder.ConnectionString;
+        }
+
+        private static async Task ExecuteNonQueryAsync(SqlConnection connection, string commandText, CancellationToken cancellationToken, params (string Name, object Value)[] parameters)
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = commandText;
+            foreach (var (name, value) in parameters)
+            {
+                command.Parameters.Add(new SqlParameter(name, value));
+            }
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SqlServiceBrokerFixture.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SqlServiceBrokerFixture.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Testcontainers.MsSql;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Collection fixture that brings up a SQL Server container once per test collection and provisions the
+    // Service Broker objects (database, message type, contract, queues, services) the SSB integration harness
+    // sends/receives over, via ServiceBrokerProvisioning. The provisioned object names are the production-pinned
+    // and harness-chosen constants on ServiceBrokerProvisioning, which the ChatterSsbPipelineHarness wires into
+    // ReceiverOptions and the stamped SSBMessageContext headers.
+    //
+    // When Docker is unavailable the fixture is a no-op: InitializeAsync starts nothing (the container stays
+    // null) and GetAppConnectionString throws. The RequiresDockerFact attribute SKIPS the tests at discovery
+    // time in that case, so a no-Docker `dotnet test` stays green and the fixture's throw is never reached.
+    // This mirrors the Azure Service Bus emulator fixture.
+    public sealed class SqlServiceBrokerFixture : IAsyncLifetime
+    {
+        // The SQL Server image is passed explicitly to MsSqlBuilder (the parameterless ctor is obsolete),
+        // mirroring how the Azure Service Bus emulator fixture pins its image. This is the Testcontainers.MsSql
+        // module's documented default image and supports the ENABLE_BROKER / Service Broker objects the harness
+        // provisions.
+        private const string SqlServerImage = "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04";
+
+        private MsSqlContainer _container;
+
+        // The master connection string for the running container. Throws if the container was not started
+        // (Docker unavailable), mirroring the Azure Service Bus fixture's GetConnectionString throw.
+        public string GetMasterConnectionString()
+        {
+            if (_container is null)
+            {
+                throw new InvalidOperationException(
+                    "The SQL Server container was not started (Docker unavailable). " +
+                    "Integration tests must be guarded with [RequiresDockerFact].");
+            }
+
+            return _container.GetConnectionString();
+        }
+
+        // The connection string pointed at the provisioned application database (ServiceBrokerProvisioning
+        // .DatabaseName). Derived from the master connection string by repointing InitialCatalog so every other
+        // setting (credentials, encryption, trust flags) the container configured is preserved. Throws if the
+        // container was not started.
+        public string GetAppConnectionString()
+        {
+            var builder = new SqlConnectionStringBuilder(GetMasterConnectionString())
+            {
+                InitialCatalog = ServiceBrokerProvisioning.DatabaseName,
+            };
+            return builder.ConnectionString;
+        }
+
+        public async Task InitializeAsync()
+        {
+            if (!DockerEnvironment.IsAvailable)
+            {
+                return;
+            }
+
+            _container = new MsSqlBuilder(SqlServerImage).Build();
+            await _container.StartAsync().ConfigureAwait(false);
+
+            await ServiceBrokerProvisioning
+                .SetupAsync(_container.GetConnectionString(), CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_container is null)
+            {
+                return;
+            }
+
+            try
+            {
+                await ServiceBrokerProvisioning
+                    .TeardownAsync(_container.GetConnectionString(), CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception)
+            {
+                // Best-effort teardown: the container is disposed below regardless, so a provisioning-object
+                // drop failure must not mask container disposal.
+            }
+
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+    }
+
+    [CollectionDefinition(Name)]
+    public sealed class SqlServiceBrokerCollection : ICollectionFixture<SqlServiceBrokerFixture>
+    {
+        public const string Name = "SqlServiceBroker";
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SqlServiceBrokerFixture.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SqlServiceBrokerFixture.cs
@@ -25,6 +25,13 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         // provisions.
         private const string SqlServerImage = "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04";
 
+        // Bounds container start + provisioning so a wedged Docker pull/start or a hung provisioning DDL fails
+        // fast instead of hanging the test collection. Generous because a cold image pull is slow; still finite.
+        private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
+
+        // Bounds the best-effort teardown so a hung object drop cannot block container disposal indefinitely.
+        private static readonly TimeSpan TeardownTimeout = TimeSpan.FromSeconds(30);
+
         private MsSqlContainer _container;
 
         // The master connection string for the running container. Throws if the container was not started
@@ -61,11 +68,13 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                 return;
             }
 
+            using var startupCts = new CancellationTokenSource(StartupTimeout);
+
             _container = new MsSqlBuilder(SqlServerImage).Build();
-            await _container.StartAsync().ConfigureAwait(false);
+            await _container.StartAsync(startupCts.Token).ConfigureAwait(false);
 
             await ServiceBrokerProvisioning
-                .SetupAsync(_container.GetConnectionString(), CancellationToken.None)
+                .SetupAsync(_container.GetConnectionString(), startupCts.Token)
                 .ConfigureAwait(false);
         }
 
@@ -78,14 +87,15 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
 
             try
             {
+                using var teardownCts = new CancellationTokenSource(TeardownTimeout);
                 await ServiceBrokerProvisioning
-                    .TeardownAsync(_container.GetConnectionString(), CancellationToken.None)
+                    .TeardownAsync(_container.GetConnectionString(), teardownCts.Token)
                     .ConfigureAwait(false);
             }
             catch (Exception)
             {
                 // Best-effort teardown: the container is disposed below regardless, so a provisioning-object
-                // drop failure must not mask container disposal.
+                // drop failure (or a teardown that exceeded TeardownTimeout) must not mask container disposal.
             }
 
             await _container.DisposeAsync().ConfigureAwait(false);

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDeadLetterTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDeadLetterTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Deadletter→DLQ integration proof for the SQL Service Broker integration harness (STEP-007). The SYSTEM
+    // UNDER TEST is Chatter's deadletter path: when RecordingMessageHandler<T> throws and the receiver's
+    // ReceiveAttempts has reached MaxReceiveAttempts, BrokeredMessageReceiver routes to
+    // SqlServiceBrokerReceiver.DeadletterMessageAsync, which ends the original dialog and dispatches a NEW
+    // OutboundBrokeredMessage to the configured deadletter service (ReceiverOptions.DeadLetterQueuePath) with the
+    // failure headers stamped on its MessageContext. The test reads the deadletter QUEUE directly at the test
+    // edge and asserts the envelope's failure headers.
+    //
+    // DEADLETTER TRIGGER LEVER: AddQueueReceiver's maxReceiveAttempts is set to 1. SqlServiceBrokerReceiver does
+    // NOT override MessageDeliveryCountAsync, so BrokeredMessageReceiver uses the interface default, which returns
+    // the inbound MessageContext.ReceiveAttempts (the receiver's local per-conversation delivery count, stamped
+    // starting at 1 on the very first delivery). On the first handler throw the worker computes
+    // deliveryCount (1) >= MaxReceiveAttempts (1) and deadletters IMMEDIATELY rather than nacking/redelivering —
+    // so the message reaches the DLQ on the first attempt with no redelivery loop to bound.
+    //
+    // FAILURE-HEADER KEYS ASSERTED (the keys DeadletterMessageAsync stamps onto the deadletter envelope's
+    // MessageContext): MessageContext.FailureDescription, MessageContext.FailureDetails,
+    // MessageContext.InfrastructureType, MessageContext.ReceiveAttempts.
+    //
+    // HOW THE DLQ IS READ AT THE TEST EDGE: a raw ADO.NET RECEIVE from the deadletter queue
+    // (ServiceBrokerProvisioning.DeadLetterQueueName), mirroring production's decompress CASE so the
+    // message_body bytes are the raw envelope, then JsonUnicodeBodyConverter.Convert<OutboundBrokeredMessage>
+    // deserializes the envelope EXACTLY as the SqlServiceBrokerSender wrote it (deadletter message type is
+    // //Chatter/BrokeredMessage, so the body is the serialized OutboundBrokeredMessage envelope). The deadletter
+    // dialog targets the deadletter SERVICE, which delivers onto the deadletter QUEUE, so reading the queue
+    // observes the deadlettered message.
+    //
+    // The fact is gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green. Mirrors SsbNackRedeliveryTests / SsbRoundTripTests for harness setup and
+    // collection membership.
+    [Trait("Category", "Integration")]
+    [Collection(SqlServiceBrokerCollection.Name)]
+    public class SsbDeadLetterTests
+    {
+        private static readonly TimeSpan DeadLetterWait = TimeSpan.FromSeconds(30);
+
+        private readonly SqlServiceBrokerFixture _fixture;
+
+        public SsbDeadLetterTests(SqlServiceBrokerFixture fixture)
+            => _fixture = fixture;
+
+        // Distinct command type so this test's queue state is independent of the other integration tests in the
+        // collection.
+        public sealed class DeadLetterCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        private ChatterSsbPipelineHarness BuildHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                // maxReceiveAttempts: 1 is the deadletter trigger lever — the first throw deadletters immediately
+                // because ReceiveAttempts (1) >= MaxReceiveAttempts (1).
+                ssb => ssb.AddQueueReceiver<DeadLetterCommand>(
+                    ServiceBrokerProvisioning.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterServiceName,
+                    maxReceiveAttempts: 1),
+                typeof(DeadLetterCommand));
+
+        // Deadletter→DLQ: a throwing handler at MaxReceiveAttempts=1 causes DeadletterMessageAsync to send the
+        // failed message to the deadletter service. Assert (a) the message lands on the deadletter QUEUE, and
+        // (b) the deadletter envelope's MessageContext carries the failure headers the receiver stamps
+        // (FailureDescription, FailureDetails, InfrastructureType, ReceiveAttempts).
+        [RequiresDockerFact]
+        public async Task ThrowingHandlerAtMaxAttemptsDeadlettersToDeadLetterQueue()
+        {
+            var harness = BuildHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                // Arm the throw BEFORE sending so the handler throws on the first (and only) delivery; with
+                // MaxReceiveAttempts=1 that single throw deadletters rather than redelivering, so the throw is
+                // left armed for the lifetime of the scenario (no anti-infinite-loop disarm needed — there is no
+                // redelivery loop).
+                harness.GetSignal<DeadLetterCommand>().ThrowOnHandle =
+                    () => new InvalidOperationException("deadletter-test forced throw");
+
+                await harness.SendAsync(new DeadLetterCommand { Marker = "deadletter" });
+
+                // The handler must be invoked at least once before deadlettering can occur. WaitForHandledAsync
+                // throws TimeoutException if the handler is never reached, failing fast instead of hanging.
+                await harness.WaitForHandledAsync<DeadLetterCommand>(DeadLetterWait);
+
+                // Read the deadletter QUEUE at the test edge. The deadletter dispatch happens AFTER the handler
+                // throw on the receiver thread, so poll the queue (bounded) until the deadlettered envelope
+                // arrives rather than racing the dispatch.
+                var deadLettered = await ReceiveFromDeadLetterQueueAsync(DeadLetterWait);
+
+                deadLettered.Should().NotBeNull(
+                    "the throwing handler at MaxReceiveAttempts=1 must cause DeadletterMessageAsync to dispatch " +
+                    "the failed message to the deadletter service, which delivers it onto the deadletter queue");
+
+                // The deadletter envelope's MessageContext carries the failure headers DeadletterMessageAsync
+                // stamps. FailureDescription is the deadLetterErrorDescription (the handler exception's ToString),
+                // FailureDetails is the deadLetterReason ("Poisoned message received").
+                deadLettered.MessageContext.Should().ContainKey(MessageContext.FailureDescription,
+                    "DeadletterMessageAsync stamps FailureDescription with the deadletter error description");
+                deadLettered.MessageContext[MessageContext.FailureDescription].ToString()
+                    .Should().Contain("deadletter-test forced throw",
+                        "the deadletter error description carries the originating handler exception");
+
+                deadLettered.MessageContext.Should().ContainKey(MessageContext.FailureDetails,
+                    "DeadletterMessageAsync stamps FailureDetails with the deadletter reason");
+
+                // InfrastructureType identifies the SSB receiver as the deadletter origin.
+                deadLettered.MessageContext.Should().ContainKey(MessageContext.InfrastructureType);
+                deadLettered.MessageContext[MessageContext.InfrastructureType].ToString()
+                    .Should().Be(SSBMessageContext.InfrastructureType);
+
+                // ReceiveAttempts must equal the MaxReceiveAttempts that tripped the deadletter (1).
+                deadLettered.MessageContext.Should().ContainKey(MessageContext.ReceiveAttempts);
+                Convert.ToInt32(deadLettered.MessageContext[MessageContext.ReceiveAttempts])
+                    .Should().Be(1, "the deadletter fired on the first delivery (MaxReceiveAttempts=1)");
+            }
+            finally
+            {
+                // Disarm before teardown so any in-flight redelivery (defensive; none expected at
+                // MaxReceiveAttempts=1) does not throw during the drain.
+                harness.GetSignal<DeadLetterCommand>().ThrowOnHandle = null;
+                await harness.DisposeAsync();
+            }
+        }
+
+        // Bounded poll of the deadletter queue, reading the deadlettered OutboundBrokeredMessage envelope at the
+        // test edge via raw ADO.NET. RECEIVE is non-blocking (no WAITFOR) so an empty queue returns immediately
+        // and the poll loop sleeps before retrying; returns null if the deadline elapses with no message so the
+        // caller's assertion fails fast rather than hanging. The decompress CASE mirrors production's RECEIVE so
+        // the message_body bytes are the raw envelope regardless of broker-side compression.
+        private async Task<OutboundBrokeredMessage> ReceiveFromDeadLetterQueueAsync(TimeSpan timeout)
+        {
+            var bodyConverter = new JsonUnicodeBodyConverter();
+            var deadline = DateTime.UtcNow + timeout;
+
+            await using var connection = new SqlConnection(_fixture.GetAppConnectionString());
+            await connection.OpenAsync().ConfigureAwait(false);
+
+            while (DateTime.UtcNow < deadline)
+            {
+                await using var transaction = (SqlTransaction)await connection.BeginTransactionAsync().ConfigureAwait(false);
+
+                byte[] messageBody = null;
+                await using (var command = connection.CreateCommand())
+                {
+                    command.Transaction = transaction;
+                    command.CommandText =
+                        "RECEIVE TOP(1) " +
+                        "CASE WHEN SUBSTRING(message_body, 1, 2) = 0x1F8B " +
+                        "THEN CAST(decompress(message_body) AS VARBINARY(MAX)) " +
+                        "ELSE message_body END AS message_body, message_type_name " +
+                        $"FROM [{ServiceBrokerProvisioning.DeadLetterQueueName}]";
+
+                    await using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+                    if (reader.Read() && !reader.IsDBNull(0))
+                    {
+                        messageBody = reader.GetSqlBytes(0).Buffer;
+                    }
+                }
+
+                await transaction.CommitAsync().ConfigureAwait(false);
+
+                if (messageBody != null)
+                {
+                    // The deadletter message type is //Chatter/BrokeredMessage, so the body is the serialized
+                    // OutboundBrokeredMessage envelope the SqlServiceBrokerSender wrote.
+                    return bodyConverter.Convert<OutboundBrokeredMessage>(messageBody);
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDeadLetterTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDeadLetterTests.cs
@@ -146,12 +146,17 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             var bodyConverter = new JsonUnicodeBodyConverter();
             var deadline = DateTime.UtcNow + timeout;
 
+            // Bound the per-operation DB awaits to the same deadline the poll loop enforces, so a wedged
+            // OpenAsync/ExecuteReaderAsync fails fast instead of awaiting on CancellationToken.None forever.
+            using var operationCts = new CancellationTokenSource(timeout);
+            var operationToken = operationCts.Token;
+
             await using var connection = new SqlConnection(_fixture.GetAppConnectionString());
-            await connection.OpenAsync().ConfigureAwait(false);
+            await connection.OpenAsync(operationToken).ConfigureAwait(false);
 
             while (DateTime.UtcNow < deadline)
             {
-                await using var transaction = (SqlTransaction)await connection.BeginTransactionAsync().ConfigureAwait(false);
+                await using var transaction = (SqlTransaction)await connection.BeginTransactionAsync(operationToken).ConfigureAwait(false);
 
                 byte[] messageBody = null;
                 await using (var command = connection.CreateCommand())
@@ -164,7 +169,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                         "ELSE message_body END AS message_body, message_type_name " +
                         $"FROM [{ServiceBrokerProvisioning.DeadLetterSet.DeadLetterQueueName}]";
 
-                    await using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
+                    await using var reader = await command.ExecuteReaderAsync(operationToken).ConfigureAwait(false);
                     if (reader.Read() && !reader.IsDBNull(0))
                     {
                         messageBody = reader.GetSqlBytes(0).Buffer;

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDeadLetterTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDeadLetterTests.cs
@@ -31,7 +31,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
     // MessageContext.InfrastructureType, MessageContext.ReceiveAttempts.
     //
     // HOW THE DLQ IS READ AT THE TEST EDGE: a raw ADO.NET RECEIVE from the deadletter queue
-    // (ServiceBrokerProvisioning.DeadLetterQueueName), mirroring production's decompress CASE so the
+    // (ServiceBrokerProvisioning.DeadLetterSet.DeadLetterQueueName), mirroring production's decompress CASE so the
     // message_body bytes are the raw envelope, then JsonUnicodeBodyConverter.Convert<OutboundBrokeredMessage>
     // deserializes the envelope EXACTLY as the SqlServiceBrokerSender wrote it (deadletter message type is
     // //Chatter/BrokeredMessage, so the body is the serialized OutboundBrokeredMessage envelope). The deadletter
@@ -62,11 +62,12 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         private ChatterSsbPipelineHarness BuildHarness()
             => ChatterSsbPipelineHarness.Build(
                 _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.DeadLetterSet,
                 // maxReceiveAttempts: 1 is the deadletter trigger lever — the first throw deadletters immediately
                 // because ReceiveAttempts (1) >= MaxReceiveAttempts (1).
                 ssb => ssb.AddQueueReceiver<DeadLetterCommand>(
-                    ServiceBrokerProvisioning.TargetQueuePathBracketed,
-                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterServiceName,
+                    ServiceBrokerProvisioning.DeadLetterSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterSet.DeadLetterServiceName,
                     maxReceiveAttempts: 1),
                 typeof(DeadLetterCommand));
 
@@ -161,7 +162,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                         "CASE WHEN SUBSTRING(message_body, 1, 2) = 0x1F8B " +
                         "THEN CAST(decompress(message_body) AS VARBINARY(MAX)) " +
                         "ELSE message_body END AS message_body, message_type_name " +
-                        $"FROM [{ServiceBrokerProvisioning.DeadLetterQueueName}]";
+                        $"FROM [{ServiceBrokerProvisioning.DeadLetterSet.DeadLetterQueueName}]";
 
                     await using var reader = await command.ExecuteReaderAsync().ConfigureAwait(false);
                     if (reader.Read() && !reader.IsDBNull(0))

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDialogLifecycleTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDialogLifecycleTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Dialog-lifecycle and bounded-timeout/cancellation teardown proofs for the SQL Service Broker integration
+    // harness (STEP-008). Two orthogonal concerns:
+    //
+    //   Test A — EndDialog auto-ack tolerance: proves the EndDialog system message that SSB delivers after
+    //   SqlServiceBrokerReceiver.AckMessageAsync commits the RECEIVE transaction is classified by
+    //   ServiceBrokerMessageClassifier as ClassificationOutcome.EndDialog, routed to AckEndDialogAsync (auto-acked
+    //   and committed), and never forwarded to Chatter's dispatcher — so InvocationCount stays at exactly 1.
+    //
+    //   Test B — Bounded teardown / WAITFOR-hang guard: proves that a harness with a finite
+    //   ReceiverTimeoutInMilliseconds against an EMPTY queue (WAITFOR RECEIVE ... TIMEOUT 5 returns an empty row
+    //   set promptly and loops on the pump CancellationToken) tears down within a bounded wall-clock window.
+    //   DisposeAsync cancels the pump CTS then stops the host; a blocked/looping RECEIVE unwinds via token
+    //   cancellation. The test wraps DisposeAsync in Task.WhenAny vs Task.Delay(30 s) and asserts the dispose
+    //   task won, proving no WAITFOR hang.
+    //
+    // Both facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green. Mirrors SsbRoundTripTests for collection membership.
+    [Trait("Category", "Integration")]
+    [Collection(SqlServiceBrokerCollection.Name)]
+    public class SsbDialogLifecycleTests
+    {
+        // How long to wait for the command handler to be invoked.
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
+
+        // After the command is handled, how long to let the pump loop before asserting InvocationCount is still 1.
+        // The EndDialog system message arrives on the same queue within milliseconds; a brief settle is enough.
+        private static readonly TimeSpan EndDialogSettleWait = TimeSpan.FromSeconds(3);
+
+        // Maximum wall-clock window for DisposeAsync to complete on a harness whose queue is empty. The pump loops
+        // on a 5 ms WAITFOR, so cancellation unwinds within one loop iteration; 30 s is a generous CI bound.
+        private static readonly TimeSpan TeardownBound = TimeSpan.FromSeconds(30);
+
+        private readonly SqlServiceBrokerFixture _fixture;
+
+        public SsbDialogLifecycleTests(SqlServiceBrokerFixture fixture)
+            => _fixture = fixture;
+
+        // Distinct command type so this test class's queue state is independent of the other integration test
+        // classes sharing the same SqlServiceBroker collection.
+        public sealed class DialogLifecycleCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        private ChatterSsbPipelineHarness BuildHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                ssb => ssb.AddQueueReceiver<DialogLifecycleCommand>(
+                    ServiceBrokerProvisioning.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterServiceName),
+                typeof(DialogLifecycleCommand));
+
+        // Test A — dialog begin/end + EndDialog auto-ack tolerance.
+        //
+        // Dispatch one command and wait for the handler. After the handler invocation Chatter's ACK path
+        // (SqlServiceBrokerReceiver.AckMessageAsync) commits and issues END CONVERSATION, which causes SSB to
+        // deliver an EndDialog system message back onto the same queue. ServiceBrokerMessageClassifier classifies
+        // that message as ClassificationOutcome.EndDialog; the receiver routes it to AckEndDialogAsync (auto-acked,
+        // never dispatched to Chatter's handler pipeline). Assert:
+        //   (a) the round-trip succeeds — the handler is invoked with the correct payload;
+        //   (b) InvocationCount == 1 immediately after the handler wait (EndDialog not yet received); and
+        //   (c) InvocationCount is STILL 1 after a bounded settle, proving the EndDialog auto-ack path does not
+        //       forward the system message to the handler.
+        [RequiresDockerFact]
+        public async Task EndDialogSystemMessageIsAutoAckedAndDoesNotReachHandler()
+        {
+            var harness = BuildHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                var sent = new DialogLifecycleCommand { Marker = "dialog-lifecycle" };
+                await harness.SendAsync(sent);
+
+                var handled = await harness.WaitForHandledAsync<DialogLifecycleCommand>(HandlerWait);
+
+                // (a) The round trip completed: the handler received the command with its payload intact.
+                handled.Message.Should().NotBeNull(
+                    "Chatter's SSB pipeline must deliver the command to the handler");
+                handled.Message.Marker.Should().Be("dialog-lifecycle");
+
+                // (b) Immediately after the handler wait InvocationCount must be exactly 1.
+                harness.GetSignal<DialogLifecycleCommand>().InvocationCount
+                    .Should().Be(1,
+                        "only the command dispatch should have reached the handler at this point");
+
+                // (c) Let the pump loop for a bounded window so the EndDialog system message has time to arrive
+                // and be processed. InvocationCount must remain at 1: the classifier routes EndDialog system
+                // messages to AckEndDialogAsync (auto-acked + committed) and returns null, so ReceiveMessageAsync
+                // returns null and the dispatcher is never invoked.
+                await Task.Delay(EndDialogSettleWait).ConfigureAwait(false);
+
+                harness.GetSignal<DialogLifecycleCommand>().InvocationCount
+                    .Should().Be(1,
+                        "the EndDialog system message must be auto-acked by the classifier and must NOT reach " +
+                        "the handler; InvocationCount must stay at 1 after the settle window");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+
+        // Test B — bounded-timeout / cancellation teardown (the WAITFOR-hang guard).
+        //
+        // Build and start a harness with a receiver but dispatch NOTHING. The queue stays empty, so each pump
+        // iteration issues WAITFOR(RECEIVE ... TIMEOUT 5) which returns an empty row set quickly and re-enters
+        // the loop on the pump CancellationToken. DisposeAsync cancels the pump CTS then stops the hosted
+        // services; token cancellation is the only signal that unwinds a blocked/looping RECEIVE
+        // (StopReceiver()/Cancel() are no-ops).
+        //
+        // The bounded-teardown assertion: wrap DisposeAsync in Task.WhenAny vs Task.Delay(TeardownBound). Assert
+        // that the dispose task won (not the delay). A WAITFOR hang would cause the delay to win, failing the test.
+        // DisposeAsync is called exactly once here; the finally block is a no-op after the assertion handles disposal.
+        [RequiresDockerFact]
+        public async Task DisposeAsyncCompletesWithinBoundedTimeOnEmptyQueue()
+        {
+            var harness = BuildHarness();
+            var disposeTask = (ValueTask?)null;
+            try
+            {
+                await harness.StartAsync();
+
+                // Dispatch nothing — the queue stays empty and the pump loops on WAITFOR ... TIMEOUT 5 until
+                // the pump CTS is cancelled by DisposeAsync.
+                var disposeValueTask = harness.DisposeAsync();
+                disposeTask = disposeValueTask;
+                var disposeAsTask = disposeValueTask.AsTask();
+                var boundTask = Task.Delay(TeardownBound);
+
+                var winner = await Task.WhenAny(disposeAsTask, boundTask).ConfigureAwait(false);
+
+                winner.Should().BeSameAs(disposeAsTask,
+                    $"DisposeAsync must complete within {TeardownBound.TotalSeconds} s on an empty queue; " +
+                    "a WAITFOR hang means the pump CTS cancellation did not unwind the RECEIVE loop");
+
+                // Surface any exception from DisposeAsync now that we know it completed.
+                await disposeAsTask.ConfigureAwait(false);
+            }
+            finally
+            {
+                // DisposeAsync was already awaited above when it won. If the assert threw before await (i.e. the
+                // delay won), we still need to drain the harness to avoid resource leaks; best-effort only.
+                if (disposeTask == null)
+                {
+                    await harness.DisposeAsync();
+                }
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDialogLifecycleTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbDialogLifecycleTests.cs
@@ -54,9 +54,10 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         private ChatterSsbPipelineHarness BuildHarness()
             => ChatterSsbPipelineHarness.Build(
                 _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.DialogSet,
                 ssb => ssb.AddQueueReceiver<DialogLifecycleCommand>(
-                    ServiceBrokerProvisioning.TargetQueuePathBracketed,
-                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterServiceName),
+                    ServiceBrokerProvisioning.DialogSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.DialogSet.DeadLetterServiceName),
                 typeof(DialogLifecycleCommand));
 
         // Test A — dialog begin/end + EndDialog auto-ack tolerance.

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbNackRedeliveryTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbNackRedeliveryTests.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Nack→redelivery integration proof for the SQL Service Broker integration harness (STEP-006). The
+    // SYSTEM UNDER TEST is Chatter's nack path: when RecordingMessageHandler<T> throws, SqlServiceBrokerReceiver's
+    // NackMessageAsync rolls back the RECEIVE transaction so the message returns to the queue and is redelivered.
+    // The test asserts (a) the handler is invoked at least twice (proving redelivery happened), and (b) the
+    // ReceiveAttempts stamp in the MessageContext climbs across deliveries (proving the in-memory
+    // ConcurrentDictionary<Guid,int> attempt counter increments on each re-receive). Mirrors SsbRoundTripTests
+    // for harness setup and collection membership.
+    //
+    // ANTI-INFINITE-LOOP: ThrowOnHandle is flipped to null as soon as >= 2 invocations are observed so the
+    // message finally acks and the conversation closes cleanly before DisposeAsync runs.
+    //
+    // The fact is gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green.
+    [Trait("Category", "Integration")]
+    [Collection(SqlServiceBrokerCollection.Name)]
+    public class SsbNackRedeliveryTests
+    {
+        private static readonly TimeSpan RedeliveryWait = TimeSpan.FromSeconds(30);
+
+        private readonly SqlServiceBrokerFixture _fixture;
+
+        public SsbNackRedeliveryTests(SqlServiceBrokerFixture fixture)
+            => _fixture = fixture;
+
+        // Distinct command type so this test's queue state is independent of SsbRoundTripTests.
+        public sealed class NackRedeliveryCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        private ChatterSsbPipelineHarness BuildHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                ssb => ssb.AddQueueReceiver<NackRedeliveryCommand>(
+                    ServiceBrokerProvisioning.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterServiceName),
+                typeof(NackRedeliveryCommand));
+
+        // Nack→redelivery: when the handler throws, NackMessageAsync rolls back the RECEIVE transaction so the
+        // message returns to the queue and is redelivered. Assert invocation count >= 2 (at least one redelivery)
+        // and that ReceiveAttempts climbs across successive deliveries (the receiver's in-memory attempt counter
+        // increments on each re-receive via ConcurrentDictionary<Guid,int>.AddOrUpdate).
+        [RequiresDockerFact]
+        public async Task ThrowingHandlerCausesRedeliveryAndClimbingReceiveAttempts()
+        {
+            var harness = BuildHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                // Arm the throw BEFORE sending so the handler throws on the very first delivery.
+                // ThrowOnHandle is Func<Exception>: returning a fresh instance per invocation matches the
+                // contract RecordingMessageHandler<T> uses (it calls thrower() and throws the result).
+                harness.GetSignal<NackRedeliveryCommand>().ThrowOnHandle =
+                    () => new InvalidOperationException("nack-redelivery-test forced throw");
+
+                await harness.SendAsync(new NackRedeliveryCommand { Marker = "nack-redelivery" });
+
+                // Wait until at least 2 handler invocations have been observed (first delivery + at least one
+                // redelivery). WaitForInvocationCountAsync returns the last observed count, which may be below
+                // minCount when the timeout elapses — the assertion below catches that case explicitly.
+                var observedCount = await harness.WaitForInvocationCountAsync<NackRedeliveryCommand>(
+                    minCount: 2, RedeliveryWait);
+
+                // ANTI-INFINITE-LOOP: stop throwing so the message is acked on the next receive and the
+                // conversation closes cleanly before DisposeAsync drains the pump.
+                harness.GetSignal<NackRedeliveryCommand>().ThrowOnHandle = null;
+
+                observedCount.Should().BeGreaterThanOrEqualTo(2,
+                    "the handler must be invoked at least twice: once for the original delivery and once for " +
+                    "the redelivery after NackMessageAsync rolled back the RECEIVE transaction");
+
+                // ReceiveAttempts must climb: the receiver's ConcurrentDictionary<Guid,int> increments the
+                // attempt count on each re-receive of the same conversation handle. Capture the attempt stamp
+                // from each recorded invocation and assert the maximum observed value exceeds 1.
+                var records = harness.GetSignal<NackRedeliveryCommand>().Records.ToList();
+                var maxAttempts = records
+                    .Where(r => r.Context?.BrokeredMessage?.MessageContext?.ContainsKey(MessageContext.ReceiveAttempts) == true)
+                    .Select(r => Convert.ToInt32(r.Context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts]))
+                    .DefaultIfEmpty(0)
+                    .Max();
+
+                maxAttempts.Should().BeGreaterThan(1,
+                    "the SSB receiver's in-memory attempt counter must increment on each re-receive of the same " +
+                    "conversation handle, so ReceiveAttempts must exceed 1 after at least one redelivery");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbNackRedeliveryTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbNackRedeliveryTests.cs
@@ -42,9 +42,10 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         private ChatterSsbPipelineHarness BuildHarness()
             => ChatterSsbPipelineHarness.Build(
                 _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.NackSet,
                 ssb => ssb.AddQueueReceiver<NackRedeliveryCommand>(
-                    ServiceBrokerProvisioning.TargetQueuePathBracketed,
-                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterServiceName),
+                    ServiceBrokerProvisioning.NackSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.NackSet.DeadLetterServiceName),
                 typeof(NackRedeliveryCommand));
 
         // Nack→redelivery: when the handler throws, NackMessageAsync rolls back the RECEIVE transaction so the

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbRoundTripTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbRoundTripTests.cs
@@ -43,9 +43,10 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         private ChatterSsbPipelineHarness BuildHarness()
             => ChatterSsbPipelineHarness.Build(
                 _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.RoundTripSet,
                 ssb => ssb.AddQueueReceiver<RoundTripCommand>(
-                    ServiceBrokerProvisioning.TargetQueuePathBracketed,
-                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterServiceName),
+                    ServiceBrokerProvisioning.RoundTripSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.RoundTripSet.DeadLetterServiceName),
                 typeof(RoundTripCommand));
 
         // Round-trip: a command sent through Chatter's dispatcher is delivered by Chatter's SSB pump to the
@@ -95,7 +96,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                 // target service, over the //Chatter contract, as the //Chatter/BrokeredMessage message type.
                 inbound.MessageContext.Should().ContainKey(SSBMessageContext.ServiceName);
                 inbound.MessageContext[SSBMessageContext.ServiceName]
-                    .Should().Be(ServiceBrokerProvisioning.TargetServiceName);
+                    .Should().Be(ServiceBrokerProvisioning.RoundTripSet.TargetServiceName);
 
                 inbound.MessageContext.Should().ContainKey(SSBMessageContext.ServiceContractName);
                 inbound.MessageContext[SSBMessageContext.ServiceContractName]

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbRoundTripTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbRoundTripTests.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Canonical end-to-end round-trip proof for the SQL Service Broker integration harness (STEP-005). The
+    // SYSTEM UNDER TEST is Chatter's own SSB send + receive path: a command dispatched ONLY through Chatter's
+    // IBrokeredMessageDispatcher.Send (harness.SendAsync) is delivered by the in-process receiver pump
+    // (ChatterSsbPipelineHarness) to a Chatter-resolved RecordingMessageHandler<TMessage>, and every assertion
+    // reads the payload Chatter deserialized and the IMessageBrokerContext Chatter built — never a raw SSB /
+    // ADO.NET type. This exercises the OutboundBrokeredMessage envelope round-trip through SQL Service Broker
+    // and the inbound header stamps SqlServiceBrokerReceiver applies on receive (InfrastructureType,
+    // ReceiveAttempts, ServiceName, ServiceContractName, MessageTypeName).
+    //
+    // The fact is gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green; the nightly SQL Server CI lane (`--filter Category=Integration`) runs it for
+    // real. Mirrors the Azure Service Bus PipelineRoundTripTests analogue.
+    [Trait("Category", "Integration")]
+    [Collection(SqlServiceBrokerCollection.Name)]
+    public class SsbRoundTripTests
+    {
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
+
+        private readonly SqlServiceBrokerFixture _fixture;
+
+        public SsbRoundTripTests(SqlServiceBrokerFixture fixture)
+            => _fixture = fixture;
+
+        // A command carrying string/int/bool fields so the body round-trip exercises Chatter's STJ body
+        // converter for each scalar kind (the on-receive materialization must restore the exact CLR values).
+        public sealed class RoundTripCommand : ICommand
+        {
+            public string Name { get; set; }
+            public int Count { get; set; }
+            public bool Flag { get; set; }
+        }
+
+        private ChatterSsbPipelineHarness BuildHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                ssb => ssb.AddQueueReceiver<RoundTripCommand>(
+                    ServiceBrokerProvisioning.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterServiceName),
+                typeof(RoundTripCommand));
+
+        // Round-trip: a command sent through Chatter's dispatcher is delivered by Chatter's SSB pump to the
+        // registered handler with its string/int/bool payload deserialized EXACTLY, and the inbound
+        // SSBMessageContext stamps the receiver applies are present and correct. Asserts the handler was
+        // invoked exactly once for the command — the post-dispatch EndDialog system message (the
+        // EndConversationAfterDispatch default) is auto-acked by the receiver's classifier and must NOT reach
+        // the handler.
+        [RequiresDockerFact]
+        public async Task SentCommandRoundTripsToHandlerWithPayloadAndBrokerContextStamps()
+        {
+            var harness = BuildHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                var sent = new RoundTripCommand { Name = "ssb-round-trip", Count = 42, Flag = true };
+                await harness.SendAsync(sent);
+
+                var handled = await harness.WaitForHandledAsync<RoundTripCommand>(HandlerWait);
+
+                // Payload round-trip: every scalar kind must survive the OutboundBrokeredMessage envelope
+                // round-trip through SQL Service Broker verbatim.
+                handled.Message.Should().NotBeNull("Chatter's SSB pipeline must deliver the command to the handler");
+                handled.Message.Name.Should().Be("ssb-round-trip");
+                handled.Message.Count.Should().Be(42);
+                handled.Message.Flag.Should().BeTrue();
+
+                // Inbound broker context: the handler must receive an IMessageBrokerContext on the SSB receive
+                // path, carrying the header stamps SqlServiceBrokerReceiver applies in ReceiveMessageAsync.
+                handled.Context.Should().NotBeNull(
+                    "the handler context must be an IMessageBrokerContext on the broker receive path");
+                var inbound = handled.Context.BrokeredMessage;
+
+                // InfrastructureType stamp identifies the SSB receiver.
+                inbound.MessageContext.Should().ContainKey(MessageContext.InfrastructureType);
+                inbound.MessageContext[MessageContext.InfrastructureType]
+                    .Should().Be(SSBMessageContext.InfrastructureType);
+
+                // ReceiveAttempts is the receiver's local per-conversation delivery count: at least one for a
+                // delivered message.
+                inbound.MessageContext.Should().ContainKey(MessageContext.ReceiveAttempts);
+                Convert.ToInt32(inbound.MessageContext[MessageContext.ReceiveAttempts])
+                    .Should().BeGreaterThanOrEqualTo(1, "a delivered message has been received at least once");
+
+                // SSB-specific stamps sourced from the received message: the message arrived on the provisioned
+                // target service, over the //Chatter contract, as the //Chatter/BrokeredMessage message type.
+                inbound.MessageContext.Should().ContainKey(SSBMessageContext.ServiceName);
+                inbound.MessageContext[SSBMessageContext.ServiceName]
+                    .Should().Be(ServiceBrokerProvisioning.TargetServiceName);
+
+                inbound.MessageContext.Should().ContainKey(SSBMessageContext.ServiceContractName);
+                inbound.MessageContext[SSBMessageContext.ServiceContractName]
+                    .Should().Be(ServiceBrokerProvisioning.ContractName);
+
+                inbound.MessageContext.Should().ContainKey(SSBMessageContext.MessageTypeName);
+                inbound.MessageContext[SSBMessageContext.MessageTypeName]
+                    .Should().Be(ServiceBrokerProvisioning.MessageTypeName);
+
+                // The post-dispatch EndDialog system message (EndConversationAfterDispatch default true) is
+                // auto-acked by the receiver's classifier and never reaches the handler, so the handler is
+                // invoked exactly once — for the command alone.
+                harness.GetSignal<RoundTripCommand>().InvocationCount
+                    .Should().Be(1, "the EndDialog system message is auto-acked and must not reach the handler");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/packages.lock.json
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/packages.lock.json
@@ -45,6 +45,15 @@
           "Castle.Core": "5.1.1"
         }
       },
+      "Testcontainers.MsSql": {
+        "type": "Direct",
+        "requested": "[4.12.0, )",
+        "resolved": "4.12.0",
+        "contentHash": "CvgBpBfCm9D0tA3n1rgWLrvx4iL8zae6cKq3bYzDQIWv8SoIkMHTL8mD/hyOjDeN1O/0iMi2Krh1f/XcwWb5gw==",
+        "dependencies": {
+          "Testcontainers": "4.12.0"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -62,12 +71,78 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
         "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
         "dependencies": {
           "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "tm2V/DpnaURbBhMQ7Z3orNR3u+H863KQuYfA/sgGjI5py07dEeV0I02f6pGrx2869KG9uNM/E96puf9i0gId2w==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0",
+          "Docker.DotNet.Enhanced.LegacyHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.NPipe": "4.2.0",
+          "Docker.DotNet.Enhanced.NativeHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.Unix": "4.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.Handler.Abstractions": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "cQNxpdadEPdNdfjFCl9vgoCQIK3aVHRn1Qlu36aZUFpp4xHfPrk4hRPNVLR/CpobIFJ+dAt8AceTKMlCfPSccw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.LegacyHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "sfbMX1HBPUec3PEMoqlP5ak6skXclcTBmu4gG3aUJatP34J2DgvYMP13bvz/rfrjVkAhPqnIiDKiHAkBCokajg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NativeHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "/ll+2ePYm1qrsMdgMO5BzCQnbfTGmPJAc9SqXEManbliVBZvEpBKHXLugx/OeEca2oC/b4RV+UNPtue5u4jAuA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NPipe": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "8wyYOD6VkvqRkITwsvkt3UbW/1WDl6NFypNAsIIDaMiglNRzFrQcK0nK9VUEZa6Oja8Bso3UYySDoL8qatatAA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Unix": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "x0wNcbww1+p9nUfw8i+JvsSArBDGkoZ9GI2PZ1wPo85B2OiFrdzp89omounNhO2GKyaIRWAqAm5jYZyNg9EnxA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "nMw+FHGwGZieDi7kBgpIVl+E8MzjzXeXHvMQpidLADT06fts2Gw6G+K+p0hMGv7liZULxyYiZnQ1UbE2B9NNQg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
         }
       },
       "Microsoft.CodeCoverage": {
@@ -471,6 +546,20 @@
           "Microsoft.Extensions.DependencyModel": "3.1.6"
         }
       },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -520,6 +609,18 @@
         "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
         "dependencies": {
           "System.Drawing.Common": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.12.0",
+        "contentHash": "PTZRdG1ZVkFMsFbc3cK/VUaOB5L3l4wYL+OkWAK33/cvgd/5FcmZlQ6NhMAl3PWBqYkpdWmeYmQW9U2OIXqtFA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "4.2.0",
+          "Docker.DotNet.Enhanced.X509": "4.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
         }
       },
       "xunit.abstractions": {
@@ -574,17 +675,16 @@
       "chatter.messagebrokers": {
         "type": "Project",
         "dependencies": {
-          "Chatter.CQRS": "[0.8.0, )",
+          "Chatter.CQRS": "[0.8.1, )",
           "Microsoft.Extensions.Configuration.Abstractions": "[10.0.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )",
           "Scrutor": "[3.3.0, )"
         }
       },
       "chatter.messagebrokers.reliability.entityframework": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers": "[0.9.0, )",
+          "Chatter.MessageBrokers": "[0.13.0, )",
           "Microsoft.EntityFrameworkCore": "[10.0.0, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.0, )"
         }
@@ -592,7 +692,7 @@
       "chatter.messagebrokers.sqlservicebroker": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers": "[0.9.0, )",
+          "Chatter.MessageBrokers": "[0.13.0, )",
           "Microsoft.Extensions.Hosting": "[10.0.0, )",
           "System.Data.SqlClient": "[4.8.6, )"
         }
@@ -600,7 +700,7 @@
       "chatter.testing.core": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.0, )",
+          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.EntityFrameworkCore.InMemory": "[10.0.8, )",
           "Moq": "[4.20.72, )"
@@ -651,6 +751,15 @@
           "Castle.Core": "5.1.1"
         }
       },
+      "Testcontainers.MsSql": {
+        "type": "Direct",
+        "requested": "[4.12.0, )",
+        "resolved": "4.12.0",
+        "contentHash": "CvgBpBfCm9D0tA3n1rgWLrvx4iL8zae6cKq3bYzDQIWv8SoIkMHTL8mD/hyOjDeN1O/0iMi2Krh1f/XcwWb5gw==",
+        "dependencies": {
+          "Testcontainers": "4.12.0"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -668,12 +777,79 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
         "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
         "dependencies": {
           "System.Diagnostics.EventLog": "6.0.0"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "tm2V/DpnaURbBhMQ7Z3orNR3u+H863KQuYfA/sgGjI5py07dEeV0I02f6pGrx2869KG9uNM/E96puf9i0gId2w==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0",
+          "Docker.DotNet.Enhanced.LegacyHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.NPipe": "4.2.0",
+          "Docker.DotNet.Enhanced.NativeHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.Unix": "4.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Handler.Abstractions": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "cQNxpdadEPdNdfjFCl9vgoCQIK3aVHRn1Qlu36aZUFpp4xHfPrk4hRPNVLR/CpobIFJ+dAt8AceTKMlCfPSccw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.LegacyHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "sfbMX1HBPUec3PEMoqlP5ak6skXclcTBmu4gG3aUJatP34J2DgvYMP13bvz/rfrjVkAhPqnIiDKiHAkBCokajg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NativeHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "/ll+2ePYm1qrsMdgMO5BzCQnbfTGmPJAc9SqXEManbliVBZvEpBKHXLugx/OeEca2oC/b4RV+UNPtue5u4jAuA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NPipe": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "8wyYOD6VkvqRkITwsvkt3UbW/1WDl6NFypNAsIIDaMiglNRzFrQcK0nK9VUEZa6Oja8Bso3UYySDoL8qatatAA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Unix": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "x0wNcbww1+p9nUfw8i+JvsSArBDGkoZ9GI2PZ1wPo85B2OiFrdzp89omounNhO2GKyaIRWAqAm5jYZyNg9EnxA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "nMw+FHGwGZieDi7kBgpIVl+E8MzjzXeXHvMQpidLADT06fts2Gw6G+K+p0hMGv7liZULxyYiZnQ1UbE2B9NNQg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
         }
       },
       "Microsoft.CodeCoverage": {
@@ -921,8 +1097,8 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
+        "resolved": "8.0.3",
+        "contentHash": "dL0QGToTxggRLMYY4ZYX5AMwBb+byQBd/5dMiZE07Nv73o6I5Are3C7eQTh7K2+A4ct0PVISSr7TZANbiNb2yQ==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
         }
@@ -1072,6 +1248,20 @@
           "Microsoft.Extensions.DependencyModel": "3.1.6"
         }
       },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -1102,6 +1292,11 @@
           "Microsoft.Win32.SystemEvents": "6.0.0"
         }
       },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
+      },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -1121,6 +1316,18 @@
         "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
         "dependencies": {
           "System.Drawing.Common": "6.0.0"
+        }
+      },
+      "Testcontainers": {
+        "type": "Transitive",
+        "resolved": "4.12.0",
+        "contentHash": "PTZRdG1ZVkFMsFbc3cK/VUaOB5L3l4wYL+OkWAK33/cvgd/5FcmZlQ6NhMAl3PWBqYkpdWmeYmQW9U2OIXqtFA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "4.2.0",
+          "Docker.DotNet.Enhanced.X509": "4.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
         }
       },
       "xunit.abstractions": {
@@ -1175,17 +1382,16 @@
       "chatter.messagebrokers": {
         "type": "Project",
         "dependencies": {
-          "Chatter.CQRS": "[0.8.0, )",
+          "Chatter.CQRS": "[0.8.1, )",
           "Microsoft.Extensions.Configuration.Abstractions": "[8.0.0, )",
           "Microsoft.Extensions.Hosting": "[8.0.0, )",
-          "Newtonsoft.Json": "[13.0.3, )",
           "Scrutor": "[3.3.0, )"
         }
       },
       "chatter.messagebrokers.reliability.entityframework": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers": "[0.9.0, )",
+          "Chatter.MessageBrokers": "[0.13.0, )",
           "Microsoft.EntityFrameworkCore": "[8.0.27, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.27, )"
         }
@@ -1193,7 +1399,7 @@
       "chatter.messagebrokers.sqlservicebroker": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers": "[0.9.0, )",
+          "Chatter.MessageBrokers": "[0.13.0, )",
           "Microsoft.Extensions.Hosting": "[8.0.0, )",
           "System.Data.SqlClient": "[4.8.6, )"
         }
@@ -1201,7 +1407,7 @@
       "chatter.testing.core": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.0, )",
+          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.1, )",
           "Microsoft.EntityFrameworkCore": "[8.0.27, )",
           "Microsoft.EntityFrameworkCore.InMemory": "[8.0.27, )",
           "Moq": "[4.20.72, )"


### PR DESCRIPTION
Closes #175.

Adds a live-SQL integration-test harness for `Chatter.MessageBrokers.SqlServiceBroker`, exercising the real `SqlServiceBrokerReceiver`/`SqlServiceBrokerSender` against a containerized SQL Server with Service Broker enabled, plus a nightly CI workflow to run it. **Test-only + CI-only — no production change, no version bump.**

## What's added

**Harness infra** (`tests/Integration/`)
- `SqlServiceBrokerFixture` — `IAsyncLifetime` collection fixture (Testcontainers.MsSql), early no-op when Docker is unavailable so plain `dotnet test` stays green.
- `ServiceBrokerProvisioning` — idempotent setup/teardown: dedicated DB, `ENABLE_BROKER WITH ROLLBACK IMMEDIATE`, `MESSAGE TYPE [//Chatter/BrokeredMessage]`, `CONTRACT [//Chatter]`, initiator + target + DLQ queue/service (bounded ENABLE_BROKER retry).
- `ChatterSsbPipelineHarness` — boots Chatter's real DI graph via `AddSqlServiceBroker`, points the production `SqlClientConnectionSource` at the container, starts the hosted receiver pump, dispatches through `IBrokeredMessageDispatcher`. **Finite `ReceiverTimeoutInMilliseconds` + token-bounded waits + CTS-before-stop teardown** (production default `-1` blocks forever and `StopReceiver`/`Cancel` is a no-op).
- `RecordingMessageHandler` (+ signals) — broker-agnostic recording/throw infra.
- `DockerEnvironment` + `RequiresDockerFactAttribute` — copied from the ASB integration suite (shared-refactor deferred to #176).

**Integration tests** (gated behind `RequiresDockerFact` + `[Trait("Category","Integration")]`)
- round-trip send → RECEIVE → ack (payload + `SSBMessageContext` stamps; EndDialog auto-ack tolerated)
- nack → redelivery (rollback returns message; attempt count climbs; anti-loop guard)
- deadletter → DLQ (`maxReceiveAttempts:1`; failure headers asserted on the re-sent DLQ message)
- dialog begin/end + EndDialog system-message auto-ack
- bounded-timeout / cancellation teardown (empty-queue pump; `DisposeAsync` completes within bound — the WAITFOR-hang guard at the test layer)

**CI** — new `.github/workflows/integration-nightly.yml`: `schedule` (cron) + `workflow_dispatch` only (NOT push/PR), `permissions: contents: read`, `ssb-integration` job mirroring `ci.yml`'s integration job, `--filter Category=Integration`. Structured for future #176/#177 sibling jobs. `ci.yml`'s push/PR job already filters `Category!=Integration`, so these never run on-commit.

## Validation
`dotnet test Chatter.sln` — **0 failed** solution-wide (both `net8.0` and `net10.0`). The 5 SSB integration tests skip locally (no Docker); the nightly workflow runs them against a real container.

## Latent finding (not fixed here — out of test-only scope)
`SqlServiceBrokerOptions.ReceiverTimeoutInMilliseconds` is named milliseconds, but the value flows into the SQL `WAITFOR (RECEIVE ...), TIMEOUT @timeoutInSeconds` parameter — a unit ambiguity. The harness picks a value finite under both readings. Worth a follow-up production-side issue.

9 checkpoint commits on the branch.
