### PR TITLE
fix(messagebrokers/ssb): rename misleading @timeoutInSeconds to @timeoutInMilliseconds (#181)

### DIFF
--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/CHANGELOG.md
@@ -12,6 +12,12 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [0.11.1] - 2026-06-12
+
+### Fixed
+
+- Renamed the SQL parameter `@timeoutInSeconds` to `@timeoutInMilliseconds` in `ReceiveMessageFromQueueCommand` to reflect that the value passed to `WAITFOR ... TIMEOUT` is in milliseconds, not seconds. Pure rename; no change to wait duration or behavior. (#181)
+
 ## [0.11.0] - 2026-06-07
 
 ### Changed

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.SqlServiceBroker</PackageId>
-    <Version>0.11.0</Version>
+    <Version>0.11.1</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for SQL Service Broker.</Description>

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Scripts/ReceiveMessageFromQueueCommand.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Scripts/ReceiveMessageFromQueueCommand.cs
@@ -74,10 +74,11 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Scripts
             }
 
             query.Append(")");
+            // INVARIANT: WAITFOR ... TIMEOUT value is in milliseconds; -1 (or <= 0) means wait forever.
             if (_timeout > 0)
             {
-                query.Append(", TIMEOUT @timeoutInSeconds");
-                receiveCommand.Parameters.Add(new SqlParameter("@timeoutInSeconds", _timeout));
+                query.Append(", TIMEOUT @timeoutInMilliseconds");
+                receiveCommand.Parameters.Add(new SqlParameter("@timeoutInMilliseconds", _timeout));
             }
 
             receiveCommand.CommandText = query.ToString();

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Scripts/UsingReceiveMessageFromQueueCommand/WhenCreatingCommand.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Scripts/UsingReceiveMessageFromQueueCommand/WhenCreatingCommand.cs
@@ -75,21 +75,30 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Scripts.UsingReceiveMess
         [Fact]
         public void MustNotAddTimeoutParameterForDefaultTimeout()
             => CreateCommandWith().Parameters.Cast<SqlParameter>()
-                .Should().NotContain(p => p.ParameterName == "@timeoutInSeconds");
+                .Should().NotContain(p => p.ParameterName == "@timeoutInMilliseconds");
 
         [Fact]
         public void MustEmitTimeoutClauseAfterClosingParenForPositiveTimeout()
             => CreateCommandWith(timeout: 5).CommandText
-                .Should().Contain("FROM TestQueue), TIMEOUT @timeoutInSeconds");
+                .Should().Contain("FROM TestQueue), TIMEOUT @timeoutInMilliseconds");
 
         [Fact]
         public void MustAddTimeoutParameterForPositiveTimeout()
             => CreateCommandWith(timeout: 5).Parameters.Cast<SqlParameter>()
-                .Should().Contain(p => p.ParameterName == "@timeoutInSeconds");
+                .Should().Contain(p => p.ParameterName == "@timeoutInMilliseconds");
 
         [Fact]
         public void MustEmitWhereClauseBeforeTimeoutClauseWhenBothPresent()
             => CreateCommandWith(timeout: 5, conversationHandle: Guid.NewGuid()).CommandText
-                .Should().Contain(" WHERE conversation_handle = @conversationHandle), TIMEOUT @timeoutInSeconds");
+                .Should().Contain(" WHERE conversation_handle = @conversationHandle), TIMEOUT @timeoutInMilliseconds");
+
+        [Fact]
+        public void MustNotContainSecondsInTimeoutParameterNameForPositiveTimeout()
+        {
+            var command = CreateCommandWith(timeout: 5);
+            command.CommandText.Should().NotContain("Seconds");
+            command.Parameters.Cast<SqlParameter>()
+                .Should().Contain(p => p.ParameterName == "@timeoutInMilliseconds");
+        }
     }
 }


### PR DESCRIPTION
## Summary

Resolves #181. Pure rename of the misleading SQL parameter `@timeoutInSeconds` -> `@timeoutInMilliseconds` in `ReceiveMessageFromQueueCommand.Create()` — both the appended query text and the `SqlParameter` constructor name (they must match exactly; SQL Server binds parameters by name). The underlying value already passed milliseconds, so this is a naming-only correction with **no behavior change** to wait duration.

Added an invariant comment noting that `WAITFOR ... TIMEOUT` is expressed in milliseconds and that `-1` (or `<= 0`) waits forever.

## Tests

- Updated the existing `WhenCreatingCommand` characterization assertions (which pinned the old token) to `@timeoutInMilliseconds`.
- Added a guard `[Fact]` asserting that for a positive timeout the generated `CommandText` contains no `Seconds` substring and the timeout `SqlParameter` name is exactly `@timeoutInMilliseconds`.

## Versioning

- `Chatter.MessageBrokers.SqlServiceBroker` patch bump `0.11.0` -> `0.11.1` with CHANGELOG entry.

## Validation

`dotnet test` SqlServiceBroker module: **208 passed**. The 5 failures are `DockerUnavailableException` in the integration fixture (no Docker daemon in this environment) — pre-existing and unrelated to this rename.

Closes #181
