### PR TITLE
test(messagebrokers): options-builder + receiver/context/circuit-breaker coverage (#173, #174)

### DIFF
--- a/src/Chatter.MessageBrokers/tests/Configuration/UsingMessageBrokerOptionsBuilder/WhenBuilding.cs
+++ b/src/Chatter.MessageBrokers/tests/Configuration/UsingMessageBrokerOptionsBuilder/WhenBuilding.cs
@@ -1,7 +1,9 @@
 using Chatter.MessageBrokers.Configuration;
 using Chatter.MessageBrokers.Receiving;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Chatter.MessageBrokers.Tests.Configuration.UsingMessageBrokerOptionsBuilder
@@ -37,5 +39,110 @@ namespace Chatter.MessageBrokers.Tests.Configuration.UsingMessageBrokerOptionsBu
 
             options.Recovery.Should().NotBeNull();
         }
+
+        [Fact]
+        public void MustReflectWithTransactionMode()
+        {
+            var services = new ServiceCollection();
+
+            var options = MessageBrokerOptionsBuilder.Create(services)
+                .WithTransactionMode(TransactionMode.FullAtomicityViaInfrastructure)
+                .Build();
+
+            options.TransactionMode.Should().Be(TransactionMode.FullAtomicityViaInfrastructure);
+        }
+
+        [Fact]
+        public void MustBuildNonNullReliabilityOptionsWhenAddReliabilityOptionsActionProvided()
+        {
+            var services = new ServiceCollection();
+
+            var options = MessageBrokerOptionsBuilder.Create(services)
+                .AddReliabilityOptions(r => r.WithOutboxRouting())
+                .Build();
+
+            options.Reliability.Should().NotBeNull();
+            options.Reliability.RouteMessagesToOutbox.Should().BeTrue();
+        }
+
+        [Fact]
+        public void MustBuildNonNullReliabilityOptionsWhenAddReliabilityOptionsActionIsNull()
+        {
+            var services = new ServiceCollection();
+
+            var options = MessageBrokerOptionsBuilder.Create(services)
+                .AddReliabilityOptions(null)
+                .Build();
+
+            options.Reliability.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void MustBuildNonNullRecoveryOptionsWhenAddRecoveryOptionsActionProvided()
+        {
+            var services = new ServiceCollection();
+
+            var options = MessageBrokerOptionsBuilder.Create(services)
+                .AddRecoveryOptions(r => r.WithMaxRetryAttempts(9))
+                .Build();
+
+            options.Recovery.Should().NotBeNull();
+            options.Recovery.MaxRetryAttempts.Should().Be(9);
+        }
+
+        [Fact]
+        public void MustBuildNonNullRecoveryOptionsWhenAddRecoveryOptionsActionIsNull()
+        {
+            var services = new ServiceCollection();
+
+            var options = MessageBrokerOptionsBuilder.Create(services)
+                .AddRecoveryOptions(null)
+                .Build();
+
+            options.Recovery.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void MustTakeConfigBranchWhenStaticFromConfigSectionPopulated()
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration();
+
+            var options = MessageBrokerOptionsBuilder.FromConfig(services, configuration);
+
+            AssertConfigBranchTaken(options);
+        }
+
+        [Fact]
+        public void MustTakeConfigBranchWhenInstanceFromConfigForwardsServicesAndConfiguration()
+        {
+            var services = new ServiceCollection();
+            var configuration = BuildConfiguration();
+            var builder = new MessageBrokerOptionsBuilder(services, configuration);
+
+            var options = builder.FromConfig();
+
+            AssertConfigBranchTaken(options);
+        }
+
+        // INVARIANT: production binds the populated section via IConfigurationSection.Get<MessageBrokerOptions>(),
+        // whose internal-set TransactionMode stays at its type default (None); the fluent else-branch (which would
+        // otherwise apply the ReceiveOnly default) is skipped. Reliability and Recovery come back null from the bind
+        // and are then defaulted to non-null instances by Build().
+        private static void AssertConfigBranchTaken(MessageBrokerOptions options)
+        {
+            options.Should().NotBeNull();
+            options.TransactionMode.Should().Be(TransactionMode.None);
+            options.Reliability.Should().NotBeNull();
+            options.Recovery.Should().NotBeNull();
+        }
+
+        private static IConfiguration BuildConfiguration()
+            => new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    [$"{MessageBrokerOptionsBuilder.MessageBrokerSectionName}:TransactionMode"] = nameof(TransactionMode.FullAtomicityViaInfrastructure)
+                })
+                .Build();
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Context/UsingMessageBrokerContext/WhenDispatching.cs
+++ b/src/Chatter.MessageBrokers/tests/Context/UsingMessageBrokerContext/WhenDispatching.cs
@@ -1,5 +1,6 @@
 using Chatter.CQRS;
 using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Routing.Options;
 using Chatter.MessageBrokers.Sending;
 using FluentAssertions;
 using Moq;
@@ -53,6 +54,94 @@ namespace Chatter.MessageBrokers.Tests.Context.UsingMessageBrokerContext
         {
             var @event = new Mock<CQRS.Events.IEvent>().Object;
             await _sut.Publish(@event);
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        // ------------------------------------------------------------------ Send: dispatcher-present delegation branches
+
+        [Fact]
+        public async Task MustDelegateSendWithOptionsToDispatcherWhenPresent()
+        {
+            IncludeDispatcher();
+            var command = new Mock<CQRS.Commands.ICommand>().Object;
+            var options = new SendOptions();
+
+            await _sut.Send(command, options);
+
+            _dispatcher.Verify(d => d.Send(command, _sut, options), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustDelegateSendWithDestinationPathToDispatcherWhenPresent()
+        {
+            IncludeDispatcher();
+            var command = new Mock<CQRS.Commands.ICommand>().Object;
+            var options = new SendOptions();
+
+            await _sut.Send(command, "destination-path", options);
+
+            _dispatcher.Verify(d => d.Send(command, "destination-path", _sut, options), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustReturnCompletedTaskSendingWithDestinationPathWhenNoDispatcherPresent()
+        {
+            var command = new Mock<CQRS.Commands.ICommand>().Object;
+            await _sut.Send(command, "destination-path");
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        // ------------------------------------------------------------------ Publish: dispatcher-present delegation branches
+
+        [Fact]
+        public async Task MustDelegatePublishWithOptionsToDispatcherWhenPresent()
+        {
+            IncludeDispatcher();
+            var @event = new Mock<CQRS.Events.IEvent>().Object;
+            var options = new PublishOptions();
+
+            await _sut.Publish(@event, options);
+
+            _dispatcher.Verify(d => d.Publish(@event, _sut, options), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustDelegatePublishWithDestinationPathToDispatcherWhenPresent()
+        {
+            IncludeDispatcher();
+            var @event = new Mock<CQRS.Events.IEvent>().Object;
+            var options = new PublishOptions();
+
+            await _sut.Publish(@event, "destination-path", options);
+
+            _dispatcher.Verify(d => d.Publish(@event, "destination-path", _sut, options), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustDelegatePublishBatchToDispatcherWhenPresent()
+        {
+            IncludeDispatcher();
+            var events = new[] { new Mock<CQRS.Events.IEvent>().Object };
+            var options = new PublishOptions();
+
+            await _sut.Publish((IEnumerable<CQRS.Events.IEvent>)events, options);
+
+            _dispatcher.Verify(d => d.Publish((IEnumerable<CQRS.Events.IEvent>)events, _sut, options), Times.Once);
+        }
+
+        [Fact]
+        public async Task MustReturnCompletedTaskPublishingWithDestinationPathWhenNoDispatcherPresent()
+        {
+            var @event = new Mock<CQRS.Events.IEvent>().Object;
+            await _sut.Publish(@event, "destination-path");
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task MustReturnCompletedTaskPublishingBatchWhenNoDispatcherPresent()
+        {
+            var events = new[] { new Mock<CQRS.Events.IEvent>().Object };
+            await _sut.Publish((IEnumerable<CQRS.Events.IEvent>)events);
             _dispatcher.Invocations.Should().BeEmpty();
         }
     }

--- a/src/Chatter.MessageBrokers/tests/Context/UsingMessageHandlerContextExtensions/WhenExtending.cs
+++ b/src/Chatter.MessageBrokers/tests/Context/UsingMessageHandlerContextExtensions/WhenExtending.cs
@@ -1,0 +1,135 @@
+using Chatter.CQRS;
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Moq;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Context.UsingMessageHandlerContextExtensions
+{
+    // INVARIANT: covers the behavioral branches of the Context/MessageHandlerContextExtensions surface (distinct from the
+    // Routing/Slips extensions): the IExternalDispatcher -> IBrokeredMessageDispatcher resolution gate, the InMemory
+    // dispatcher factory, the IMessageBrokerContext inbound-message projection, the transaction-context read, and ONE
+    // representative Send + ONE Publish overload's no-op-vs-delegate branch (the branch logic is shared across the four
+    // Send/Publish overloads, so a single representative of each proves both arms).
+    public class WhenExtending : Testing.Core.Context
+    {
+        private readonly Mock<IBrokeredMessageDispatcher> _dispatcher = new Mock<IBrokeredMessageDispatcher>();
+        private readonly MessageHandlerContext _context = new MessageHandlerContext(CancellationToken.None);
+
+        private void IncludeBrokeredDispatcher()
+            => _context.Container.Include<IExternalDispatcher>(_dispatcher.Object);
+
+        // ------------------------------------------------------------------ TryGetBrokeredMessageDispatcher
+
+        [Fact]
+        public void MustReturnTrueAndDispatcherWhenExternalDispatcherIsAlsoBrokeredMessageDispatcher()
+        {
+            IncludeBrokeredDispatcher();
+
+            var found = _context.TryGetBrokeredMessageDispatcher(out var resolved);
+
+            found.Should().BeTrue();
+            resolved.Should().BeSameAs(_dispatcher.Object);
+        }
+
+        [Fact]
+        public void MustReturnFalseWhenExternalDispatcherIsNotBrokeredMessageDispatcher()
+        {
+            _context.Container.Include<IExternalDispatcher>(new Mock<IExternalDispatcher>().Object);
+
+            var found = _context.TryGetBrokeredMessageDispatcher(out var resolved);
+
+            found.Should().BeFalse();
+            resolved.Should().BeNull();
+        }
+
+        [Fact]
+        public void MustReturnFalseWhenNoExternalDispatcherRegistered()
+        {
+            var found = _context.TryGetBrokeredMessageDispatcher(out var resolved);
+
+            found.Should().BeFalse();
+            resolved.Should().BeNull();
+        }
+
+        // ------------------------------------------------------------------ InMemory
+
+        [Fact]
+        public void MustReturnInMemoryDispatcher()
+            => _context.InMemory().Should().BeAssignableTo<IInMemoryDispatcher>();
+
+        // ------------------------------------------------------------------ GetInboundBrokeredMessage
+
+        [Fact]
+        public void MustReturnBrokeredMessageWhenContextIsMessageBrokerContext()
+        {
+            var bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+            bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+            var brokerContext = new MessageBrokerContext("message-id", new byte[] { 1 }, new Dictionary<string, object>(), "receiver-path", CancellationToken.None, bodyConverter.Object);
+
+            brokerContext.GetInboundBrokeredMessage().Should().BeSameAs(brokerContext.BrokeredMessage);
+        }
+
+        [Fact]
+        public void MustReturnNullInboundBrokeredMessageWhenContextIsNotMessageBrokerContext()
+            => _context.GetInboundBrokeredMessage().Should().BeNull();
+
+        // ------------------------------------------------------------------ GetTransactionContext
+
+        [Fact]
+        public void MustReadTransactionContextFromContainer()
+        {
+            var transactionContext = new TransactionContext("receiver-path");
+            _context.Container.Include(transactionContext);
+
+            _context.GetTransactionContext().Should().BeSameAs(transactionContext);
+        }
+
+        // ------------------------------------------------------------------ Send (one representative overload): no-op vs delegate
+
+        [Fact]
+        public async Task MustReturnCompletedTaskSendingWhenNoDispatcherPresent()
+        {
+            var command = new Mock<CQRS.Commands.ICommand>().Object;
+            await _context.Send(command);
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task MustDelegateSendToDispatcherWhenPresent()
+        {
+            IncludeBrokeredDispatcher();
+            var command = new Mock<CQRS.Commands.ICommand>().Object;
+
+            await _context.Send(command);
+
+            _dispatcher.Verify(d => d.Send(command, _context, null), Times.Once);
+        }
+
+        // ------------------------------------------------------------------ Publish (one representative overload): no-op vs delegate
+
+        [Fact]
+        public async Task MustReturnCompletedTaskPublishingWhenNoDispatcherPresent()
+        {
+            var @event = new Mock<CQRS.Events.IEvent>().Object;
+            await _context.Publish(@event);
+            _dispatcher.Invocations.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task MustDelegatePublishToDispatcherWhenPresent()
+        {
+            IncludeBrokeredDispatcher();
+            var @event = new Mock<CQRS.Events.IEvent>().Object;
+
+            await _context.Publish(@event);
+
+            _dispatcher.Verify(d => d.Publish(@event, _context, null), Times.Once);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiveErrorBranchesRun.cs
+++ b/src/Chatter.MessageBrokers/tests/Receiving/UsingBrokeredMessageReceiver/WhenReceiveErrorBranchesRun.cs
@@ -1,0 +1,260 @@
+#nullable disable
+
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Exceptions;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Recovery;
+using Chatter.MessageBrokers.Tests.Receiving.Fakes;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Receiving.UsingBrokeredMessageReceiver
+{
+    // INVARIANT: drives two genuinely-uncovered ERROR branches in BrokeredMessageReceiver that the sibling receiver tests
+    // do not reach:
+    //   (1) a CriticalReceiverException thrown by the RECEIVE call itself (the recovery Func<Task<MessageBrokerContext>>
+    //       overload throws critical) is caught at the inline receive catch(CriticalReceiverException), releases the slot,
+    //       stops the loop, and fires ICriticalFailureNotifier.Notify exactly once — distinct from the worker-published
+    //       critical-fault tests, where the fault originates in DispatchAsync.
+    //   (2) delivery count >= max + the deadletter recovery call returns false (the recovery Func<Task<bool>> overload
+    //       throws so TryDeadletterWithRecoveryAsync returns false) means IMaxReceivesExceededAction.ExecuteAsync is NOT
+    //       invoked (the `if (await TryDeadletter...)` false branch).
+    // Reuses the established harness: InMemoryMessagingInfrastructureReceiver fake + IRecoveryStrategy mock + 15s watchdog,
+    // NullLogger to no-op the critical logs. A regression becomes a Timeout rather than a hang.
+    public class WhenReceiveErrorBranchesRun : Testing.Core.Context
+    {
+        private static MessageBrokerOptions BuildOptions(TransactionMode mode = TransactionMode.None)
+        {
+            var opts = new MessageBrokerOptions();
+            opts.TransactionMode = mode;
+            return opts;
+        }
+
+        private static Mock<IRecoveryStrategy> PassThroughRecovery()
+        {
+            var mock = new Mock<IRecoveryStrategy>();
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            mock.Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+            return mock;
+        }
+
+        private static ReceiverOptions BuildReceiverOptions(int maxReceiveAttempts = 10, int maxConcurrentCalls = 1)
+            => new ReceiverOptions
+            {
+                InfrastructureType = InMemoryMessagingInfrastructureProvider.InfrastructureType,
+                MessageReceiverPath = "test-queue",
+                SendingPath = "test-queue",
+                ErrorQueuePath = "error-queue",
+                DeadLetterQueuePath = "deadletter-queue",
+                TransactionMode = TransactionMode.None,
+                MaxReceiveAttempts = maxReceiveAttempts,
+                MaxConcurrentCalls = maxConcurrentCalls,
+            };
+
+        private static MessageBrokerContext BuildContext()
+        {
+            var converter = new JsonBodyConverter();
+            var body = converter.Convert(new FakeMessage { Value = "hello" });
+            return new MessageBrokerContext(
+                messageId: Guid.NewGuid().ToString(),
+                body: body,
+                applicationProperties: new Dictionary<string, object>(),
+                messageReceiverPath: "test-queue",
+                receiverCancellationToken: CancellationToken.None,
+                bodyConverter: converter);
+        }
+
+        private BrokeredMessageReceiver<FakeMessage> CreateSut(
+            InMemoryMessagingInfrastructureReceiver infraReceiver,
+            Mock<IReceivedMessageDispatcher> dispatcher,
+            Mock<IRecoveryStrategy> recovery,
+            Mock<IMaxReceivesExceededAction> maxReceivesAction = null,
+            Mock<ICriticalFailureNotifier> criticalNotifier = null)
+        {
+            var provider = new InMemoryMessagingInfrastructureProvider(infraReceiver);
+            maxReceivesAction ??= new Mock<IMaxReceivesExceededAction>();
+            criticalNotifier ??= new Mock<ICriticalFailureNotifier>();
+
+            return new BrokeredMessageReceiver<FakeMessage>(
+                infrastructureProvider: provider,
+                messageBrokerOptions: BuildOptions(),
+                logger: NullLogger<BrokeredMessageReceiver<FakeMessage>>.Instance,
+                recoveryAction: maxReceivesAction.Object,
+                criticalFailureNotifier: criticalNotifier.Object,
+                recoveryStrategy: recovery.Object,
+                receivedMessageDispatcher: dispatcher.Object);
+        }
+
+        private static async Task WaitUntilAsync(Func<bool> predicate, CancellationToken watchdog)
+        {
+            while (!predicate())
+            {
+                watchdog.ThrowIfCancellationRequested();
+                await Task.Yield();
+            }
+        }
+
+        private class FakeMessage : CQRS.IMessage
+        {
+            public string Value { get; set; }
+        }
+
+        // ------------------------------------------------------------------ (1) CriticalReceiverException from the RECEIVE call itself
+
+        [Fact]
+        public async Task MustNotifyOnceAndStopLoopWhenReceiveItselfThrowsCritical()
+        {
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.Enqueue(BuildContext());
+
+            var thrown = new CriticalReceiverException("receive boom");
+
+            // The recovery MessageBrokerContext overload (the RECEIVE call) throws critical on its FIRST invocation. This
+            // hits the inline receive catch(CriticalReceiverException) in the loop — distinct from the worker-published
+            // path where DispatchAsync throws. The inline catch releases the slot and rethrows to stop the loop; the outer
+            // loop catch records the fault and the notify-once epilogue fires ICriticalFailureNotifier.Notify exactly once.
+            var recovery = new Mock<IRecoveryStrategy>();
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((_, __) => throw thrown);
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) => action());
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+
+            FailureContext observedContext = null;
+            var notified = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var criticalNotifier = new Mock<ICriticalFailureNotifier>();
+            criticalNotifier
+                .Setup(n => n.Notify(It.IsAny<FailureContext>()))
+                .Returns((FailureContext ctx) =>
+                {
+                    observedContext = ctx;
+                    notified.TrySetResult(true);
+                    return Task.CompletedTask;
+                });
+
+            var sut = CreateSut(infraReceiver, dispatcher, recovery, criticalNotifier: criticalNotifier);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+            var notifiedCompleted = await Task.WhenAny(notified.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            notifiedCompleted.Should().BeSameAs(notified.Task, "a critical fault from the receive call itself must drive ICriticalFailureNotifier.Notify");
+            await notified.Task;
+
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop, "the loop must stop after the inline receive critical fault");
+            await loop;
+
+            criticalNotifier.Verify(n => n.Notify(It.IsAny<FailureContext>()), Times.Once,
+                "the inline-receive critical fault must notify exactly once");
+            observedContext.Should().NotBeNull();
+            observedContext.Failure.Should().BeSameAs(thrown, "the FailureContext must carry the CriticalReceiverException thrown by the receive call");
+            dispatcher.Verify(
+                d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()),
+                Times.Never,
+                "the receive itself faulted critically, so no message must reach the dispatcher");
+        }
+
+        // ------------------------------------------------------------------ (2) DeliveryCount >= max + deadletter returns false → MaxReceivesExceededAction NOT invoked
+
+        [Fact]
+        public async Task MustNotInvokeMaxReceivesActionWhenDeadletterRecoveryReturnsFalseAtMax()
+        {
+            const int maxAttempts = 3;
+
+            var infraReceiver = new InMemoryMessagingInfrastructureReceiver(expectedMessageCount: 1);
+            infraReceiver.DeliveryCount = maxAttempts; // >= Max
+
+            // The handler throws generic so the worker enters its delivery-count ladder. DeliveryCount >= Max routes to
+            // TryDeadletterWithRecoveryAsync, whose recovery Func<Task<bool>> overload THROWS — TryDeadletterWithRecoveryAsync
+            // catches and returns false, so the `if (await TryDeadletter...)` false branch SKIPS IMaxReceivesExceededAction.
+            var handlerThrew = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var dispatcher = new Mock<IReceivedMessageDispatcher>();
+            dispatcher
+                .Setup(d => d.DispatchAsync(It.IsAny<FakeMessage>(), It.IsAny<MessageBrokerContext>(), It.IsAny<CancellationToken>()))
+                .Returns(() =>
+                {
+                    handlerThrew.TrySetResult(true);
+                    throw new InvalidOperationException("handler boom at max");
+                });
+
+            // The bool recovery overload is invoked twice for this message: FIRST for the dispatch action (which delegates
+            // through so the dispatcher's own throw routes the worker to its generic catch), THEN for the deadletter call
+            // (which THROWS so TryDeadletterWithRecoveryAsync catches and returns false). The int (delivery-count) overload
+            // delegates through so the probe returns DeliveryCount (>= max).
+            var deadletterAttempted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            var boolRecoveryCalls = new StrongBox<int>(0);
+            var recovery = new Mock<IRecoveryStrategy>();
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<MessageBrokerContext>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<MessageBrokerContext>>, CancellationToken>((action, _) => action());
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<bool>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<bool>>, CancellationToken>((action, _) =>
+                {
+                    if (Interlocked.Increment(ref boolRecoveryCalls.Value) == 1)
+                    {
+                        // Dispatch action: delegate through so the dispatcher's InvalidOperationException routes the worker
+                        // to its generic-error delivery-count ladder.
+                        return action();
+                    }
+
+                    // Deadletter recovery: throw so TryDeadletterWithRecoveryAsync returns false.
+                    deadletterAttempted.TrySetResult(true);
+                    throw new Exception("deadletter recovery failed");
+                });
+            recovery
+                .Setup(r => r.ExecuteAsync(It.IsAny<Func<Task<int>>>(), It.IsAny<CancellationToken>()))
+                .Returns<Func<Task<int>>, CancellationToken>((action, _) => action());
+
+            var maxReceivesAction = new Mock<IMaxReceivesExceededAction>();
+            maxReceivesAction
+                .Setup(a => a.ExecuteAsync(It.IsAny<FailureContext>()))
+                .Returns(Task.CompletedTask);
+
+            infraReceiver.Enqueue(BuildContext());
+
+            var sut = CreateSut(infraReceiver, dispatcher, recovery, maxReceivesAction: maxReceivesAction);
+
+            using var cts = new CancellationTokenSource();
+            var loop = Task.Run(() => sut.StartReceiver(BuildReceiverOptions(maxReceiveAttempts: maxAttempts), cts.Token));
+
+            using var watchdog = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+            var handlerCompleted = await Task.WhenAny(handlerThrew.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            handlerCompleted.Should().BeSameAs(handlerThrew.Task, "the handler must run and throw so the worker enters its delivery-count ladder");
+            await handlerThrew.Task;
+
+            var deadletterCompleted = await Task.WhenAny(deadletterAttempted.Task, Task.Delay(TimeSpan.FromSeconds(15)));
+            deadletterCompleted.Should().BeSameAs(deadletterAttempted.Task, "the worker must attempt the deadletter recovery (which throws → returns false)");
+            await deadletterAttempted.Task;
+
+            cts.Cancel();
+            var loopCompleted = await Task.WhenAny(loop, Task.Delay(TimeSpan.FromSeconds(15)));
+            loopCompleted.Should().BeSameAs(loop, "the loop must cancel cleanly after the failed-deadletter branch");
+            await loop;
+
+            maxReceivesAction.Verify(a => a.ExecuteAsync(It.IsAny<FailureContext>()), Times.Never,
+                "a failed deadletter (recovery returned false) must SKIP the MaxReceivesExceededAction");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Recovery/CircuitBreaker/UsingCircuitBreaker/WhenConstructing.cs
+++ b/src/Chatter.MessageBrokers/tests/Recovery/CircuitBreaker/UsingCircuitBreaker/WhenConstructing.cs
@@ -41,5 +41,15 @@ namespace Chatter.MessageBrokers.Tests.Recovery.CircuitBreaker.UsingCircuitBreak
         public void MustThrowArgumentNullExceptionWhenExceptionEvaluatorIsNull()
             => FluentActions.Invoking(() => new MessageBrokers.Recovery.CircuitBreaker.CircuitBreaker(_store.Object, _options, _logger, null))
                 .Should().Throw<ArgumentNullException>();
+
+        [Fact]
+        public void MustNotThrowWhenDisposedTwice()
+        {
+            var sut = new MessageBrokers.Recovery.CircuitBreaker.CircuitBreaker(_store.Object, _options, _logger, _evaluator.Object);
+            sut.Dispose();
+
+            // The _disposedValue guard must make a second Dispose a no-op rather than re-disposing the (already-null) timer/semaphore.
+            FluentActions.Invoking(() => sut.Dispose()).Should().NotThrow();
+        }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Recovery/CircuitBreaker/UsingCircuitBreakerOptionsBuilder/WhenBuilding.cs
+++ b/src/Chatter.MessageBrokers/tests/Recovery/CircuitBreaker/UsingCircuitBreakerOptionsBuilder/WhenBuilding.cs
@@ -1,7 +1,10 @@
 using Chatter.MessageBrokers.Recovery.CircuitBreaker;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Chatter.MessageBrokers.Tests.Recovery.CircuitBreaker.UsingCircuitBreakerOptionsBuilder
@@ -28,6 +31,110 @@ namespace Chatter.MessageBrokers.Tests.Recovery.CircuitBreaker.UsingCircuitBreak
             var create = () => CircuitBreakerOptionsBuilder.Create(null);
 
             create.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void MustReflectSetOpenToHalfOpenWaitTime()
+        {
+            var services = new ServiceCollection();
+
+            var options = CircuitBreakerOptionsBuilder.Create(services).SetOpenToHalfOpenWaitTime(99).Build();
+
+            options.OpenToHalfOpenWaitTimeInSeconds.Should().Be(99);
+        }
+
+        [Fact]
+        public void MustReflectSetConcurrentHalfOpenAttempts()
+        {
+            var services = new ServiceCollection();
+
+            var options = CircuitBreakerOptionsBuilder.Create(services).SetConcurrentHalfOpenAttempts(4).Build();
+
+            options.ConcurrentHalfOpenAttempts.Should().Be(4);
+        }
+
+        [Fact]
+        public void MustReflectSetNumberOfFailuresBeforeOpen()
+        {
+            var services = new ServiceCollection();
+
+            var options = CircuitBreakerOptionsBuilder.Create(services).SetNumberOfFailuresBeforeOpen(11).Build();
+
+            options.NumberOfFailuresBeforeOpen.Should().Be(11);
+        }
+
+        [Fact]
+        public void MustReflectSetNumberOfHalfOpenSuccessesBeforeClose()
+        {
+            var services = new ServiceCollection();
+
+            var options = CircuitBreakerOptionsBuilder.Create(services).SetNumberOfHalfOpenSuccessesBeforeClose(7).Build();
+
+            options.NumberOfHalfOpenSuccessesToClose.Should().Be(7);
+        }
+
+        [Fact]
+        public void MustReflectSetTimeOpenBeforeCriticalEvent()
+        {
+            var services = new ServiceCollection();
+
+            var options = CircuitBreakerOptionsBuilder.Create(services).SetTimeOpenBeforeCriticalEvent(60).Build();
+
+            options.SecondsOpenBeforeCriticalFailureNotification.Should().Be(60);
+        }
+
+        [Fact]
+        public void MustNotThrowWhenIsTrippedByPredicatesIsNull()
+        {
+            var services = new ServiceCollection();
+
+            var build = () => CircuitBreakerOptionsBuilder.Create(services).IsTrippedBy(null).Build();
+
+            build.Should().NotThrow();
+        }
+
+        [Fact]
+        public void MustRegisterCircuitBreakerExceptionPredicatesProviderWhenIsTrippedByPredicatesProvided()
+        {
+            var services = new ServiceCollection();
+
+            CircuitBreakerOptionsBuilder.Create(services)
+                .IsTrippedBy(e => e is InvalidOperationException)
+                .Build();
+
+            services.Any(d => d.ServiceType == typeof(ICircuitBreakerExceptionPredicatesProvider)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void MustRegisterCircuitBreakerExceptionPredicatesProviderWhenGenericIsTrippedByUsed()
+        {
+            var services = new ServiceCollection();
+
+            CircuitBreakerOptionsBuilder.Create(services)
+                .IsTrippedBy<InvalidOperationException>()
+                .Build();
+
+            services.Any(d => d.ServiceType == typeof(ICircuitBreakerExceptionPredicatesProvider)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void MustTakeConfigBranchAndSkipFluentDefaultsWhenFromConfigSectionPopulated()
+        {
+            // INVARIANT: production binds the populated section via IConfigurationSection.Get<CircuitBreakerOptions>(),
+            // whose internal-set scalar properties stay at their type default; the fluent else-branch (which would
+            // otherwise apply the default of 5) is skipped, so a populated section yields 0, not 5.
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    [$"{CircuitBreakerOptionsBuilder.CircuitBreakerOptionsSectionName}:NumberOfFailuresBeforeOpen"] = "42"
+                })
+                .Build();
+
+            var options = CircuitBreakerOptionsBuilder.FromConfig(services, configuration);
+
+            options.Should().NotBeNull();
+            options.NumberOfFailuresBeforeOpen.Should().Be(0);
         }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Recovery/Options/UsingRecoveryOptionsBuilder/WhenBuilding.cs
+++ b/src/Chatter.MessageBrokers/tests/Recovery/Options/UsingRecoveryOptionsBuilder/WhenBuilding.cs
@@ -1,7 +1,12 @@
+using Chatter.MessageBrokers.Recovery.CircuitBreaker;
 using Chatter.MessageBrokers.Recovery.Options;
+using Chatter.MessageBrokers.Recovery.Retry;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Xunit;
 
 namespace Chatter.MessageBrokers.Tests.Recovery.Options.UsingRecoveryOptionsBuilder
@@ -44,6 +49,110 @@ namespace Chatter.MessageBrokers.Tests.Recovery.Options.UsingRecoveryOptionsBuil
             var options = RecoveryOptionsBuilder.Create(services).WithMaxRetryAttempts(99).Build();
 
             options.MaxRetryAttempts.Should().Be(99);
+        }
+
+        [Fact]
+        public void MustBuildNonNullCircuitBreakerOptionsWhenWithCircuitBreakerActionProvided()
+        {
+            var services = new ServiceCollection();
+
+            var options = RecoveryOptionsBuilder.Create(services)
+                .WithCircuitBreaker(cb => cb.SetNumberOfFailuresBeforeOpen(7))
+                .Build();
+
+            options.CircuitBreakerOptions.Should().NotBeNull();
+            options.CircuitBreakerOptions.NumberOfFailuresBeforeOpen.Should().Be(7);
+        }
+
+        [Fact]
+        public void MustBuildNonNullCircuitBreakerOptionsWhenWithCircuitBreakerActionIsNull()
+        {
+            var services = new ServiceCollection();
+
+            var options = RecoveryOptionsBuilder.Create(services)
+                .WithCircuitBreaker(null)
+                .Build();
+
+            options.CircuitBreakerOptions.Should().NotBeNull();
+        }
+
+        [Fact]
+        public void MustClampMaxRetryAttemptsToFifteenWhenExponentialDelayExceedsCeiling()
+        {
+            var services = new ServiceCollection();
+
+            var options = RecoveryOptionsBuilder.Create(services)
+                .UseExponentialDelayRecovery(99)
+                .Build();
+
+            options.MaxRetryAttempts.Should().Be(15);
+        }
+
+        [Fact]
+        public void MustNotClampMaxRetryAttemptsWhenExponentialDelayBelowCeiling()
+        {
+            var services = new ServiceCollection();
+
+            var options = RecoveryOptionsBuilder.Create(services)
+                .UseExponentialDelayRecovery(3)
+                .Build();
+
+            options.MaxRetryAttempts.Should().Be(3);
+        }
+
+        [Fact]
+        public void MustNotThrowWhenRetryWhenPredicatesIsNull()
+        {
+            var services = new ServiceCollection();
+
+            var build = () => RecoveryOptionsBuilder.Create(services).RetryWhen(null).Build();
+
+            build.Should().NotThrow();
+        }
+
+        [Fact]
+        public void MustRegisterRetryExceptionPredicatesProviderWhenRetryWhenPredicatesProvided()
+        {
+            var services = new ServiceCollection();
+
+            RecoveryOptionsBuilder.Create(services)
+                .RetryWhen(e => e is InvalidOperationException)
+                .Build();
+
+            services.Any(d => d.ServiceType == typeof(IRetryExceptionPredicatesProvider)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void MustRegisterRetryExceptionPredicatesProviderWhenGenericRetryWhenUsed()
+        {
+            var services = new ServiceCollection();
+
+            RecoveryOptionsBuilder.Create(services)
+                .RetryWhen<InvalidOperationException>()
+                .Build();
+
+            services.Any(d => d.ServiceType == typeof(IRetryExceptionPredicatesProvider)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void MustTakeConfigBranchAndSkipFluentDefaultsWhenFromConfigSectionPopulated()
+        {
+            // INVARIANT: production binds the populated section via IConfigurationSection.Get<RecoveryOptions>(),
+            // whose internal-set scalar properties stay at their type default; the fluent else-branch (which would
+            // otherwise apply the _defaultMaxRetryAttempts of 5) is skipped, so a populated section yields 0, not 5.
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    [$"{RecoveryOptionsBuilder.RecoveryOptionsSectionName}:MaxRetryAttempts"] = "42"
+                })
+                .Build();
+
+            var options = RecoveryOptionsBuilder.FromConfig(services, configuration);
+
+            options.Should().NotBeNull();
+            options.MaxRetryAttempts.Should().Be(0);
+            options.CircuitBreakerOptions.Should().NotBeNull();
         }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Reliability/Configuration/UsingReliabilityOptionsBuilder/WhenBuilding.cs
+++ b/src/Chatter.MessageBrokers/tests/Reliability/Configuration/UsingReliabilityOptionsBuilder/WhenBuilding.cs
@@ -1,7 +1,9 @@
 using Chatter.MessageBrokers.Reliability.Configuration;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace Chatter.MessageBrokers.Tests.Reliability.Configuration.UsingReliabilityOptionsBuilder
@@ -27,6 +29,71 @@ namespace Chatter.MessageBrokers.Tests.Reliability.Configuration.UsingReliabilit
             var create = () => ReliabilityOptionsBuilder.Create(null);
 
             create.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void MustEnableOutboxRoutingWhenWithOutboxRoutingCalled()
+        {
+            var services = new ServiceCollection();
+
+            var options = ReliabilityOptionsBuilder.Create(services).WithOutboxRouting().Build();
+
+            options.RouteMessagesToOutbox.Should().BeTrue();
+        }
+
+        [Fact]
+        public void MustReflectWithInMemoryOutboxTimeToLive()
+        {
+            var services = new ServiceCollection();
+
+            var options = ReliabilityOptionsBuilder.Create(services).WithInMemoryOutboxTimeToLive(99).Build();
+
+            options.MinutesToLiveInMemory.Should().Be(99);
+        }
+
+        [Fact]
+        public void MustEnableOutboxPollingProcessorWithCustomIntervalWhenWithOutboxPollingProcessorCalled()
+        {
+            var services = new ServiceCollection();
+
+            var options = ReliabilityOptionsBuilder.Create(services).WithOutboxPollingProcessor(7500).Build();
+
+            options.EnableOutboxPollingProcessor.Should().BeTrue();
+            options.OutboxProcessingIntervalInMilliseconds.Should().Be(7500);
+        }
+
+        [Fact]
+        public void MustEnableOutboxPollingProcessorWithDefaultIntervalWhenWithOutboxPollingProcessorCalledWithoutArgument()
+        {
+            var services = new ServiceCollection();
+
+            var options = ReliabilityOptionsBuilder.Create(services).WithOutboxPollingProcessor().Build();
+
+            options.EnableOutboxPollingProcessor.Should().BeTrue();
+            options.OutboxProcessingIntervalInMilliseconds.Should().Be(5000);
+        }
+
+        [Fact]
+        public void MustTakeConfigBranchAndSkipFluentDefaultsWhenFromConfigSectionPopulated()
+        {
+            // INVARIANT: production binds the populated section via IConfigurationSection.Get<ReliabilityOptions>(),
+            // whose internal-set scalar properties stay at their type default; the fluent else-branch (which would
+            // otherwise apply MinutesToLiveInMemory of 10 and an interval of 5000) is skipped, so a populated
+            // section yields the type defaults (0), not the fluent defaults.
+            var services = new ServiceCollection();
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string>
+                {
+                    [$"{ReliabilityOptionsBuilder.ReliabilityOptionsSectionName}:RouteMessagesToOutbox"] = "true",
+                    [$"{ReliabilityOptionsBuilder.ReliabilityOptionsSectionName}:OutboxProcessingIntervalInMilliseconds"] = "1234"
+                })
+                .Build();
+
+            var options = ReliabilityOptionsBuilder.FromConfig(services, configuration);
+
+            options.Should().NotBeNull();
+            options.MinutesToLiveInMemory.Should().Be(0);
+            options.OutboxProcessingIntervalInMilliseconds.Should().Be(0);
         }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Routing/Options/UsingRoutingOptions/WhenConfiguring.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Options/UsingRoutingOptions/WhenConfiguring.cs
@@ -1,0 +1,77 @@
+using Chatter.MessageBrokers.Routing.Options;
+using FluentAssertions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Options.UsingRoutingOptions
+{
+    public class WhenConfiguring : Testing.Core.Context
+    {
+        [Fact]
+        public void MustReturnDefaultContentTypeWhenUnset()
+        {
+            var options = new SendOptions();
+
+            options.ContentType.Should().Be("application/json");
+            options.ContentType.Should().Be(RoutingOptions.DefaultContentType);
+        }
+
+        [Fact]
+        public void MustRoundTripContentTypeThroughMessageContextWhenSet()
+        {
+            var options = new SendOptions();
+
+            options.ContentType = "application/xml";
+
+            options.ContentType.Should().Be("application/xml");
+            options.MessageContext[MessageContext.ContentType].Should().Be("application/xml");
+        }
+
+        [Fact]
+        public void MustWriteCorrelationIdToMessageContext()
+        {
+            var options = new SendOptions();
+
+            options.SetCorrelationId("corr-123");
+
+            options.MessageContext[MessageContext.CorrelationId].Should().Be("corr-123");
+        }
+
+        [Fact]
+        public void MustWriteInfrastructureTypeToMessageContext()
+        {
+            var options = new SendOptions();
+
+            options.UseMessagingInfrastructure(t => t.Default);
+
+            options.MessageContext[MessageContext.InfrastructureType].Should().Be(string.Empty);
+        }
+
+        [Fact]
+        public void MustReturnSameInstanceWhenMergeContextIsNull()
+        {
+            var options = new SendOptions();
+
+            var result = options.Merge((IDictionary<string, object>)null);
+
+            result.Should().BeSameAs(options);
+        }
+
+        [Fact]
+        public void MustOverwriteAndCopyKeysWhenMergePopulatedContext()
+        {
+            var options = new SendOptions();
+            options.SetCorrelationId("original");
+            var contextToMerge = new Dictionary<string, object>
+            {
+                [MessageContext.CorrelationId] = "overwritten",
+                [MessageContext.Subject] = "added"
+            };
+
+            options.Merge(contextToMerge);
+
+            options.MessageContext[MessageContext.CorrelationId].Should().Be("overwritten");
+            options.MessageContext[MessageContext.Subject].Should().Be("added");
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers/tests/Routing/Options/UsingSendOptions/WhenConfiguring.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Options/UsingSendOptions/WhenConfiguring.cs
@@ -1,0 +1,99 @@
+using Chatter.MessageBrokers.Routing.Options;
+using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Routing.Options.UsingSendOptions
+{
+    public class WhenConfiguring : Testing.Core.Context
+    {
+        [Fact]
+        public void MustWriteSubjectToMessageContext()
+        {
+            var options = new SendOptions();
+
+            options.WithSubject("the-subject");
+
+            options.MessageContext[MessageContext.Subject].Should().Be("the-subject");
+        }
+
+        [Fact]
+        public void MustWriteGroupIdToMessageContext()
+        {
+            var options = new SendOptions();
+
+            options.WithGroupId("group-1");
+
+            options.MessageContext[MessageContext.GroupId].Should().Be("group-1");
+        }
+
+        [Fact]
+        public void MustWriteTimeToLiveAsTimeSpanFromMinutesToMessageContext()
+        {
+            var options = new SendOptions();
+
+            options.WithTimeToLiveInMinutes(5);
+
+            options.MessageContext[MessageContext.TimeToLive].Should().Be(TimeSpan.FromMinutes(5));
+        }
+
+        [Fact]
+        public void MustWriteReplyToAddressToMessageContext()
+        {
+            var options = new SendOptions();
+
+            options.SetReplyToAddress("reply-here");
+
+            options.MessageContext[MessageContext.ReplyToAddress].Should().Be("reply-here");
+        }
+
+        [Fact]
+        public void MustWriteReplyToGroupIdToMessageContext()
+        {
+            var options = new SendOptions();
+
+            options.SetReplyToGroupId("reply-group");
+
+            options.MessageContext[MessageContext.ReplyToGroupId].Should().Be("reply-group");
+        }
+
+        [Fact]
+        public void MustReturnSendOptionsWhenMergeOptionsToMergeIsNull()
+        {
+            var options = new SendOptions();
+
+            var result = options.Merge((SendOptions)null);
+
+            result.Should().BeSameAs(options);
+        }
+
+        [Fact]
+        public void MustMergeContextWhenMergePopulatedSendOptions()
+        {
+            var options = new SendOptions();
+            options.WithSubject("original");
+            var optionsToMerge = new SendOptions();
+            optionsToMerge.WithSubject("overwritten").WithGroupId("added");
+
+            var result = options.Merge(optionsToMerge);
+
+            result.MessageContext[MessageContext.Subject].Should().Be("overwritten");
+            result.MessageContext[MessageContext.GroupId].Should().Be("added");
+        }
+
+        [Fact]
+        public void MustProduceSendOptionsOverSuppliedContextWhenCreateUsed()
+        {
+            var context = new Dictionary<string, object>
+            {
+                [MessageContext.Subject] = "supplied"
+            };
+
+            var options = SendOptions.Create(context);
+
+            options.Should().BeOfType<SendOptions>();
+            options.MessageContext[MessageContext.Subject].Should().Be("supplied");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Test-only coverage for `Chatter.MessageBrokers`, resolving #173 then #174 on one branch/PR. No production source changed.

Closes #173
Closes #174

### #173 — options-builder branches (45 tests, commit 743f82a)
Defaults + overrides + guards only (no gold-plating) across:
- `Recovery/Options/RecoveryOptionsBuilder` — WithCircuitBreaker override/null-guard, UseExponentialDelayRecovery 15-attempt clamp, RetryWhen guard/predicate/generic, FromConfig branch
- `Recovery/CircuitBreaker/CircuitBreakerOptionsBuilder` — each setter override, IsTrippedBy guard/predicate/generic, FromConfig branch
- `Configuration/MessageBrokerOptionsBuilder` — WithTransactionMode, AddReliability/AddRecovery (action + null), static/instance FromConfig
- `Reliability/Configuration/ReliabilityOptionsBuilder` — WithOutboxRouting, TTL, polling processor (+default interval), FromConfig
- `Routing/Options/RoutingOptions` + `SendOptions` (new files) — ContentType default/get/set, correlation/infra keys, Merge null+populated, With*/SetReplyTo* writers, Create factory

### #174 — receiver/context/circuit-breaker edges (22 tests, commit e2d4fad)
Genuinely-behavioral remainders only; trivial guards & exception ctors deprioritized per triage:
- `Context/MessageHandlerContextExtensions` (new) — TryGetBrokeredMessageDispatcher 3 branches, InMemory, GetInboundBrokeredMessage, GetTransactionContext, Send/Publish no-op vs delegate
- `Context/MessageBrokerContext` — dispatcher-present Send/Publish delegation + remaining no-op-absent variants
- `Recovery/CircuitBreaker/CircuitBreaker` — Dispose idempotency (state edges already saturated)
- `Receiving/BrokeredMessageReceiver` (new) — inline-receive CriticalReceiverException stops loop + Notify once; deadletter-returns-false skips MaxReceivesExceededAction

## Validation
`Chatter.MessageBrokers.Tests`: 675/675 pass on net8.0 and net10.0. The 36 solution-wide failures are pre-existing `DockerUnavailableException` integration tests (ServiceBus emulator + SqlServiceBroker live-SQL) in untouched modules — environmental, no Docker in this runner.

## Versioning
No bump. Test-only change touches no shipped/package path (governance: test-only = No-bump row; matches repo precedent #175/#172/#158/#153).

## Follow-up note (not addressed here)
While covering the builders, `FromConfig` populated-section paths were found NOT to bind the options POCOs' `internal set` scalars via `IConfigurationSection.Get<T>()` (default binder, `BindNonPublicProperties` off) — a populated section yields type-default scalars. Tests pin the actual as-built behavior (config branch taken). This is a possible separate production defect worth its own issue; flagged, not patched (out of scope for test-only work).