### PR TITLE
fix(messagebrokers): stop per-send options leaking into the inbound handler context

### DIFF
--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
@@ -12,6 +12,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+- Per-send `SendOptions`/`PublishOptions` no longer leak into the inbound handler message context: `SendOptions.Create`/`PublishOptions.Create` now copy the inbound context so a routed/configured send does not persist its options (exchange/routing key, subject, TTL, correlation-id, etc.) into subsequent sends on the same handler context (#201).
+
 ## [0.13.1] - 2026-06-09
 
 ### Fixed

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
@@ -7,7 +7,7 @@
          TryEncodeUnicodeScalar) is char*-pointer based, so the overrides must be unsafe. -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Chatter.MessageBrokers</PackageId>
-    <Version>0.13.1</Version>
+    <Version>0.13.2</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A message broker adapter library built on top of Chatter.CQRS.</Description>

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/PublishOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/PublishOptions.cs
@@ -6,7 +6,8 @@ namespace Chatter.MessageBrokers.Routing.Options
     {
         public PublishOptions() { }
         private PublishOptions(IDictionary<string, object> messageContext) : base(messageContext) { }
-        internal static PublishOptions Create(IDictionary<string, object> messageContext) => new PublishOptions(messageContext);
+        internal static PublishOptions Create(IDictionary<string, object> messageContext)
+            => new PublishOptions(messageContext is null ? null : new Dictionary<string, object>(messageContext));
 
         public PublishOptions Merge(PublishOptions optionsToMerge) => Merge(optionsToMerge?.MessageContext) as PublishOptions;
     }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/SendOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/SendOptions.cs
@@ -7,7 +7,8 @@ namespace Chatter.MessageBrokers.Routing.Options
     {
         public SendOptions() { }
         private SendOptions(IDictionary<string, object> messageContext) : base(messageContext) { }
-        internal static SendOptions Create(IDictionary<string, object> messageContext) => new SendOptions(messageContext);
+        internal static SendOptions Create(IDictionary<string, object> messageContext)
+            => new SendOptions(messageContext is null ? null : new Dictionary<string, object>(messageContext));
         
         public SendOptions Merge(SendOptions optionsToMerge) => Merge(optionsToMerge?.MessageContext) as SendOptions;
 

--- a/src/Chatter.MessageBrokers/tests/Routing/Options/UsingRoutingOptions/WhenConfiguring.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Options/UsingRoutingOptions/WhenConfiguring.cs
@@ -73,5 +73,51 @@ namespace Chatter.MessageBrokers.Tests.Routing.Options.UsingRoutingOptions
             options.MessageContext[MessageContext.CorrelationId].Should().Be("overwritten");
             options.MessageContext[MessageContext.Subject].Should().Be("added");
         }
+
+        [Fact]
+        public void MustNotMutateSuppliedInboundContextWhenPublishOptionsMergeAppliesOverride()
+        {
+            var inbound = new Dictionary<string, object>
+            {
+                [MessageContext.CorrelationId] = "corr-inbound"
+            };
+            var perPublishOverride = new PublishOptions();
+            perPublishOverride.SetCorrelationId("corr-override");
+
+            PublishOptions.Create(inbound).Merge(perPublishOverride);
+
+            inbound[MessageContext.CorrelationId].Should().Be("corr-inbound");
+        }
+
+        [Fact]
+        public void MustApplyOverrideToReturnedPublishOptionsWhenMergeAppliesOverride()
+        {
+            var inbound = new Dictionary<string, object>
+            {
+                [MessageContext.CorrelationId] = "corr-inbound"
+            };
+            var perPublishOverride = new PublishOptions();
+            perPublishOverride.SetCorrelationId("corr-override");
+
+            var merged = PublishOptions.Create(inbound).Merge(perPublishOverride);
+
+            merged.MessageContext[MessageContext.CorrelationId].Should().Be("corr-override");
+        }
+
+        [Fact]
+        public void MustNotLeakPriorOverrideIntoLaterPublishOptionsCreateOnSameInboundContext()
+        {
+            var inbound = new Dictionary<string, object>
+            {
+                [MessageContext.CorrelationId] = "corr-inbound"
+            };
+            var firstOverride = new PublishOptions();
+            firstOverride.SetCorrelationId("first-publish-corr");
+
+            PublishOptions.Create(inbound).Merge(firstOverride);
+            var secondMerged = PublishOptions.Create(inbound).Merge(new PublishOptions());
+
+            secondMerged.MessageContext[MessageContext.CorrelationId].Should().Be("corr-inbound");
+        }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Routing/Options/UsingSendOptions/WhenConfiguring.cs
+++ b/src/Chatter.MessageBrokers/tests/Routing/Options/UsingSendOptions/WhenConfiguring.cs
@@ -95,5 +95,49 @@ namespace Chatter.MessageBrokers.Tests.Routing.Options.UsingSendOptions
             options.Should().BeOfType<SendOptions>();
             options.MessageContext[MessageContext.Subject].Should().Be("supplied");
         }
+
+        [Fact]
+        public void MustNotMutateSuppliedInboundContextWhenMergeAppliesOverride()
+        {
+            var inbound = new Dictionary<string, object>
+            {
+                [MessageContext.CorrelationId] = "corr-inbound"
+            };
+            var perSendOverride = new SendOptions().WithSubject("per-send-subject");
+
+            SendOptions.Create(inbound).Merge(perSendOverride);
+
+            inbound.Should().NotContainKey(MessageContext.Subject);
+            inbound[MessageContext.CorrelationId].Should().Be("corr-inbound");
+        }
+
+        [Fact]
+        public void MustApplyOverrideToReturnedOptionsWhenMergeAppliesOverride()
+        {
+            var inbound = new Dictionary<string, object>
+            {
+                [MessageContext.CorrelationId] = "corr-inbound"
+            };
+            var perSendOverride = new SendOptions().WithSubject("per-send-subject");
+
+            var merged = SendOptions.Create(inbound).Merge(perSendOverride);
+
+            merged.MessageContext[MessageContext.Subject].Should().Be("per-send-subject");
+            merged.MessageContext[MessageContext.CorrelationId].Should().Be("corr-inbound");
+        }
+
+        [Fact]
+        public void MustNotLeakPriorOverrideIntoLaterCreateOnSameInboundContext()
+        {
+            var inbound = new Dictionary<string, object>
+            {
+                [MessageContext.CorrelationId] = "corr-inbound"
+            };
+
+            SendOptions.Create(inbound).Merge(new SendOptions().WithSubject("first-send-subject"));
+            var secondMerged = SendOptions.Create(inbound).Merge(new SendOptions());
+
+            secondMerged.MessageContext.Should().NotContainKey(MessageContext.Subject);
+        }
     }
 }

--- a/src/Chatter.MessageBrokers/tests/Sending/UsingBrokeredMessageDispatcher/WhenDispatching.cs
+++ b/src/Chatter.MessageBrokers/tests/Sending/UsingBrokeredMessageDispatcher/WhenDispatching.cs
@@ -1,0 +1,84 @@
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.Routing;
+using Chatter.MessageBrokers.Routing.Options;
+using Chatter.MessageBrokers.Sending;
+using FluentAssertions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Tests.Sending.UsingBrokeredMessageDispatcher
+{
+    public class WhenDispatching : Testing.Core.Context
+    {
+        private readonly Mock<IRouteBrokeredMessages> _messageRouter = new Mock<IRouteBrokeredMessages>();
+        private readonly Mock<IForwardMessages> _forwarder = new Mock<IForwardMessages>();
+        private readonly Mock<IBrokeredMessageAttributeDetailProvider> _detailProvider = new Mock<IBrokeredMessageAttributeDetailProvider>();
+        private readonly Mock<IBodyConverterFactory> _bodyConverterFactory = new Mock<IBodyConverterFactory>();
+        private readonly Mock<IBrokeredMessageBodyConverter> _bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+        private readonly Mock<IMessageIdGenerator> _idGenerator = new Mock<IMessageIdGenerator>();
+        private readonly BrokeredMessageDispatcher _sut;
+
+        private List<OutboundBrokeredMessage> _routedMessages;
+
+        public WhenDispatching()
+        {
+            _bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+            _bodyConverter.Setup(c => c.Convert(It.IsAny<object>())).Returns(new byte[] { 1, 2, 3 });
+            _bodyConverterFactory.Setup(f => f.CreateBodyConverter(It.IsAny<string>())).Returns(_bodyConverter.Object);
+            _idGenerator.Setup(g => g.GenerateId(It.IsAny<byte[]>())).Returns(Guid.NewGuid());
+
+            _messageRouter.Setup(r => r.Route(It.IsAny<IEnumerable<OutboundBrokeredMessage>>(), It.IsAny<TransactionContext>(), It.IsAny<string>()))
+                          .Callback<IEnumerable<OutboundBrokeredMessage>, TransactionContext, string>((m, _, __) => _routedMessages = m.ToList())
+                          .Returns(Task.CompletedTask);
+
+            _sut = new BrokeredMessageDispatcher(
+                _messageRouter.Object,
+                _forwarder.Object,
+                _detailProvider.Object,
+                _bodyConverterFactory.Object,
+                _idGenerator.Object);
+        }
+
+        private class FakeCommand : ICommand { }
+
+        // A real MessageBrokerContext carries an inbound InboundBrokeredMessage whose internal MessageContextImpl
+        // is what BrokeredMessageDispatcher merges per-send SendOptions over via SendOptions.Create(...).Merge(...).
+        private static MessageBrokerContext HandlerContextWithInbound(Mock<IBrokeredMessageBodyConverter> bodyConverter)
+            => new MessageBrokerContext(
+                "inbound-message-id",
+                new byte[] { 9 },
+                new Dictionary<string, object>(),
+                "receiver-path",
+                CancellationToken.None,
+                bodyConverter.Object);
+
+        [Fact]
+        public async Task MustCarryPerSendOverrideOntoOutboundWhenDispatchedThroughHandlerContext()
+        {
+            var handlerContext = HandlerContextWithInbound(_bodyConverter);
+            var options = new SendOptions().WithSubject("first-send-subject");
+
+            await _sut.Send(new FakeCommand(), "destination", handlerContext, options);
+
+            _routedMessages.Single().GetMessageContextByKey<string>(MessageContext.Subject).Should().Be("first-send-subject");
+        }
+
+        [Fact]
+        public async Task MustNotLeakPriorSendOverrideOntoLaterDispatchOnSameHandlerContext()
+        {
+            var handlerContext = HandlerContextWithInbound(_bodyConverter);
+
+            await _sut.Send(new FakeCommand(), "destination", handlerContext, new SendOptions().WithSubject("first-send-subject"));
+            await _sut.Send(new FakeCommand(), "destination", handlerContext, new SendOptions());
+
+            _routedMessages.Single().GetMessageContextByKey<string>(MessageContext.Subject).Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
Fixes a per-send option leak in `Chatter.MessageBrokers` core (surfaced by PR #201 review, thread r3408758475; separate core PR per maintainer decision).

## Problem
`SendOptions.Create`/`PublishOptions.Create` passed the **live inbound** message-context dictionary into `RoutingOptions`, which **aliased** it; `RoutingOptions.Merge` (and `OutboundBrokeredMessage`'s ctor) then wrote option keys into that live dict. So `Send(msg, options)` mutated the inbound handler context in place, and a later `Send(...)` on the same context inherited stale keys (exchange/routing-key, subject, TTL, correlation-id, content-type, …). Affected all option keys and all adapters.

## Fix (minimal, internal)
`SendOptions.Create` / `PublishOptions.Create` now **copy** the supplied inbound dictionary before wrapping it (null-tolerant), so the per-dispatch merge and outbound construction mutate only a per-dispatch copy — never the caller's inbound context. No public API change; `Create` stays internal. Verified no caller depended on the prior aliasing/mutation.

## Tests
- Options seam: `Create(inbound).Merge(override)` does not mutate `inbound`; the merged options still carry the override; a second `Create(inbound).Merge(...)` on the same dict sees no stale key (SendOptions + PublishOptions).
- Dispatcher path: a per-send override reaches the first outbound, but a second dispatch with no options on the same handler context produces an outbound **without** the stale key (end-to-end leak-closed proof).

## Validation
`dotnet test Chatter.sln --filter Category!=Integration` — green both net8.0 and net10.0. Chatter.MessageBrokers 683 tests each TFM; all modules 0 failed (2 ASB integration cases skipped — no Docker).

## Versioning
`Chatter.MessageBrokers` 0.13.1 → **0.13.2** (patch; bug fix, no public API change) + CHANGELOG.

Related: PR #201 (#200) — the RabbitMQ routing override that surfaced this; it remains correct for a single send and is unaffected by this fix.
