### PR TITLE
test(messagebrokers/azureservicebus): isolate integration tests with dedicated emulator queues (#198)

### DIFF
--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/Config.json
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/Config.json
@@ -113,6 +113,61 @@
               "RequiresDuplicateDetection": false,
               "RequiresSession": false
             }
+          },
+          {
+            "Name": "chatter.complexpayload",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          },
+          {
+            "Name": "chatter.scheduled",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          },
+          {
+            "Name": "chatter.multireceiver.a",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          },
+          {
+            "Name": "chatter.multireceiver.b",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
+          },
+          {
+            "Name": "chatter.concurrency",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": false
+            }
           }
         ],
         "Topics": [

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineComplexPayloadTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineComplexPayloadTests.cs
@@ -34,7 +34,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
     [Collection(ServiceBusEmulatorCollection.Name)]
     public class PipelineComplexPayloadTests
     {
-        private const string ComplexQueue = "chatter.roundtrip";
+        private const string ComplexQueue = "chatter.complexpayload";
         private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
 
         private readonly ServiceBusEmulatorFixture _emulator;

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineConcurrencyTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineConcurrencyTests.cs
@@ -36,11 +36,10 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
     [Collection(ServiceBusEmulatorCollection.Name)]
     public class PipelineConcurrencyTests
     {
-        // Reuse an existing emulator queue (no new Config.json entity). MaxDeliveryCount is 10 so the broker does
-        // not deadletter before the handlers are released; LockDuration (PT10S) comfortably covers the time the
-        // handlers stay latched waiting for the concurrency signal. xUnit runs classes within a collection
-        // serially, so reusing this queue cannot collide with the deadletter class that also references it.
-        private const string ConcurrencyQueue = "chatter.attempts";
+        // Dedicated emulator queue for this class. MaxDeliveryCount is 10 so the broker does not deadletter
+        // before the handlers are released; LockDuration (PT10S) comfortably covers the time the handlers stay
+        // latched waiting for the concurrency signal.
+        private const string ConcurrencyQueue = "chatter.concurrency";
 
         // The global concurrency cap under test (> 1) and the number of messages sent (M > N), so the loop must
         // hold more messages than it can process at once — proving the gate admits exactly N, not 1 and not M.

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineMultiReceiverTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineMultiReceiverTests.cs
@@ -32,11 +32,10 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
     [Collection(ServiceBusEmulatorCollection.Name)]
     public class PipelineMultiReceiverTests
     {
-        // Two DISTINCT top-level queue entities, reused from the existing emulator Config.json (no new
-        // entities). xUnit runs classes within a collection serially, so reusing these queues cannot collide
-        // with the round-trip / transaction-mode classes that also reference them.
-        private const string QueueA = "chatter.roundtrip";
-        private const string QueueB = "chatter.receiveonly";
+        // Two DISTINCT top-level queue entities dedicated to this class — one per receiver — so no other test
+        // class can send to or receive from these queues concurrently.
+        private const string QueueA = "chatter.multireceiver.a";
+        private const string QueueB = "chatter.multireceiver.b";
 
         // Generous on purpose: two receivers must each deliver against the slow emulator, where a full
         // integration run takes minutes. 90s per handler gives headroom without masking a real wiring failure

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineScheduledDeliveryTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineScheduledDeliveryTests.cs
@@ -27,7 +27,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
     [Collection(ServiceBusEmulatorCollection.Name)]
     public class PipelineScheduledDeliveryTests
     {
-        private const string ScheduledQueue = "chatter.roundtrip";
+        private const string ScheduledQueue = "chatter.scheduled";
         // How far in the future the message is scheduled. Long enough that the "not yet" assertion is meaningful
         // against the slow emulator, short enough to keep the test quick.
         private static readonly TimeSpan ScheduleDelay = TimeSpan.FromSeconds(10);


### PR DESCRIPTION
## Fix ASB integration test flake — dedicated emulator queue per test class

Closes #198.

### Problem
The AzureServiceBus emulator integration suite shared hardcoded queues across test classes with no purge between tests, causing cross-test message contamination → nondeterministic failures (e.g. `PipelineComplexPayloadTests.ComplexPayloadRoundTripsEveryFieldThroughChatterSerializer` failing on net10.0 / passing net8.0). STJ lenient deserialization turns a leftover/foreign message into a non-null wrong-typed command, so an assertion fails fast (~176ms). Shared: `chatter.roundtrip` (4 classes), `chatter.receiveonly` (2), `chatter.attempts` (2).

### Fix (closed-by-construction)
Dedicated emulator queue per test class — no two classes share a queue, so contamination is unrepresentable regardless of teardown timing. One class keeps each original name as sole owner; the rest get class-unique names, all declared in `Integration/Config.json` (the emulator does not auto-create entities).

| Class | Queue |
|---|---|
| PipelineRoundTripTests | `chatter.roundtrip` (sole owner) |
| PipelineComplexPayloadTests | `chatter.complexpayload` |
| PipelineScheduledDeliveryTests | `chatter.scheduled` |
| PipelineMultiReceiverTests | `chatter.multireceiver.a` / `chatter.multireceiver.b` |
| PipelineTransactionModeTests | `chatter.receiveonly` (sole owner) |
| PipelineDeadLetterTests | `chatter.attempts` (sole owner) |
| PipelineConcurrencyTests | `chatter.concurrency` (mirrors `chatter.attempts` props: MaxDeliveryCount 10, LockDuration PT10S) |

### Scope & validation
- **Test files + `Config.json` only.** No production/core/RabbitMQ change. No version bump (ASB stays 1.3.0).
- Unit gate: 0 failed both TFMs. ASB emulator integration lane: **green 3× on net8.0 AND net10.0** (determinism proven — the flake no longer reproduces).
