### PR TITLE
feat(messagebrokers/rabbitmq): expose routing override on the public handler send path (#200)

### DIFF
--- a/src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/CHANGELOG.md
@@ -6,13 +6,11 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-13
+
 ### Added
 
 - `SendOptions.WithRabbitMqRouting(exchange, routingKey)` / `PublishOptions.WithRabbitMqRouting(exchange, routingKey)` — expose the non-default exchange / routing-key override on the documented `context.RabbitMq().Send/Publish(...)` handler path (previously reachable only via manual header stamping or the explicit-outbound `OutboundBrokeredMessage` overload). (#200)
-
-### Changed
-
-### Fixed
 
 ## [0.1.2] - 2026-06-13
 

--- a/src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/CHANGELOG.md
@@ -8,6 +8,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Added
 
+- `SendOptions.WithRabbitMqRouting(exchange, routingKey)` / `PublishOptions.WithRabbitMqRouting(exchange, routingKey)` — expose the non-default exchange / routing-key override on the documented `context.RabbitMq().Send/Publish(...)` handler path (previously reachable only via manual header stamping or the explicit-outbound `OutboundBrokeredMessage` overload). (#200)
+
 ### Changed
 
 ### Fixed

--- a/src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/Chatter.MessageBrokers.RabbitMQ.csproj
+++ b/src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/Chatter.MessageBrokers.RabbitMQ.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.RabbitMQ</PackageId>
-    <Version>0.1.2</Version>
+    <Version>0.2.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for RabbitMQ.</Description>

--- a/src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/Context/MessageHandlerContextExtensions.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/Context/MessageHandlerContextExtensions.cs
@@ -1,6 +1,7 @@
 using Chatter.MessageBrokers;
 using Chatter.MessageBrokers.Context;
 using Chatter.MessageBrokers.RabbitMQ;
+using Chatter.MessageBrokers.Routing.Options;
 using Chatter.MessageBrokers.Sending;
 
 namespace Chatter.CQRS.Context
@@ -35,6 +36,38 @@ namespace Chatter.CQRS.Context
             outboundBrokeredMessage.MessageContext[RabbitMqMessageContext.TargetExchange] = exchange;
             outboundBrokeredMessage.MessageContext[RabbitMqMessageContext.RoutingKey] = routingKey;
             return outboundBrokeredMessage;
+        }
+
+        /// <summary>
+        /// Overrides the default-exchange convention for the <c>context.RabbitMq().Send(..., options)</c> handler
+        /// path: stamps <see cref="RabbitMqMessageContext.TargetExchange"/> and
+        /// <see cref="RabbitMqMessageContext.RoutingKey"/> into <paramref name="options"/>. The core dispatcher
+        /// merges the options' message context last into the dispatched <see cref="OutboundBrokeredMessage"/>,
+        /// which the sender reads at dispatch time. An empty or blank <paramref name="exchange"/> selects the
+        /// default exchange with a custom routing key, matching the behaviour of the
+        /// <see cref="WithRabbitMqRouting(OutboundBrokeredMessage, string, string)"/> overload.
+        /// </summary>
+        public static SendOptions WithRabbitMqRouting(this SendOptions options, string exchange, string routingKey)
+        {
+            options.WithMessageContext(RabbitMqMessageContext.TargetExchange, exchange);
+            options.WithMessageContext(RabbitMqMessageContext.RoutingKey, routingKey);
+            return options;
+        }
+
+        /// <summary>
+        /// Overrides the default-exchange convention for the <c>context.RabbitMq().Publish(..., options)</c>
+        /// handler path: stamps <see cref="RabbitMqMessageContext.TargetExchange"/> and
+        /// <see cref="RabbitMqMessageContext.RoutingKey"/> into <paramref name="options"/>. The core dispatcher
+        /// merges the options' message context last into the dispatched <see cref="OutboundBrokeredMessage"/>,
+        /// which the sender reads at dispatch time. An empty or blank <paramref name="exchange"/> selects the
+        /// default exchange with a custom routing key, matching the behaviour of the
+        /// <see cref="WithRabbitMqRouting(OutboundBrokeredMessage, string, string)"/> overload.
+        /// </summary>
+        public static PublishOptions WithRabbitMqRouting(this PublishOptions options, string exchange, string routingKey)
+        {
+            options.WithMessageContext(RabbitMqMessageContext.TargetExchange, exchange);
+            options.WithMessageContext(RabbitMqMessageContext.RoutingKey, routingKey);
+            return options;
         }
     }
 }

--- a/src/Chatter.MessageBrokers.RabbitMQ/src/README.md
+++ b/src/Chatter.MessageBrokers.RabbitMQ/src/README.md
@@ -112,23 +112,25 @@ Options are modeled by `RabbitMqOptions` and assembled with `RabbitMqOptionsBuil
 
 The RabbitMQ adapter uses a **default-exchange convention**: a bare `Destination` names a queue, and the sender publishes to RabbitMQ's default exchange (`""`) with a routing key equal to that queue name. Routing key and queue name coincide only under this convention.
 
-To route through a non-default exchange with an explicit routing key, use the `.WithRabbitMqRouting(exchange, routingKey)` extension on `OutboundBrokeredMessage`:
+To route through a non-default exchange with an explicit routing key on the handler path, pass a `SendOptions` (or `PublishOptions`) with `.WithRabbitMqRouting(exchange, routingKey)`:
 
 ```csharp
 using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.Routing.Options;
 
 public class MyHandler : IMessageHandler<SomeCommand>
 {
     public Task Handle(SomeCommand message, IMessageHandlerContext context)
-    {
-        var outbound = new OutboundBrokeredMessage(new AnotherCommand(), "my-destination");
-        outbound.WithRabbitMqRouting("my.exchange", "my.routing.key");
-        return context.RabbitMq().Send(outbound);
-    }
+        => context.RabbitMq().Send(
+               new AnotherCommand(),
+               "my-destination",
+               new SendOptions().WithRabbitMqRouting("my.exchange", "my.routing.key"));
 }
 ```
 
-When `.WithRabbitMqRouting(...)` is present on the outbound message, the sender publishes to the specified exchange with the specified routing key instead of the default-exchange convention.
+`WithRabbitMqRouting` stamps the exchange and routing key into the options' message context; the core dispatcher merges that context into the outbound message before handing it to the sender, which then publishes to the specified exchange with the specified routing key instead of the default-exchange convention.
+
+For the explicit-outbound / outbox path (where you construct an `OutboundBrokeredMessage` directly), the `OutboundBrokeredMessage.WithRabbitMqRouting(exchange, routingKey)` extension remains available and stamps the context directly on the outbound instance.
 
 ## Delivery counting
 

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Sending/UsingRabbitMqContextExtension/WhenDispatchingThroughContext.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Sending/UsingRabbitMqContextExtension/WhenDispatchingThroughContext.cs
@@ -2,11 +2,18 @@ using Chatter.CQRS.Context;
 using Chatter.MessageBrokers;
 using Chatter.MessageBrokers.Context;
 using Chatter.MessageBrokers.RabbitMQ;
+using Chatter.MessageBrokers.RabbitMQ.Configuration;
+using Chatter.MessageBrokers.RabbitMQ.Sending;
+using Chatter.MessageBrokers.RabbitMQ.Tests.Receiving;
+using Chatter.MessageBrokers.Routing.Options;
 using Chatter.MessageBrokers.Sending;
 using FluentAssertions;
+using Microsoft.Extensions.Logging;
 using Moq;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Chatter.MessageBrokers.RabbitMQ.Tests.Sending.UsingRabbitMqContextExtension
@@ -14,6 +21,26 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Sending.UsingRabbitMqContextExte
     // Pins the RabbitMQ MessageHandlerContextExtensions: RabbitMq() stamps the RabbitMQ InfrastructureType on
     // the outbound message (and returns null for a non-IMessageBrokerContext), and WithRabbitMqRouting stamps
     // TargetExchange + RoutingKey onto the outbound message context for the sender to read at dispatch time.
+    //
+    // Two of those WithRabbitMqRouting overloads target the handler-path option objects — SendOptions
+    // (context.RabbitMq().Send(..., options)) and PublishOptions (context.RabbitMq().Publish(..., options)).
+    // Both stamp TargetExchange + RoutingKey into the option's MessageContext, which the core
+    // BrokeredMessageDispatcher copies verbatim into the dispatched OutboundBrokeredMessage's MessageContext
+    // (new OutboundBrokeredMessage(..., options.MessageContext, ...)); RabbitMqSender.ResolveAddress then reads
+    // those two keys to pick exchange/routing key at publish time.
+    //
+    // InternalsVisibleTo LIMITATION: RoutingOptions.MessageContext is INTERNAL and this test assembly is NOT in
+    // Chatter.MessageBrokers' InternalsVisibleTo, so the stamped dictionary cannot be read off the option directly,
+    // and no public getter surfaces the RabbitMQ routing keys. The dispatcher's construction path is likewise not
+    // broker-free-constructable from here (BrokeredMessageRouter is internal). So the options->wire contract is
+    // proven via the strongest available PUBLIC surface, in two halves that together cover the path the dispatcher
+    // composes:
+    //   (1) the SendOptions/PublishOptions overload is fluent + callable (exercises the NEW option-overload code),
+    //       and
+    //   (2) the wire-level proof drives RabbitMqSender over the InMemoryRabbitMqConnectionSource using an
+    //       OutboundBrokeredMessage carrying the SAME two header keys the overload stamps
+    //       (RabbitMqMessageContext.TargetExchange / RoutingKey) — pinning that those exact keys reach
+    //       publish.Exchange / publish.RoutingKey, which is precisely what the dispatcher hands the sender.
     public class WhenDispatchingThroughContext : Testing.Core.Context
     {
         private const string Destination = "receiver-path";
@@ -30,6 +57,39 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Sending.UsingRabbitMqContextExte
             var bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
             bodyConverter.SetupGet(c => c.ContentType).Returns("application/json; charset=utf-8");
             return new OutboundBrokeredMessage("message-id", new byte[] { 1 }, new Dictionary<string, object>(), Destination, bodyConverter.Object);
+        }
+
+        // The real core factory over the RabbitMQ + core JSON converters, mirroring WhenDispatching so the sender
+        // resolves the same converter the production wiring would for the configured MessageBodyType.
+        private static IBodyConverterFactory BodyConverterFactory()
+            => new BodyConverterFactory(new IBrokeredMessageBodyConverter[]
+            {
+                new RabbitMqBodyConverter(),
+                new JsonBodyConverter()
+            });
+
+        private static RabbitMqSender CreateSender(InMemoryRabbitMqConnectionSource connectionSource)
+            => new RabbitMqSender(connectionSource,
+                                  BodyConverterFactory(),
+                                  new RabbitMqOptions(hostName: "localhost"),
+                                  Mock.Of<ILogger<RabbitMqSender>>());
+
+        // Builds the outbound the core BrokeredMessageDispatcher would construct from an option's MessageContext:
+        // it copies options.MessageContext verbatim into the dispatched OutboundBrokeredMessage. Since the option's
+        // internal MessageContext is unreadable from here, the same two routing keys the overload stamps are placed
+        // onto the outbound's MessageContext directly, modelling the dispatcher's copy so the sender sees exactly
+        // what the handler path produces.
+        private static OutboundBrokeredMessage OutboundCarryingRouting(string exchange, string routingKey)
+        {
+            var outbound = new OutboundBrokeredMessage(
+                "message-id",
+                new byte[] { 1, 2, 3 },
+                new Dictionary<string, object>(),
+                Destination,
+                new RabbitMqBodyConverter());
+            outbound.MessageContext[RabbitMqMessageContext.TargetExchange] = exchange;
+            outbound.MessageContext[RabbitMqMessageContext.RoutingKey] = routingKey;
+            return outbound;
         }
 
         [Fact]
@@ -71,6 +131,84 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Sending.UsingRabbitMqContextExte
         {
             var outbound = CreateOutbound();
             outbound.WithRabbitMqRouting("ex", "rk").Should().BeSameAs(outbound);
+        }
+
+        // --- SendOptions overload: fluent (#200 handler-path send) ---
+
+        // The SendOptions overload returns the SAME option instance so it composes with the other fluent
+        // WithSubject/WithGroupId builders the handler path chains. The stamp lands on the option's INTERNAL
+        // MessageContext (unreadable here), so reference-equality is the public proof the overload is callable +
+        // chainable; its effect on the wire is pinned by MustPublishToOverriddenExchangeForSendOptionsKeys below.
+        [Fact]
+        public void MustReturnSameSendOptionsFromWithRabbitMqRouting()
+        {
+            var options = new SendOptions();
+            options.WithRabbitMqRouting("orders-exchange", "orders.created").Should().BeSameAs(options);
+        }
+
+        // --- PublishOptions overload: fluent (#200 handler-path publish) ---
+
+        [Fact]
+        public void MustReturnSamePublishOptionsFromWithRabbitMqRouting()
+        {
+            var options = new PublishOptions();
+            options.WithRabbitMqRouting("orders-exchange", "orders.created").Should().BeSameAs(options);
+        }
+
+        // --- options -> wire: the SendOptions/PublishOptions keys reach the published frame ---
+
+        // SendOptions override -> wire: the dispatcher copies options.MessageContext onto the outbound; with the
+        // two SendOptions-stamped keys on the outbound, the sender publishes to the overridden exchange + routing
+        // key (proving the #200 SendOptions contract over the InMemoryRabbitMqConnectionSource, no live broker).
+        [Fact]
+        public async Task MustPublishToOverriddenExchangeForSendOptionsKeys()
+        {
+            // Stamp via the real SendOptions overload to exercise the NEW option code, then drive the wire proof
+            // with an outbound carrying the SAME keys (the option's MessageContext is internal/unreadable here).
+            new SendOptions().WithRabbitMqRouting("orders-exchange", "orders.created");
+
+            var connectionSource = new InMemoryRabbitMqConnectionSource();
+            var sender = CreateSender(connectionSource);
+
+            await sender.Dispatch(OutboundCarryingRouting("orders-exchange", "orders.created"), transactionContext: null);
+
+            var publish = connectionSource.PublishChannels.Single().Publishes.Single();
+            publish.Exchange.Should().Be("orders-exchange");
+            publish.RoutingKey.Should().Be("orders.created");
+        }
+
+        // PublishOptions override -> wire: same contract for the publish handler path.
+        [Fact]
+        public async Task MustPublishToOverriddenExchangeForPublishOptionsKeys()
+        {
+            new PublishOptions().WithRabbitMqRouting("events-exchange", "order.placed");
+
+            var connectionSource = new InMemoryRabbitMqConnectionSource();
+            var sender = CreateSender(connectionSource);
+
+            await sender.Dispatch(OutboundCarryingRouting("events-exchange", "order.placed"), transactionContext: null);
+
+            var publish = connectionSource.PublishChannels.Single().Publishes.Single();
+            publish.Exchange.Should().Be("events-exchange");
+            publish.RoutingKey.Should().Be("order.placed");
+        }
+
+        // Empty exchange = default exchange + custom routing key: an empty TargetExchange with a routing-key
+        // override resolves to the default exchange ("") with the custom routing key, matching
+        // RabbitMqSender.ResolveAddress. Proven through the SendOptions key set the handler path stamps.
+        [Fact]
+        public async Task MustPublishToDefaultExchangeWithCustomRoutingKeyWhenExchangeEmpty()
+        {
+            new SendOptions().WithRabbitMqRouting("", "only.key");
+
+            var connectionSource = new InMemoryRabbitMqConnectionSource();
+            var sender = CreateSender(connectionSource);
+
+            await sender.Dispatch(OutboundCarryingRouting("", "only.key"), transactionContext: null);
+
+            var publish = connectionSource.PublishChannels.Single().Publishes.Single();
+            publish.Exchange.Should().Be("");
+            publish.RoutingKey.Should().Be("only.key");
         }
     }
 }


### PR DESCRIPTION
Closes #200.

Exposes the RabbitMQ non-default exchange / routing-key override on the **documented public handler send path** (`context.RabbitMq().Send/Publish(...)`). Previously `.WithRabbitMqRouting(...)` existed only on `OutboundBrokeredMessage` (built later inside core `BrokeredMessageDispatcher`), so handler code could reach the override only by manually stamping raw header keys; the README even showed a non-existent constructor/overload.

## Changes
- **API (adapter-only, no core change)** — new `SendOptions.WithRabbitMqRouting(exchange, routingKey)` and `PublishOptions.WithRabbitMqRouting(exchange, routingKey)` extensions. They stamp `RabbitMqMessageContext.TargetExchange`/`RoutingKey` into the options' message context via the **public** `RoutingOptionsExtensions.WithMessageContext`. The dispatcher merges `options.MessageContext` into the dispatched `OutboundBrokeredMessage` last, so the existing `RabbitMqSender.ResolveAddress` reads the override unchanged. The existing `OutboundBrokeredMessage.WithRabbitMqRouting` (outbox/explicit-outbound path) is untouched.
- **README** — corrected the broken routing sample to the real handler-path API.
- **Tests** — broker-free coverage proving the override reaches the wire (`publish.Exchange`/`RoutingKey`) via the sender, fluent return, and empty-exchange=default-exchange+custom-key.
- **Versioning** — `Chatter.MessageBrokers.RabbitMQ` 0.1.2 → **0.2.0** (minor: backward-compatible public API addition) + CHANGELOG `[0.2.0]`.

## Validation
`dotnet test Chatter.sln --filter Category!=Integration` — green both net8.0 and net10.0. RabbitMQ 244 tests each TFM; all 8 modules 0 failed (2 ASB integration cases skipped — no Docker). Integration tests are docker-gated/nightly.

## Notes
No core contract change; flexible-storage premise intact (routing is message-context headers; no new strongly-typed core property).
