### PR TITLE
test(messagebrokers/rabbitmq): fix recovery-epoch IT to use Testcontainers-mapped management port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,3 +337,11 @@ Publish/
 
 # Claude Code personal overrides
 CLAUDE.local.md
+
+.claude/settings.local.json
+
+.claude/agent-memory/*
+.claude/agent-memory/
+
+# Claude Code worktree sessions
+.claude/worktrees/

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqConnectionKiller.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqConnectionKiller.cs
@@ -16,21 +16,28 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
     // recovers the SAME IChannel — the exact path that leaves the receive-channel epoch stale unless the source's
     // RecoverySucceededAsync subscription advances it. Used only by the recovery-epoch integration proof.
     //
-    // The management port (15672) is derived from the AMQP URI's host and credentials; the management plugin is
-    // present because the fixture pins the `-management` image. Connections are listed and deleted by name.
+    // The management base URI is supplied by the caller (the fixture resolves it from the Testcontainers-mapped
+    // management port, which is a RANDOM host port — NOT the default 15672). Only the management credentials are
+    // derived from the AMQP URI's userinfo; the management plugin is present because the fixture pins the
+    // `-management` image. Connections are listed and deleted by name.
     internal static class RabbitMqConnectionKiller
     {
-        private const int ManagementPort = 15672;
         private static readonly TimeSpan OperationTimeout = TimeSpan.FromSeconds(30);
 
         // Kills every current broker connection except those whose client-provided name marks them as a management
         // or out-of-band helper. Returns the number of connections deleted so the caller can assert at least one
-        // (the receiver's) was dropped, forcing recovery.
-        public static async Task<int> KillAllConnectionsAsync(string amqpUri, CancellationToken cancellationToken)
+        // (the receiver's) was dropped, forcing recovery. The management base URI must point at the
+        // Testcontainers-mapped management endpoint; credentials are taken from the AMQP URI's userinfo.
+        public static async Task<int> KillAllConnectionsAsync(string amqpUri, Uri managementBase, CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(amqpUri))
             {
                 throw new ArgumentException("An AMQP connection URI is required.", nameof(amqpUri));
+            }
+
+            if (managementBase is null)
+            {
+                throw new ArgumentNullException(nameof(managementBase), "A management base URI is required.");
             }
 
             var uri = new Uri(amqpUri);
@@ -42,13 +49,15 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
             operationCts.CancelAfter(OperationTimeout);
             var token = operationCts.Token;
 
-            var managementBase = new UriBuilder("http", uri.Host, ManagementPort).Uri;
-
             using var client = new HttpClient { BaseAddress = managementBase, Timeout = OperationTimeout };
             var credentials = Convert.ToBase64String(Encoding.UTF8.GetBytes($"{userName}:{password}"));
             client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Basic", credentials);
 
-            var names = await ListConnectionNamesAsync(client, token).ConfigureAwait(false);
+            // RabbitMQ's management stats are eventually consistent: a freshly-opened AMQP connection can take a
+            // moment to surface in /api/connections even though it is already live. Poll until at least one
+            // connection is listed (bounded by the operation timeout) so the kill is not a no-op against a stale,
+            // not-yet-populated view.
+            var names = await WaitForConnectionNamesAsync(client, token).ConfigureAwait(false);
 
             var deleted = 0;
             foreach (var name in names)
@@ -65,6 +74,21 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
             }
 
             return deleted;
+        }
+
+        // Polls /api/connections until at least one connection is listed, or the token trips. Absorbs the
+        // management API's eventual-consistency lag between a connection opening and appearing in the stats view.
+        private static async Task<IReadOnlyList<string>> WaitForConnectionNamesAsync(HttpClient client, CancellationToken token)
+        {
+            var pollInterval = TimeSpan.FromMilliseconds(250);
+            IReadOnlyList<string> names = await ListConnectionNamesAsync(client, token).ConfigureAwait(false);
+            while (names.Count == 0 && !token.IsCancellationRequested)
+            {
+                await Task.Delay(pollInterval, token).ConfigureAwait(false);
+                names = await ListConnectionNamesAsync(client, token).ConfigureAwait(false);
+            }
+
+            return names;
         }
 
         private static async Task<IReadOnlyList<string>> ListConnectionNamesAsync(HttpClient client, CancellationToken token)

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqFixture.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqFixture.cs
@@ -22,6 +22,10 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
         // which the deadletter scenario proves on both per ADR-0001.
         private const string RabbitMqImage = "rabbitmq:3.13-management";
 
+        // The container-internal management API port. Testcontainers maps this to a RANDOM host port (NOT 15672),
+        // so the management base URI must be built from GetMappedPublicPort(15672) rather than a hardcoded port.
+        private const int ManagementContainerPort = 15672;
+
         // Bounds container start so a wedged Docker pull/start fails fast instead of hanging the test collection.
         // Generous because a cold image pull is slow; still finite.
         private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
@@ -42,6 +46,22 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
             return _container.GetConnectionString();
         }
 
+        // The management HTTP API base URI (http://host:mappedManagementPort) for the running container. The
+        // management port 15672 is mapped by Testcontainers to a RANDOM host port, so this resolves the mapped
+        // port at call time rather than assuming the default. Throws if the container was not started (Docker
+        // unavailable), mirroring GetAmqpConnectionString.
+        public Uri GetManagementBaseUri()
+        {
+            if (_container is null)
+            {
+                throw new InvalidOperationException(
+                    "The RabbitMQ container was not started (Docker unavailable). " +
+                    "Integration tests must be guarded with [RequiresDockerFact].");
+            }
+
+            return new UriBuilder("http", _container.Hostname, _container.GetMappedPublicPort(ManagementContainerPort)).Uri;
+        }
+
         public async Task InitializeAsync()
         {
             if (!DockerEnvironment.IsAvailable)
@@ -51,7 +71,12 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
 
             using var startupCts = new CancellationTokenSource(StartupTimeout);
 
-            _container = new RabbitMqBuilder(RabbitMqImage).Build();
+            // RabbitMqBuilder publishes only the AMQP port (5672) by default. The recovery-epoch test drops broker
+            // connections via the management HTTP API, so the management port (15672) must also be published to a
+            // random host port; GetManagementBaseUri resolves that mapped port at call time.
+            _container = new RabbitMqBuilder(RabbitMqImage)
+                .WithPortBinding(ManagementContainerPort, assignRandomHostPort: true)
+                .Build();
             await _container.StartAsync(startupCts.Token).ConfigureAwait(false);
         }
 

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqRecoveryEpochTests.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqRecoveryEpochTests.cs
@@ -116,7 +116,8 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
                 // Force automatic recovery: drop the broker connection out-of-band. The source's
                 // RecoverySucceededAsync handler recreates the receive channel, bumps the epoch, and re-registers
                 // the consumer under the gate.
-                var killed = await RabbitMqConnectionKiller.KillAllConnectionsAsync(amqpUri, CancellationToken.None);
+                var killed = await RabbitMqConnectionKiller.KillAllConnectionsAsync(
+                    amqpUri, _fixture.GetManagementBaseUri(), CancellationToken.None);
                 killed.Should().BeGreaterThan(0,
                     "at least the receiver's broker connection must be dropped to trigger automatic recovery");
 


### PR DESCRIPTION
Test-only fix. Makes the RabbitMQ docker integration suite fully green locally and on the nightly.

## Problem
The RecoveryEpoch integration test failed `HttpRequestException: Connection refused (127.0.0.1:15672)` (9/10 passing). `RabbitMqConnectionKiller` hardcoded the management port `15672` and built the management API base from the AMQP URI host + that constant. Two layered causes:
1. The fixture's `RabbitMqBuilder` publishes only the AMQP port (5672) by default — **15672 was never mapped**.
2. Even mapped, Testcontainers assigns a **random host port**, so `127.0.0.1:15672` is wrong.

## Fix (tests only)
- `RabbitMqFixture` — explicitly publish the management port (`.WithPortBinding(15672, assignRandomHostPort: true)`) and expose `GetManagementBaseUri()` = `http://{Hostname}:{GetMappedPublicPort(15672)}`.
- `RabbitMqConnectionKiller.KillAllConnectionsAsync` — take the management base `Uri` from the caller instead of the hardcoded `15672`/`uri.Host`; credentials still derived from the AMQP userinfo. Added a bounded poll (`WaitForConnectionNamesAsync`, 250ms, capped by the existing 30s timeout) for the management API's eventually-consistent `/api/connections` listing — on timeout it returns empty so `killed > 0` still fails (no false pass).
- `RabbitMqRecoveryEpochTests` — passes the fixture's mapped management base into the killer.

No production/adapter code changed; no version bump (test files do not ship).

## Validation (docker available locally)
- Integration (`--filter Category=Integration`): **10/10** both net8.0 and net10.0 (was 9/10 — RecoveryEpoch now passes).
- Unit (`--filter Category!=Integration`): 244/244 both TFMs.
- Local Codex adversarial review: clean, 0 findings.
