### PR TITLE
test(messagebrokers/rabbitmq): close coverage gaps + assert republish-before-ack ordering

### DIFF
--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/InMemoryRabbitMqConnectionSource.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/InMemoryRabbitMqConnectionSource.cs
@@ -27,6 +27,11 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
         private long _currentReceiveChannelEpoch;
         private readonly RabbitMqPublishChannelRentalFactory _rentalFactory = new RabbitMqPublishChannelRentalFactory();
 
+        // One shared monotonic clock for every recording channel this source hands out (receive + publish), so a
+        // test can witness the RELATIVE order of a publish-channel republish and a receive-channel ack across the
+        // two separate channels — the confirm-before-ack ordering (ADR-0001) is otherwise unobservable per-channel.
+        private readonly OperationSequencer _sequencer = new();
+
         // The stored consume-registration delegate, mirroring the production source. Re-run on every receive
         // channel (re)creation with the freshly-bumped epoch; returns the broker-assigned consumer tag the source
         // stores so it owns cancellation. CLEARED by StopReceivingAsync (terminal stop) so a late recovery
@@ -39,7 +44,7 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
 
         public InMemoryRabbitMqConnectionSource()
         {
-            ReceiveChannel = new RecordingChannel();
+            ReceiveChannel = new RecordingChannel(_sequencer);
         }
 
         // The CURRENT serialized receive channel handed to RunOnReceiveChannelAsync. Records ack/nack and
@@ -94,7 +99,7 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
                 return;
             }
 
-            ReceiveChannel = new RecordingChannel();
+            ReceiveChannel = new RecordingChannel(_sequencer);
             ReceiveChannels.Add(ReceiveChannel);
             Interlocked.Increment(ref _currentReceiveChannelEpoch);
 
@@ -120,7 +125,7 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
             // exactly as a real recreate would. When the cold channel already exists (epoch 0) it is reused in place.
             if (ReceiveChannel is null)
             {
-                ReceiveChannel = new RecordingChannel();
+                ReceiveChannel = new RecordingChannel(_sequencer);
                 Interlocked.Increment(ref _currentReceiveChannelEpoch);
             }
 
@@ -174,7 +179,7 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
         public Task<RabbitMqPublishChannelRental> AcquirePublishChannelAsync(CancellationToken cancellationToken)
         {
             AcquirePublishChannelCount++;
-            var channel = new RecordingChannel();
+            var channel = new RecordingChannel(_sequencer);
             PublishChannels.Add(channel);
             OnPublishChannelCreated?.Invoke(channel);
             return Task.FromResult(_rentalFactory.Create(channel));

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/RecordingChannel.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/RecordingChannel.cs
@@ -13,8 +13,32 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
     // member throws NotImplementedException: reaching one is a signal the production code took an untested
     // path, which a test should surface rather than silently accept. Reports IsOpen == false so a rental's
     // ReturnPublishChannel disposes (not re-pools) it, leaving its recordings intact for assertions.
+    // A shared monotonic clock across every RecordingChannel a single connection-source hands out. Publishes land
+    // on a pooled publish channel and acks/nacks on the receive channel, so a per-channel list cannot witness their
+    // RELATIVE order. INVARIANT: confirm-before-ack (ADR-0001) — the confirmed republish must be recorded BEFORE the
+    // original ack; tests assert republish.Seq < ack.Seq off this single source of truth.
+    internal sealed class OperationSequencer
+    {
+        private long _last;
+
+        public long Next() => Interlocked.Increment(ref _last);
+    }
+
     internal sealed class RecordingChannel : IChannel
     {
+        private readonly OperationSequencer _sequencer;
+
+        // Self-seeding overload for the sibling connection-source tests (WhenReplacingStaleConnection,
+        // WhenDisposing) that assert no cross-channel ordering: each gets its own fresh sequencer. The
+        // settlement tests instead go through InMemoryRabbitMqConnectionSource, which passes its one shared
+        // sequencer into every RecordingChannel so receive + publish channels share a single clock.
+        public RecordingChannel() : this(new OperationSequencer()) { }
+
+        public RecordingChannel(OperationSequencer sequencer)
+        {
+            _sequencer = sequencer ?? throw new ArgumentNullException(nameof(sequencer));
+        }
+
         public List<AckRecord> Acks { get; } = new List<AckRecord>();
         public List<NackRecord> Nacks { get; } = new List<NackRecord>();
         public List<PublishRecord> Publishes { get; } = new List<PublishRecord>();
@@ -31,13 +55,13 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
 
         public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple, CancellationToken cancellationToken = default)
         {
-            Acks.Add(new AckRecord(deliveryTag, multiple));
+            Acks.Add(new AckRecord(deliveryTag, multiple, _sequencer.Next()));
             return default;
         }
 
         public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue, CancellationToken cancellationToken = default)
         {
-            Nacks.Add(new NackRecord(deliveryTag, multiple, requeue));
+            Nacks.Add(new NackRecord(deliveryTag, multiple, requeue, _sequencer.Next()));
             return default;
         }
 
@@ -63,7 +87,8 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
                 basicProperties.IsContentEncodingPresent() ? basicProperties.ContentEncoding : null,
                 basicProperties.IsCorrelationIdPresent() ? basicProperties.CorrelationId : null,
                 basicProperties.Headers is null ? null : new Dictionary<string, object>(basicProperties.Headers),
-                body.ToArray()));
+                body.ToArray(),
+                _sequencer.Next()));
 
             if (PublishFault is not null)
             {
@@ -148,28 +173,34 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
 
     internal readonly struct AckRecord
     {
-        public AckRecord(ulong deliveryTag, bool multiple)
+        public AckRecord(ulong deliveryTag, bool multiple, long seq)
         {
             DeliveryTag = deliveryTag;
             Multiple = multiple;
+            Seq = seq;
         }
 
         public ulong DeliveryTag { get; }
         public bool Multiple { get; }
+        // The shared-sequencer tick at which this ack was recorded, so a test can assert republish.Seq < ack.Seq.
+        public long Seq { get; }
     }
 
     internal readonly struct NackRecord
     {
-        public NackRecord(ulong deliveryTag, bool multiple, bool requeue)
+        public NackRecord(ulong deliveryTag, bool multiple, bool requeue, long seq)
         {
             DeliveryTag = deliveryTag;
             Multiple = multiple;
             Requeue = requeue;
+            Seq = seq;
         }
 
         public ulong DeliveryTag { get; }
         public bool Multiple { get; }
         public bool Requeue { get; }
+        // The shared-sequencer tick at which this nack was recorded, so a test can assert settlement ordering.
+        public long Seq { get; }
     }
 
     internal sealed class PublishRecord
@@ -187,7 +218,8 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
                              string contentEncoding,
                              string correlationId,
                              IDictionary<string, object> headers,
-                             byte[] body)
+                             byte[] body,
+                             long seq)
         {
             Exchange = exchange;
             RoutingKey = routingKey;
@@ -203,6 +235,7 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
             CorrelationId = correlationId;
             Headers = headers;
             Body = body;
+            Seq = seq;
         }
 
         public string Exchange { get; }
@@ -224,5 +257,7 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving
         public string CorrelationId { get; }
         public IDictionary<string, object> Headers { get; }
         public byte[] Body { get; }
+        // The shared-sequencer tick at which this publish was recorded, so a test can assert republish.Seq < ack.Seq.
+        public long Seq { get; }
     }
 }

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenAcquiringPublishChannel.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenAcquiringPublishChannel.cs
@@ -29,19 +29,29 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectio
 
         // Builds a fake open connection that hands back a fresh open publish channel from a supplied queue per
         // CreateChannelAsync call, counting the creations so the reuse branch (no new create on the second acquire)
-        // is assertable.
+        // is assertable, and CAPTURING the CreateChannelOptions each publish-channel creation passed so a test can
+        // assert publisher confirmations + confirmation tracking were enabled (the confirm-before-ack safety
+        // invariant — a regression dropping them must FAIL the suite, not pass it).
         private static RabbitMqConnectionSource NewSourceServingPublishChannels(Queue<OpenPublishChannel> channelsToServe, out int[] createCount)
+            => NewSourceServingPublishChannels(channelsToServe, out createCount, out _);
+
+        private static RabbitMqConnectionSource NewSourceServingPublishChannels(Queue<OpenPublishChannel> channelsToServe,
+                                                                                out int[] createCount,
+                                                                                out List<CreateChannelOptions> capturedOptions)
         {
             var creations = new int[1];
             createCount = creations;
+            var captured = new List<CreateChannelOptions>();
+            capturedOptions = captured;
             var source = new RabbitMqConnectionSource(new RabbitMqOptions(hostName: "in-memory"));
             var connectionMock = new Mock<IConnection>();
             connectionMock.SetupGet(c => c.IsOpen).Returns(true);
             connectionMock
                 .Setup(c => c.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()))
-                .Returns<CreateChannelOptions, CancellationToken>((_, _) =>
+                .Returns<CreateChannelOptions, CancellationToken>((options, _) =>
                 {
                     creations[0]++;
+                    captured.Add(options);
                     return Task.FromResult<IChannel>(channelsToServe.Dequeue());
                 });
             SetCreateConnectionHook(source, _ => Task.FromResult(connectionMock.Object));
@@ -93,6 +103,27 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectio
 
             createCount[0].Should().Be(1, "the second acquire must TryTake the re-pooled channel, not create a fresh one");
             secondRental.Channel.Should().BeSameAs(first, "the second acquire reuses the same re-pooled channel");
+
+            await source.DisposeAsync();
+        }
+
+        // The publish channel MUST be created with publisher confirmations AND confirmation tracking enabled: this
+        // is the adapter's confirm-before-ack/publish safety invariant (RabbitMQ.Client 7.2.1 faults an unroutable
+        // mandatory publish via confirm-tracking, so an unroutable publish surfaces as a Dispatch failure rather
+        // than silent loss). Asserting the captured CreateChannelOptions makes a regression in
+        // CreatePublishChannelAsync that dropped either flag FAIL this suite instead of passing it.
+        [Fact]
+        public async Task MustCreatePublishChannelWithPublisherConfirmationsEnabled()
+        {
+            var channels = new Queue<OpenPublishChannel>(new[] { new OpenPublishChannel() });
+            var source = NewSourceServingPublishChannels(channels, out _, out var capturedOptions);
+
+            await using var rental = await source.AcquirePublishChannelAsync(CancellationToken.None);
+
+            var options = capturedOptions.Should().ContainSingle("the acquire creates exactly one publish channel").Subject;
+            options.Should().NotBeNull("the publish channel must be created with explicit confirm options, not the default null");
+            options.PublisherConfirmationsEnabled.Should().BeTrue("publisher confirmations must be enabled (confirm-before-ack safety)");
+            options.PublisherConfirmationTrackingEnabled.Should().BeTrue("publisher confirmation tracking must be enabled so an unroutable mandatory publish faults rather than silently dropping");
 
             await source.DisposeAsync();
         }

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenAcquiringPublishChannel.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenAcquiringPublishChannel.cs
@@ -1,0 +1,189 @@
+using Chatter.MessageBrokers.RabbitMQ.Configuration;
+using Chatter.MessageBrokers.RabbitMQ.Receiving;
+using FluentAssertions;
+using Moq;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectionSource
+{
+    // Pins the PRODUCTION RabbitMqConnectionSource publish-channel acquire/return lifecycle on a LIVE source:
+    // AcquirePublishChannelAsync creates a publish channel (with confirms) off the connection and hands back a live
+    // RabbitMqPublishChannelRental; disposing the rental RE-POOLS the channel when IsOpen == true; a second acquire
+    // TryTakes the pooled channel (the reuse branch) rather than creating a fresh one. Also pins the null-arg guards
+    // on RunOnReceiveChannelAsync / StartReceivingAsync. Drives the source via the connection-create reflection seam
+    // + an open publish-channel double, broker-free.
+    public class WhenAcquiringPublishChannel : Testing.Core.Context
+    {
+        private static readonly FieldInfo CreateConnectionHookField = typeof(RabbitMqConnectionSource)
+            .GetField("_createConnectionForTest", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private static void SetCreateConnectionHook(RabbitMqConnectionSource source, Func<CancellationToken, Task<IConnection>> hook)
+            => CreateConnectionHookField.SetValue(source, hook);
+
+        // Builds a fake open connection that hands back a fresh open publish channel from a supplied queue per
+        // CreateChannelAsync call, counting the creations so the reuse branch (no new create on the second acquire)
+        // is assertable.
+        private static RabbitMqConnectionSource NewSourceServingPublishChannels(Queue<OpenPublishChannel> channelsToServe, out int[] createCount)
+        {
+            var creations = new int[1];
+            createCount = creations;
+            var source = new RabbitMqConnectionSource(new RabbitMqOptions(hostName: "in-memory"));
+            var connectionMock = new Mock<IConnection>();
+            connectionMock.SetupGet(c => c.IsOpen).Returns(true);
+            connectionMock
+                .Setup(c => c.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()))
+                .Returns<CreateChannelOptions, CancellationToken>((_, _) =>
+                {
+                    creations[0]++;
+                    return Task.FromResult<IChannel>(channelsToServe.Dequeue());
+                });
+            SetCreateConnectionHook(source, _ => Task.FromResult(connectionMock.Object));
+            return source;
+        }
+
+        [Fact]
+        public async Task MustReturnLiveRentalWithChannelOnAcquire()
+        {
+            var channels = new Queue<OpenPublishChannel>(new[] { new OpenPublishChannel() });
+            var source = NewSourceServingPublishChannels(channels, out _);
+
+            await using var rental = await source.AcquirePublishChannelAsync(CancellationToken.None);
+
+            rental.Should().NotBeNull();
+            rental.Channel.Should().NotBeNull("a live acquire hands back a rental carrying the rented channel");
+
+            await source.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task MustRePoolChannelWhenRentalDisposedAndChannelOpen()
+        {
+            var channel = new OpenPublishChannel();
+            var channels = new Queue<OpenPublishChannel>(new[] { channel });
+            var source = NewSourceServingPublishChannels(channels, out _);
+
+            var rental = await source.AcquirePublishChannelAsync(CancellationToken.None);
+            await rental.DisposeAsync();
+
+            channel.Disposed.Should().BeFalse("an open channel returned by a rental is re-pooled, not disposed");
+
+            await source.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task MustReusePooledChannelOnSecondAcquire()
+        {
+            var first = new OpenPublishChannel();
+            // Only ONE channel is ever served: if the second acquire created a fresh one the queue would underflow,
+            // proving the second acquire must reuse the re-pooled channel.
+            var channels = new Queue<OpenPublishChannel>(new[] { first });
+            var source = NewSourceServingPublishChannels(channels, out var createCount);
+
+            var firstRental = await source.AcquirePublishChannelAsync(CancellationToken.None);
+            await firstRental.DisposeAsync();
+
+            await using var secondRental = await source.AcquirePublishChannelAsync(CancellationToken.None);
+
+            createCount[0].Should().Be(1, "the second acquire must TryTake the re-pooled channel, not create a fresh one");
+            secondRental.Channel.Should().BeSameAs(first, "the second acquire reuses the same re-pooled channel");
+
+            await source.DisposeAsync();
+        }
+
+        // --- null-arg guards (the early ArgumentNullException before any gate acquisition) ---
+
+        [Fact]
+        public async Task MustThrowOnNullRunOnReceiveChannelOperation()
+        {
+            var source = new RabbitMqConnectionSource(new RabbitMqOptions(hostName: "in-memory"));
+
+            Func<Task> act = async () => await source.RunOnReceiveChannelAsync<object>(null, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentNullException>();
+
+            await source.DisposeAsync();
+        }
+
+        [Fact]
+        public async Task MustThrowOnNullStartReceivingRegistration()
+        {
+            var source = new RabbitMqConnectionSource(new RabbitMqOptions(hostName: "in-memory"));
+
+            Func<Task> act = async () => await source.StartReceivingAsync(null, CancellationToken.None);
+
+            await act.Should().ThrowAsync<ArgumentNullException>();
+
+            await source.DisposeAsync();
+        }
+
+        // An open publish channel double: reports IsOpen == true so ReturnPublishChannel RE-POOLS it (unlike
+        // RecordingChannel, which is hardwired IsOpen == false and would always be disposed on return). Records its
+        // disposal so a re-pool test can assert it was NOT disposed. Every untested member throws so an untested path
+        // surfaces.
+        private sealed class OpenPublishChannel : IChannel
+        {
+            public bool Disposed { get; private set; }
+
+            public void Dispose() => Disposed = true;
+            public ValueTask DisposeAsync()
+            {
+                Disposed = true;
+                return default;
+            }
+
+            public bool IsOpen => true;
+            public bool IsClosed => false;
+
+            // --- Unused IChannel surface: a production path reaching any of these is untested by design ---------
+            public int ChannelNumber => throw new NotImplementedException();
+            public ShutdownEventArgs CloseReason => throw new NotImplementedException();
+            public IAsyncBasicConsumer DefaultConsumer { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public string CurrentQueue => throw new NotImplementedException();
+            public TimeSpan ContinuationTimeout { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public event AsyncEventHandler<BasicAckEventArgs> BasicAcksAsync { add { } remove { } }
+            public event AsyncEventHandler<BasicNackEventArgs> BasicNacksAsync { add { } remove { } }
+            public event AsyncEventHandler<BasicReturnEventArgs> BasicReturnAsync { add { } remove { } }
+            public event AsyncEventHandler<CallbackExceptionEventArgs> CallbackExceptionAsync { add { } remove { } }
+            public event AsyncEventHandler<FlowControlEventArgs> FlowControlAsync { add { } remove { } }
+            public event AsyncEventHandler<ShutdownEventArgs> ChannelShutdownAsync { add { } remove { } }
+
+            public Task BasicQosAsync(uint prefetchSize, ushort prefetchCount, bool global, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<string> BasicConsumeAsync(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IDictionary<string, object> arguments, IAsyncBasicConsumer consumer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task BasicCancelAsync(string consumerTag, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken cancellationToken = default) where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();
+            public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken cancellationToken = default) where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();
+            public ValueTask<ulong> GetNextPublishSequenceNumberAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<BasicGetResult> BasicGetAsync(string queue, bool autoAck, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicRejectAsync(ulong deliveryTag, bool requeue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task CloseAsync(ushort replyCode, string replyText, bool abort, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task CloseAsync(ShutdownEventArgs reason, bool abort) => throw new NotImplementedException();
+            public Task CloseAsync(ShutdownEventArgs reason, bool abort, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task ExchangeDeclareAsync(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments = null, bool passive = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeDeclarePassiveAsync(string exchange, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeBindAsync(string destination, string source, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeUnbindAsync(string destination, string source, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<QueueDeclareOk> QueueDeclareAsync(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments = null, bool passive = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<QueueDeclareOk> QueueDeclarePassiveAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> QueueDeleteAsync(string queue, bool ifUnused, bool ifEmpty, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> QueuePurgeAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task QueueBindAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task QueueUnbindAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> MessageCountAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> ConsumerCountAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxCommitAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxRollbackAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxSelectAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenReplacingStaleConnection.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenReplacingStaleConnection.cs
@@ -1,0 +1,109 @@
+using Chatter.MessageBrokers.RabbitMQ.Configuration;
+using Chatter.MessageBrokers.RabbitMQ.Receiving;
+using FluentAssertions;
+using Moq;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectionSource
+{
+    // Pins EnsureConnectionAsync's STALE-REPLACE arm: an existing _connection that is NOT open (IsOpen false) is
+    // unsubscribed from RecoverySucceededAsync, DisposeAsync'd, and replaced with a freshly-created, subscribed
+    // connection. This is distinct from the cold-start arm (_connection == null, no dispose) and the open-fast-path
+    // (IsOpen true, returned without dispose/replace). Drives the production source through the SetConnection and
+    // SetCreateConnectionHook reflection seams from WhenDisposing, broker-free.
+    public class WhenReplacingStaleConnection : Testing.Core.Context
+    {
+        private static readonly FieldInfo ConnectionField = typeof(RabbitMqConnectionSource)
+            .GetField("_connection", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo CreateConnectionHookField = typeof(RabbitMqConnectionSource)
+            .GetField("_createConnectionForTest", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private static IConnection Connection(RabbitMqConnectionSource source)
+            => (IConnection)ConnectionField.GetValue(source);
+
+        private static void SetConnection(RabbitMqConnectionSource source, IConnection connection)
+            => ConnectionField.SetValue(source, connection);
+
+        private static void SetCreateConnectionHook(RabbitMqConnectionSource source, Func<CancellationToken, Task<IConnection>> hook)
+            => CreateConnectionHookField.SetValue(source, hook);
+
+        // Builds a connection mock that hands back a fresh RecordingChannel for the receive-channel recreate, so
+        // StartReceivingAsync's registration (QoS + consume) succeeds on the replacement connection.
+        private static Mock<IConnection> NewOpenConnectionServingRecordingChannels()
+        {
+            var connectionMock = new Mock<IConnection>();
+            connectionMock.SetupGet(c => c.IsOpen).Returns(true);
+            connectionMock
+                .Setup(c => c.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()))
+                .Returns<CreateChannelOptions, CancellationToken>((_, _) => Task.FromResult<IChannel>(new RecordingChannel()));
+            return connectionMock;
+        }
+
+        [Fact]
+        public async Task MustUnsubscribeDisposeAndReplaceStaleConnection()
+        {
+            var source = new RabbitMqConnectionSource(new RabbitMqOptions(hostName: "in-memory"));
+
+            // Seed a STALE connection: present but reporting IsOpen == false, so EnsureConnectionAsync takes the
+            // replace arm (NOT the open-fast-path and NOT the cold-start null arm).
+            var staleConnection = new Mock<IConnection>();
+            staleConnection.SetupGet(c => c.IsOpen).Returns(false);
+            SetConnection(source, staleConnection.Object);
+
+            var freshConnection = NewOpenConnectionServingRecordingChannels();
+            SetCreateConnectionHook(source, _ => Task.FromResult(freshConnection.Object));
+
+            // StartReceivingAsync -> EnsureReceiveChannelAsync -> RecreateReceiveChannelAsync -> EnsureConnectionAsync
+            // observes the stale (not-open) connection and replaces it.
+            await source.StartReceivingAsync(
+                (channel, _, ct) => Task.FromResult("consumer-tag"), CancellationToken.None);
+
+            // The stale connection was unsubscribed from recovery BEFORE being disposed, then disposed.
+            staleConnection.VerifyRemove(c => c.RecoverySucceededAsync -= It.IsAny<AsyncEventHandler<AsyncEventArgs>>(), Times.Once,
+                "the stale connection must be unsubscribed from recovery before disposal");
+            staleConnection.Verify(c => c.DisposeAsync(), Times.Once,
+                "the stale (not-open) connection must be disposed before being replaced");
+
+            // The fresh connection became the committed connection and was subscribed to recovery.
+            Connection(source).Should().BeSameAs(freshConnection.Object, "the fresh connection replaces the stale one");
+            freshConnection.VerifyAdd(c => c.RecoverySucceededAsync += It.IsAny<AsyncEventHandler<AsyncEventArgs>>(), Times.Once,
+                "the replacement connection must subscribe the recovery handler");
+
+            await source.DisposeAsync();
+        }
+
+        // Contrast arm: an OPEN existing connection is returned by the fast path WITHOUT being unsubscribed,
+        // disposed, or replaced — proving the replace arm is gated on IsOpen == false, not taken unconditionally.
+        [Fact]
+        public async Task MustNotDisposeOrReplaceOpenConnection()
+        {
+            var source = new RabbitMqConnectionSource(new RabbitMqOptions(hostName: "in-memory"));
+
+            var openConnection = NewOpenConnectionServingRecordingChannels();
+            SetConnection(source, openConnection.Object);
+
+            // The create hook must NOT be invoked: the open fast path returns the existing connection.
+            var hookInvoked = false;
+            SetCreateConnectionHook(source, _ =>
+            {
+                hookInvoked = true;
+                return Task.FromResult(openConnection.Object);
+            });
+
+            await source.StartReceivingAsync(
+                (channel, _, ct) => Task.FromResult("consumer-tag"), CancellationToken.None);
+
+            hookInvoked.Should().BeFalse("an open existing connection must be returned by the fast path, not recreated");
+            openConnection.Verify(c => c.DisposeAsync(), Times.Never, "an open connection must not be disposed by EnsureConnectionAsync");
+            Connection(source).Should().BeSameAs(openConnection.Object);
+
+            await source.DisposeAsync();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenStopping.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenStopping.cs
@@ -1,0 +1,237 @@
+using Chatter.MessageBrokers.RabbitMQ.Configuration;
+using Chatter.MessageBrokers.RabbitMQ.Receiving;
+using Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.TestSupport;
+using FluentAssertions;
+using Moq;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectionSource
+{
+    // Pins the PRODUCTION RabbitMqConnectionSource.StopReceivingAsync surgical terminal teardown: under the receive
+    // gate it cancels the registered consumer on the current receive channel, disposes+nulls the receive channel,
+    // and CLEARS _registerConsumer/_consumerTag — while leaving the connection and the publish pool intact. Drives
+    // the source via the connection-create reflection seam + IConnection/IChannel doubles (the same pattern as
+    // WhenRecreatingReceiveChannelOnRecovery / WhenDisposing), broker-free.
+    public class WhenStopping : Testing.Core.Context
+    {
+        private static readonly FieldInfo CreateConnectionHookField = typeof(RabbitMqConnectionSource)
+            .GetField("_createConnectionForTest", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo ReceiveChannelField = typeof(RabbitMqConnectionSource)
+            .GetField("_receiveChannel", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo RegisterConsumerField = typeof(RabbitMqConnectionSource)
+            .GetField("_registerConsumer", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo ConsumerTagField = typeof(RabbitMqConnectionSource)
+            .GetField("_consumerTag", BindingFlags.Instance | BindingFlags.NonPublic);
+        private static readonly FieldInfo ConnectionField = typeof(RabbitMqConnectionSource)
+            .GetField("_connection", BindingFlags.Instance | BindingFlags.NonPublic);
+
+        private static void SetCreateConnectionHook(RabbitMqConnectionSource source, Func<CancellationToken, Task<IConnection>> hook)
+            => CreateConnectionHookField.SetValue(source, hook);
+
+        private static IChannel ReceiveChannel(RabbitMqConnectionSource source)
+            => (IChannel)ReceiveChannelField.GetValue(source);
+
+        private static object RegisterConsumer(RabbitMqConnectionSource source)
+            => RegisterConsumerField.GetValue(source);
+
+        private static string ConsumerTag(RabbitMqConnectionSource source)
+            => (string)ConsumerTagField.GetValue(source);
+
+        private static IConnection Connection(RabbitMqConnectionSource source)
+            => (IConnection)ConnectionField.GetValue(source);
+
+        // Wires a source to a fake open connection that hands back a single cancellable receive channel, then runs a
+        // cold-start StartReceivingAsync (storing the registration delegate + consumer tag) so the source is in the
+        // "receiving" state a stop tears down. Returns the receive channel the source committed.
+        private static async Task<RabbitMqConnectionSource> NewReceivingSourceAsync(CancellableReceiveChannel receiveChannel,
+                                                                                    IConnection connection = null)
+        {
+            var source = new RabbitMqConnectionSource(new RabbitMqOptions(hostName: "in-memory"));
+            var connectionMock = connection;
+            if (connectionMock is null)
+            {
+                var mock = new Mock<IConnection>();
+                mock.SetupGet(c => c.IsOpen).Returns(true);
+                mock.Setup(c => c.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()))
+                    .Returns<CreateChannelOptions, CancellationToken>((_, _) => Task.FromResult<IChannel>(receiveChannel));
+                connectionMock = mock.Object;
+            }
+            SetCreateConnectionHook(source, _ => Task.FromResult(connectionMock));
+
+            await source.StartReceivingAsync(
+                (channel, _, ct) => Task.FromResult("the-consumer-tag"), CancellationToken.None);
+
+            return source;
+        }
+
+        [Fact]
+        public async Task MustCancelConsumerDisposeChannelAndClearRegistrationOnStop()
+        {
+            var receiveChannel = new CancellableReceiveChannel();
+            var source = await NewReceivingSourceAsync(receiveChannel);
+
+            await source.StopReceivingAsync(CancellationToken.None);
+
+            receiveChannel.CancelledConsumerTags.Should().ContainSingle().Which.Should().Be("the-consumer-tag",
+                "stop must cancel the stored consumer on the current receive channel");
+            receiveChannel.Disposed.Should().BeTrue("stop must dispose the receive channel");
+            ReceiveChannel(source).Should().BeNull("stop must null the receive channel");
+            RegisterConsumer(source).Should().BeNull("stop must clear the registration delegate (terminal)");
+            ConsumerTag(source).Should().BeNull("stop must clear the consumer tag (terminal)");
+        }
+
+        // The connection and the publish pool are deliberately left intact by a surgical stop: the source is a
+        // process singleton shared with the sender, so the publish path must keep working after the receiver stops.
+        [Fact]
+        public async Task MustLeaveConnectionAndPublishPoolIntactOnStop()
+        {
+            var receiveChannel = new CancellableReceiveChannel();
+            var connectionMock = new Mock<IConnection>();
+            connectionMock.SetupGet(c => c.IsOpen).Returns(true);
+            connectionMock.Setup(c => c.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()))
+                .Returns<CreateChannelOptions, CancellationToken>((_, _) => Task.FromResult<IChannel>(receiveChannel));
+            var source = await NewReceivingSourceAsync(receiveChannel, connectionMock.Object);
+
+            await source.StopReceivingAsync(CancellationToken.None);
+
+            connectionMock.Verify(c => c.DisposeAsync(), Times.Never, "stop must not dispose the shared connection");
+            Connection(source).Should().BeSameAs(connectionMock.Object, "stop leaves the connection intact for the sender");
+
+            await source.DisposeAsync();
+        }
+
+        // The BasicCancelAsync try/catch swallows AlreadyClosed/ObjectDisposed: a channel whose cancel throws
+        // AlreadyClosedException (the consumer is implicitly cancelled when the channel is already gone) must NOT
+        // fault the stop — the channel is still disposed and the registration still cleared.
+        [Fact]
+        public async Task MustSwallowAlreadyClosedFromBasicCancelOnStop()
+        {
+            var receiveChannel = new CancellableReceiveChannel(cancelFault: RabbitMqExceptionFactory.AlreadyClosed());
+            var source = await NewReceivingSourceAsync(receiveChannel);
+
+            Func<Task> stop = async () => await source.StopReceivingAsync(CancellationToken.None);
+
+            await stop.Should().NotThrowAsync("an AlreadyClosedException from BasicCancelAsync is swallowed as a no-op");
+            receiveChannel.Disposed.Should().BeTrue("the channel is still disposed after the swallowed cancel fault");
+            RegisterConsumer(source).Should().BeNull("the registration is still cleared after the swallowed cancel fault");
+        }
+
+        // Idempotent double-stop: the second stop finds a null channel + null registration and no-ops (no second
+        // cancel, no throw).
+        [Fact]
+        public async Task MustNoOpOnSecondStop()
+        {
+            var receiveChannel = new CancellableReceiveChannel();
+            var source = await NewReceivingSourceAsync(receiveChannel);
+
+            await source.StopReceivingAsync(CancellationToken.None);
+            Func<Task> stopAgain = async () => await source.StopReceivingAsync(CancellationToken.None);
+
+            await stopAgain.Should().NotThrowAsync("a double-stop finds a null channel + null registration and no-ops");
+            receiveChannel.CancelledConsumerTags.Should().ContainSingle("the second stop must not cancel again");
+        }
+
+        // A stop AFTER DisposeAsync is a clean no-op: RunReceiveGatedAsync throws ObjectDisposedException on the
+        // torn source, which StopReceivingAsync swallows (a disposed source has nothing left to stop).
+        [Fact]
+        public async Task MustNoOpOnStopAfterDispose()
+        {
+            var receiveChannel = new CancellableReceiveChannel();
+            var source = await NewReceivingSourceAsync(receiveChannel);
+
+            await source.DisposeAsync();
+
+            Func<Task> stopAfterDispose = async () => await source.StopReceivingAsync(CancellationToken.None);
+
+            await stopAfterDispose.Should().NotThrowAsync("a terminal stop on an already-disposed source is a clean no-op");
+        }
+
+        // A receive IChannel that records the cancelled consumer tag and its disposal, and can optionally fault its
+        // BasicCancelAsync to drive the AlreadyClosed/ObjectDisposed swallow arm. Reports IsOpen so the source's
+        // EnsureReceiveChannelAsync commits it. Every untested member throws so an untested path surfaces.
+        private sealed class CancellableReceiveChannel : IChannel
+        {
+            private readonly Exception _cancelFault;
+
+            public CancellableReceiveChannel(Exception cancelFault = null)
+            {
+                _cancelFault = cancelFault;
+            }
+
+            public List<string> CancelledConsumerTags { get; } = new List<string>();
+            public bool Disposed { get; private set; }
+
+            public Task BasicQosAsync(uint prefetchSize, ushort prefetchCount, bool global, CancellationToken cancellationToken = default)
+                => Task.CompletedTask;
+
+            public Task BasicCancelAsync(string consumerTag, bool noWait = false, CancellationToken cancellationToken = default)
+            {
+                CancelledConsumerTags.Add(consumerTag);
+                if (_cancelFault is not null)
+                {
+                    throw _cancelFault;
+                }
+                return Task.CompletedTask;
+            }
+
+            public void Dispose() => Disposed = true;
+            public ValueTask DisposeAsync()
+            {
+                Disposed = true;
+                return default;
+            }
+
+            public bool IsOpen => true;
+            public bool IsClosed => false;
+
+            // --- Unused IChannel surface: a production path reaching any of these is untested by design ---------
+            public int ChannelNumber => throw new NotImplementedException();
+            public ShutdownEventArgs CloseReason => throw new NotImplementedException();
+            public IAsyncBasicConsumer DefaultConsumer { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public string CurrentQueue => throw new NotImplementedException();
+            public TimeSpan ContinuationTimeout { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public event AsyncEventHandler<BasicAckEventArgs> BasicAcksAsync { add { } remove { } }
+            public event AsyncEventHandler<BasicNackEventArgs> BasicNacksAsync { add { } remove { } }
+            public event AsyncEventHandler<BasicReturnEventArgs> BasicReturnAsync { add { } remove { } }
+            public event AsyncEventHandler<CallbackExceptionEventArgs> CallbackExceptionAsync { add { } remove { } }
+            public event AsyncEventHandler<FlowControlEventArgs> FlowControlAsync { add { } remove { } }
+            public event AsyncEventHandler<ShutdownEventArgs> ChannelShutdownAsync { add { } remove { } }
+
+            public Task<string> BasicConsumeAsync(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IDictionary<string, object> arguments, IAsyncBasicConsumer consumer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken cancellationToken = default) where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();
+            public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken cancellationToken = default) where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();
+            public ValueTask<ulong> GetNextPublishSequenceNumberAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<BasicGetResult> BasicGetAsync(string queue, bool autoAck, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicRejectAsync(ulong deliveryTag, bool requeue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task CloseAsync(ushort replyCode, string replyText, bool abort, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task CloseAsync(ShutdownEventArgs reason, bool abort) => throw new NotImplementedException();
+            public Task CloseAsync(ShutdownEventArgs reason, bool abort, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task ExchangeDeclareAsync(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments = null, bool passive = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeDeclarePassiveAsync(string exchange, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeBindAsync(string destination, string source, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeUnbindAsync(string destination, string source, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<QueueDeclareOk> QueueDeclareAsync(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments = null, bool passive = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<QueueDeclareOk> QueueDeclarePassiveAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> QueueDeleteAsync(string queue, bool ifUnused, bool ifEmpty, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> QueuePurgeAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task QueueBindAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task QueueUnbindAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> MessageCountAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> ConsumerCountAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxCommitAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxRollbackAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxSelectAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenStopping.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenStopping.cs
@@ -7,6 +7,7 @@ using RabbitMQ.Client;
 using RabbitMQ.Client.Events;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
@@ -101,10 +102,17 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectio
             // the post-stop acquire (proving the publish path is exercised, not the already-disposed receive channel).
             var publishChannel = new OpenStopPublishChannel();
             var served = new Queue<IChannel>(new IChannel[] { receiveChannel, publishChannel });
+            // Capture the CreateChannelOptions per creation so the post-stop publish channel can be asserted to carry
+            // the confirm-before-ack safety flags (not just to exist).
+            var capturedOptions = new List<CreateChannelOptions>();
             var connectionMock = new Mock<IConnection>();
             connectionMock.SetupGet(c => c.IsOpen).Returns(true);
             connectionMock.Setup(c => c.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()))
-                .Returns<CreateChannelOptions, CancellationToken>((_, _) => Task.FromResult(served.Dequeue()));
+                .Returns<CreateChannelOptions, CancellationToken>((options, _) =>
+                {
+                    capturedOptions.Add(options);
+                    return Task.FromResult(served.Dequeue());
+                });
             var source = await NewReceivingSourceAsync(receiveChannel, connectionMock.Object);
 
             await source.StopReceivingAsync(CancellationToken.None);
@@ -119,6 +127,14 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectio
                 rental.Channel.Should().BeSameAs(publishChannel,
                     "a post-stop acquire hands back a live rental carrying the freshly-created publish channel");
             }
+
+            // The post-stop publish channel is still created in confirm mode: the receive cold-start created the
+            // receive channel (options null), and the post-stop acquire created the publish channel with confirms.
+            var publishOptions = capturedOptions.Should().HaveCount(2,
+                "one create for the receive channel cold-start, one for the post-stop publish acquire").And.Subject.Last();
+            publishOptions.Should().NotBeNull("the post-stop publish channel must carry explicit confirm options");
+            publishOptions.PublisherConfirmationsEnabled.Should().BeTrue("a post-stop publish channel must still enable publisher confirmations");
+            publishOptions.PublisherConfirmationTrackingEnabled.Should().BeTrue("a post-stop publish channel must still enable confirmation tracking");
 
             await source.DisposeAsync();
         }

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenStopping.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqConnectionSource/WhenStopping.cs
@@ -89,20 +89,36 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectio
 
         // The connection and the publish pool are deliberately left intact by a surgical stop: the source is a
         // process singleton shared with the sender, so the publish path must keep working after the receiver stops.
+        // This asserts sender-OBSERVABLE liveness, not just retained field state: after stop the real publish
+        // entrypoint (AcquirePublishChannelAsync) must still hand back a live rental carrying a usable channel. A
+        // regression that tore the lifecycle down on stop, or rejected later acquires, would leave _connection
+        // assigned and the connection undisposed yet FAIL this acquire — which retained-state assertions alone miss.
         [Fact]
         public async Task MustLeaveConnectionAndPublishPoolIntactOnStop()
         {
             var receiveChannel = new CancellableReceiveChannel();
+            // The connection serves the receive channel for the cold-start, then a DISTINCT open publish channel for
+            // the post-stop acquire (proving the publish path is exercised, not the already-disposed receive channel).
+            var publishChannel = new OpenStopPublishChannel();
+            var served = new Queue<IChannel>(new IChannel[] { receiveChannel, publishChannel });
             var connectionMock = new Mock<IConnection>();
             connectionMock.SetupGet(c => c.IsOpen).Returns(true);
             connectionMock.Setup(c => c.CreateChannelAsync(It.IsAny<CreateChannelOptions>(), It.IsAny<CancellationToken>()))
-                .Returns<CreateChannelOptions, CancellationToken>((_, _) => Task.FromResult<IChannel>(receiveChannel));
+                .Returns<CreateChannelOptions, CancellationToken>((_, _) => Task.FromResult(served.Dequeue()));
             var source = await NewReceivingSourceAsync(receiveChannel, connectionMock.Object);
 
             await source.StopReceivingAsync(CancellationToken.None);
 
             connectionMock.Verify(c => c.DisposeAsync(), Times.Never, "stop must not dispose the shared connection");
             Connection(source).Should().BeSameAs(connectionMock.Object, "stop leaves the connection intact for the sender");
+
+            // Sender-observable proof: the publish pool is still usable after the receiver stopped.
+            await using (var rental = await source.AcquirePublishChannelAsync(CancellationToken.None))
+            {
+                rental.Should().NotBeNull("the publish path must keep serving rentals after the receiver stops");
+                rental.Channel.Should().BeSameAs(publishChannel,
+                    "a post-stop acquire hands back a live rental carrying the freshly-created publish channel");
+            }
 
             await source.DisposeAsync();
         }
@@ -206,6 +222,68 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqConnectio
             public event AsyncEventHandler<ShutdownEventArgs> ChannelShutdownAsync { add { } remove { } }
 
             public Task<string> BasicConsumeAsync(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IDictionary<string, object> arguments, IAsyncBasicConsumer consumer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken cancellationToken = default) where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();
+            public ValueTask BasicPublishAsync<TProperties>(CachedString exchange, CachedString routingKey, bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken cancellationToken = default) where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();
+            public ValueTask<ulong> GetNextPublishSequenceNumberAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<BasicGetResult> BasicGetAsync(string queue, bool autoAck, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public ValueTask BasicRejectAsync(ulong deliveryTag, bool requeue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task CloseAsync(ushort replyCode, string replyText, bool abort, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task CloseAsync(ShutdownEventArgs reason, bool abort) => throw new NotImplementedException();
+            public Task CloseAsync(ShutdownEventArgs reason, bool abort, CancellationToken cancellationToken) => throw new NotImplementedException();
+            public Task ExchangeDeclareAsync(string exchange, string type, bool durable, bool autoDelete, IDictionary<string, object> arguments = null, bool passive = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeDeclarePassiveAsync(string exchange, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeDeleteAsync(string exchange, bool ifUnused = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeBindAsync(string destination, string source, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task ExchangeUnbindAsync(string destination, string source, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<QueueDeclareOk> QueueDeclareAsync(string queue, bool durable, bool exclusive, bool autoDelete, IDictionary<string, object> arguments = null, bool passive = false, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<QueueDeclareOk> QueueDeclarePassiveAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> QueueDeleteAsync(string queue, bool ifUnused, bool ifEmpty, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> QueuePurgeAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task QueueBindAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task QueueUnbindAsync(string queue, string exchange, string routingKey, IDictionary<string, object> arguments = null, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> MessageCountAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<uint> ConsumerCountAsync(string queue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxCommitAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxRollbackAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task TxSelectAsync(CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        }
+
+        // An open publish-channel double for the post-stop acquire: reports IsOpen == true so the source commits it as
+        // a live rental (and re-pools rather than disposes it on return). DISTINCT from the receive channel so the
+        // post-stop publish path is genuinely exercised. Every untested member throws so an untested path surfaces.
+        private sealed class OpenStopPublishChannel : IChannel
+        {
+            public bool Disposed { get; private set; }
+
+            public void Dispose() => Disposed = true;
+            public ValueTask DisposeAsync()
+            {
+                Disposed = true;
+                return default;
+            }
+
+            public bool IsOpen => true;
+            public bool IsClosed => false;
+
+            // --- Unused IChannel surface: a production path reaching any of these is untested by design ---------
+            public int ChannelNumber => throw new NotImplementedException();
+            public ShutdownEventArgs CloseReason => throw new NotImplementedException();
+            public IAsyncBasicConsumer DefaultConsumer { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+            public string CurrentQueue => throw new NotImplementedException();
+            public TimeSpan ContinuationTimeout { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+            public event AsyncEventHandler<BasicAckEventArgs> BasicAcksAsync { add { } remove { } }
+            public event AsyncEventHandler<BasicNackEventArgs> BasicNacksAsync { add { } remove { } }
+            public event AsyncEventHandler<BasicReturnEventArgs> BasicReturnAsync { add { } remove { } }
+            public event AsyncEventHandler<CallbackExceptionEventArgs> CallbackExceptionAsync { add { } remove { } }
+            public event AsyncEventHandler<FlowControlEventArgs> FlowControlAsync { add { } remove { } }
+            public event AsyncEventHandler<ShutdownEventArgs> ChannelShutdownAsync { add { } remove { } }
+
+            public Task BasicQosAsync(uint prefetchSize, ushort prefetchCount, bool global, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task<string> BasicConsumeAsync(string queue, bool autoAck, string consumerTag, bool noLocal, bool exclusive, IDictionary<string, object> arguments, IAsyncBasicConsumer consumer, CancellationToken cancellationToken = default) => throw new NotImplementedException();
+            public Task BasicCancelAsync(string consumerTag, bool noWait = false, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public ValueTask BasicAckAsync(ulong deliveryTag, bool multiple, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public ValueTask BasicNackAsync(ulong deliveryTag, bool multiple, bool requeue, CancellationToken cancellationToken = default) => throw new NotImplementedException();
             public ValueTask BasicPublishAsync<TProperties>(string exchange, string routingKey, bool mandatory, TProperties basicProperties, ReadOnlyMemory<byte> body, CancellationToken cancellationToken = default) where TProperties : IReadOnlyBasicProperties, IAmqpHeader => throw new NotImplementedException();

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqReceiver/WhenReceivingMessage.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqReceiver/WhenReceivingMessage.cs
@@ -591,5 +591,88 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqReceiver
 
             context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts].Should().Be(int.MaxValue);
         }
+
+        // --- ReadHeaderAsLong numeric-type arms (the broker/client may surface the native delivery-count header as
+        // any of several CLR numeric types; ReadHeaderAsLong reads each tolerantly). long/int/byte[] are already
+        // covered above; these cover short/byte/uint/ushort, a non-byte[] string, and the unparseable default arm.
+        // All pushed VERBATIM (coerceStringHeadersToBytes:false) so the CLR type survives to the receiver rather
+        // than being longstr-coerced to a byte[]. ReceiveAttempts == priorDeliveries + 1, floored to 1.
+
+        [Fact]
+        public async Task MustReadQuorumNativeCountWhenShortTyped()
+        {
+            var harness = ReceiverHarness.Create(QueueType.Quorum);
+            var headers = new Dictionary<string, object> { [ReceiverHarness.NativeDeliveryCountHeader] = (short)3 };
+            await harness.PushVerbatimAsync(deliveryTag: 1, headers: headers);
+
+            var context = await harness.ReceiveAsync();
+
+            context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts].Should().Be(4);
+        }
+
+        [Fact]
+        public async Task MustReadQuorumNativeCountWhenByteTyped()
+        {
+            var harness = ReceiverHarness.Create(QueueType.Quorum);
+            var headers = new Dictionary<string, object> { [ReceiverHarness.NativeDeliveryCountHeader] = (byte)2 };
+            await harness.PushVerbatimAsync(deliveryTag: 1, headers: headers);
+
+            var context = await harness.ReceiveAsync();
+
+            context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts].Should().Be(3);
+        }
+
+        [Fact]
+        public async Task MustReadQuorumNativeCountWhenUIntTyped()
+        {
+            var harness = ReceiverHarness.Create(QueueType.Quorum);
+            var headers = new Dictionary<string, object> { [ReceiverHarness.NativeDeliveryCountHeader] = (uint)4 };
+            await harness.PushVerbatimAsync(deliveryTag: 1, headers: headers);
+
+            var context = await harness.ReceiveAsync();
+
+            context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts].Should().Be(5);
+        }
+
+        [Fact]
+        public async Task MustReadQuorumNativeCountWhenUShortTyped()
+        {
+            var harness = ReceiverHarness.Create(QueueType.Quorum);
+            var headers = new Dictionary<string, object> { [ReceiverHarness.NativeDeliveryCountHeader] = (ushort)6 };
+            await harness.PushVerbatimAsync(deliveryTag: 1, headers: headers);
+
+            var context = await harness.ReceiveAsync();
+
+            context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts].Should().Be(7);
+        }
+
+        // A non-byte[] string native count is parsed via the string arm (the byte[] longstr arm is bypassed because
+        // the value is pushed verbatim as a CLR string).
+        [Fact]
+        public async Task MustReadQuorumNativeCountWhenNonByteArrayStringTyped()
+        {
+            var harness = ReceiverHarness.Create(QueueType.Quorum);
+            var headers = new Dictionary<string, object> { [ReceiverHarness.NativeDeliveryCountHeader] = "8" };
+            await harness.PushVerbatimAsync(deliveryTag: 1, headers: headers);
+
+            var context = await harness.ReceiveAsync();
+
+            context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts].Should().Be(9);
+        }
+
+        // An unparseable native count hits the default arm (returns the default 0 prior deliveries), so attempts
+        // floor to 1 — the value never stamps a bogus or negative attempt count.
+        [Fact]
+        public async Task MustFloorQuorumAttemptsToOneWhenNativeCountUnparseable()
+        {
+            var harness = ReceiverHarness.Create(QueueType.Quorum);
+            var headers = new Dictionary<string, object> { [ReceiverHarness.NativeDeliveryCountHeader] = true };
+            await harness.PushVerbatimAsync(deliveryTag: 1, headers: headers);
+
+            var context = await harness.ReceiveAsync();
+
+            context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts].Should().Be(1,
+                "a bool native count is unparseable, so ReadHeaderAsLong returns the default and attempts floor to 1");
+        }
     }
 }

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqReceiver/WhenSettlingMessage.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqReceiver/WhenSettlingMessage.cs
@@ -163,6 +163,9 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqReceiver
             // INVARIANT under test is that the (confirmed) republish happened and THEN the original was acked.
             harness.ConnectionSource.PublishChannels.Single().Publishes.Should().ContainSingle();
             harness.ConnectionSource.ReceiveChannel.Acks.Single().DeliveryTag.Should().Be(9UL);
+            harness.ConnectionSource.PublishChannels.Single().Publishes.Single().Seq
+                .Should().BeLessThan(harness.ConnectionSource.ReceiveChannel.Acks.Single().Seq,
+                    "the confirmed republish must be recorded before the original ack (ADR-0001 confirm-before-ack)");
         }
 
         [Fact]
@@ -201,6 +204,9 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqReceiver
             republish.Headers[MessageContext.FailureDetails].Should().Be("poisoned");
             republish.Headers[MessageContext.FailureDescription].Should().Be("could not be handled");
             harness.ConnectionSource.ReceiveChannel.Acks.Single().DeliveryTag.Should().Be(11UL);
+            harness.ConnectionSource.PublishChannels.Single().Publishes.Single().Seq
+                .Should().BeLessThan(harness.ConnectionSource.ReceiveChannel.Acks.Single().Seq,
+                    "the confirmed deadletter republish must be recorded before the original ack (ADR-0001 confirm-before-ack)");
         }
 
         // OWNERSHIP (r3408649034): the dead-letter queue is the ADAPTER's responsibility; the ERROR queue is the
@@ -233,6 +239,10 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqReceiver
             // single copy; letting the core forward again would be the duplicate.
             deadlettered.Should().BeFalse(
                 "the method must return false so the core's error-recovery action is suppressed and the adapter's single error-queue copy is not duplicated");
+            // (d) The confirmed error-path republish is recorded BEFORE the original ack.
+            harness.ConnectionSource.PublishChannels.Single().Publishes.Single().Seq
+                .Should().BeLessThan(harness.ConnectionSource.ReceiveChannel.Acks.Single().Seq,
+                    "the confirmed error-path republish must be recorded before the original ack (ADR-0001 confirm-before-ack)");
         }
 
         // No message loss in the error-only path under a stale epoch: the republish is publisher-confirmed REGARDLESS

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqReceiver/WhenSettlingMessage.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Receiving/UsingRabbitMqReceiver/WhenSettlingMessage.cs
@@ -65,6 +65,39 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Receiving.UsingRabbitMqReceiver
             harness.ConnectionSource.ReceiveChannel.Acks.Should().BeEmpty();
         }
 
+        // A bare context carrying no ReceivedMessage (no Container.Include) has nothing to settle: nack must return
+        // false and perform no nack/republish — mirroring the ack false arm above.
+        [Fact]
+        public async Task MustReturnFalseOnNackWhenContextCarriesNoReceivedMessage()
+        {
+            var harness = ReceiverHarness.Create(QueueType.Quorum);
+            var bareContext = new Chatter.MessageBrokers.Context.MessageBrokerContext(
+                "id", new byte[] { 1 }, new Dictionary<string, object>(), ReceiverHarness.ReceiverPath, CancellationToken.None, new RabbitMqBodyConverter());
+
+            var nacked = await harness.Receiver.NackMessageAsync(bareContext, transactionContext: null, CancellationToken.None);
+
+            nacked.Should().BeFalse();
+            harness.ConnectionSource.ReceiveChannel.Nacks.Should().BeEmpty("no carried delivery means nothing to nack");
+            harness.ConnectionSource.PublishChannels.Should().BeEmpty("no carried delivery means nothing to republish");
+        }
+
+        // A bare context carrying no ReceivedMessage has nothing to deadletter: deadletter must return false and
+        // perform no publish/ack.
+        [Fact]
+        public async Task MustReturnFalseOnDeadletterWhenContextCarriesNoReceivedMessage()
+        {
+            var harness = ReceiverHarness.Create(deadLetterQueuePath: ReceiverHarness.DeadLetterPath);
+            var bareContext = new Chatter.MessageBrokers.Context.MessageBrokerContext(
+                "id", new byte[] { 1 }, new Dictionary<string, object>(), ReceiverHarness.ReceiverPath, CancellationToken.None, new RabbitMqBodyConverter());
+
+            var deadlettered = await harness.Receiver.DeadletterMessageAsync(
+                bareContext, transactionContext: null, "poisoned", "bad", CancellationToken.None);
+
+            deadlettered.Should().BeFalse();
+            harness.ConnectionSource.PublishChannels.Should().BeEmpty("no carried delivery means nothing to republish");
+            harness.ConnectionSource.ReceiveChannel.Acks.Should().BeEmpty("no carried delivery means nothing to ack");
+        }
+
         // --- nack: Quorum requeues natively ---
 
         [Fact]

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/UsingRabbitMqHeaderMarshaller/WhenCoercingHeaders.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/UsingRabbitMqHeaderMarshaller/WhenCoercingHeaders.cs
@@ -1,0 +1,232 @@
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.RabbitMQ;
+using FluentAssertions;
+using RabbitMQ.Client;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.UsingRabbitMqHeaderMarshaller
+{
+    // Exercises the RabbitMqHeaderMarshaller public static surface directly (the type is internal static; the
+    // test assembly's InternalsVisibleTo reaches it). ToHeaderTable coerces each outbound MessageContext CLR value
+    // to an AMQP-field-table-legal wire type (or drops un-encodable core keys); DecodeHeaderValue is the inbound
+    // type-total string decode the translator delegates to for a native-frame field sourced from its header copy.
+    // No live broker, no translator — just the coercion arms.
+    public class WhenCoercingHeaders : Testing.Core.Context
+    {
+        private static BasicProperties NewProperties() => new BasicProperties();
+
+        // --- ToHeaderTable: CoerceOutboundValue passthrough arms (string/bool/sbyte/int/long/decimal/byte[]) ---
+
+        [Fact]
+        public void MustPassThroughFieldTableLegalTypesVerbatim()
+        {
+            var bytes = new byte[] { 0xDE, 0xAD };
+            var context = new Dictionary<string, object>
+            {
+                ["a-string"] = "value",
+                ["a-bool"] = true,
+                ["a-sbyte"] = (sbyte)-7,
+                ["an-int"] = 42,
+                ["a-long"] = 9_000_000_000L,
+                ["a-decimal"] = 12.5m,
+                ["a-byte-array"] = bytes
+            };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table["a-string"].Should().Be("value");
+            table["a-bool"].Should().Be(true);
+            table["a-sbyte"].Should().Be((sbyte)-7);
+            table["an-int"].Should().Be(42);
+            table["a-long"].Should().Be(9_000_000_000L);
+            table["a-decimal"].Should().Be(12.5m);
+            table["a-byte-array"].Should().BeSameAs(bytes, "a byte[] is field-table-legal and passes through verbatim");
+        }
+
+        // --- ToHeaderTable: numeric-widening arms (ulong/uint/ushort/byte -> long; short -> int) ---
+
+        [Fact]
+        public void MustWidenInRangeULongToLong()
+        {
+            var context = new Dictionary<string, object> { ["a-ulong"] = 5UL };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table["a-ulong"].Should().Be(5L, "an in-range ulong widens to long (field-table-legal)");
+        }
+
+        [Fact]
+        public void MustRenderOutOfRangeULongAsInvariantString()
+        {
+            var context = new Dictionary<string, object> { ["a-ulong"] = ulong.MaxValue };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table["a-ulong"].Should().Be(ulong.MaxValue.ToString(CultureInfo.InvariantCulture),
+                "a ulong above long.MaxValue cannot widen to long, so it falls back to its invariant string form");
+        }
+
+        [Fact]
+        public void MustWidenUIntUShortAndByteToLong()
+        {
+            var context = new Dictionary<string, object>
+            {
+                ["a-uint"] = (uint)123,
+                ["a-ushort"] = (ushort)45,
+                ["a-byte"] = (byte)7
+            };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table["a-uint"].Should().Be(123L);
+            table["a-ushort"].Should().Be(45L);
+            table["a-byte"].Should().Be(7L);
+        }
+
+        [Fact]
+        public void MustWidenShortToInt()
+        {
+            var context = new Dictionary<string, object> { ["a-short"] = (short)-9 };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table["a-short"].Should().Be(-9, "a short widens to int (field-table-legal)");
+            table["a-short"].Should().BeOfType<int>();
+        }
+
+        // --- ToHeaderTable: Guid -> string and the unencodable catch-all default arm ---
+
+        [Fact]
+        public void MustRenderGuidAsString()
+        {
+            var guid = Guid.NewGuid();
+            var context = new Dictionary<string, object> { ["a-guid"] = guid };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table["a-guid"].Should().Be(guid.ToString());
+        }
+
+        [Fact]
+        public void MustRenderUnencodableTypeAsInvariantStringViaDefaultArm()
+        {
+            // An enum is not a field-table-legal type and is not handled by an explicit arm, so it falls through to
+            // the documented Convert.ToString(InvariantCulture) catch-all rather than faulting the publish.
+            var context = new Dictionary<string, object> { ["an-enum"] = SampleEnum.Second };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table["an-enum"].Should().Be(Convert.ToString(SampleEnum.Second, CultureInfo.InvariantCulture));
+        }
+
+        private enum SampleEnum
+        {
+            First,
+            Second
+        }
+
+        // --- ToHeaderTable: TimeToLive dropped; ExpiryTimeUtc encode arms; null-coerced dropped; null context ---
+
+        [Fact]
+        public void MustDropTimeToLiveKey()
+        {
+            var context = new Dictionary<string, object>
+            {
+                [MessageContext.TimeToLive] = TimeSpan.FromSeconds(30),
+                ["kept"] = "value"
+            };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table.Should().NotContainKey(MessageContext.TimeToLive,
+                "TimeToLive is lifted onto the native Expiration by the translator and must never reach the field table");
+            table.Should().ContainKey("kept");
+        }
+
+        [Fact]
+        public void MustEncodeExpiryTimeUtcDateTimeAsIsoO()
+        {
+            var expiry = new DateTime(2026, 6, 13, 10, 30, 0, DateTimeKind.Utc);
+            var context = new Dictionary<string, object> { [MessageContext.ExpiryTimeUtc] = expiry };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table[MessageContext.ExpiryTimeUtc].Should().Be(expiry.ToString("O", CultureInfo.InvariantCulture),
+                "a DateTime ExpiryTimeUtc is ISO-8601 (\"O\") encoded so it round-trips back to a DateTime");
+        }
+
+        [Fact]
+        public void MustEncodeNonDateTimeExpiryTimeUtcViaOutboundFallback()
+        {
+            // A non-DateTime ExpiryTimeUtc value falls back to the general outbound coercion (here a uint -> long).
+            var context = new Dictionary<string, object> { [MessageContext.ExpiryTimeUtc] = (uint)17 };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table[MessageContext.ExpiryTimeUtc].Should().Be(17L,
+                "a non-DateTime ExpiryTimeUtc falls back to the general outbound coercion rather than the ISO encode");
+        }
+
+        [Fact]
+        public void MustDropNullCoercedValue()
+        {
+            var context = new Dictionary<string, object>
+            {
+                ["a-null"] = null,
+                ["kept"] = "value"
+            };
+
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(context, NewProperties());
+
+            table.Should().NotContainKey("a-null", "a null value is not field-table-legal and must be dropped");
+            table["kept"].Should().Be("value");
+        }
+
+        [Fact]
+        public void MustReturnEmptyTableForNullContext()
+        {
+            var table = RabbitMqHeaderMarshaller.ToHeaderTable(null, NewProperties());
+
+            table.Should().NotBeNull();
+            table.Should().BeEmpty();
+        }
+
+        // --- DecodeHeaderValue: byte[] -> UTF8 string; string passthrough; null; default-arm invariant string ---
+
+        [Fact]
+        public void MustDecodeByteArrayValueToUtf8String()
+        {
+            var bytes = Encoding.UTF8.GetBytes("corr-123");
+
+            RabbitMqHeaderMarshaller.DecodeHeaderValue(bytes).Should().Be("corr-123",
+                "a byte[] AMQP longstr decodes to its UTF-8 string");
+        }
+
+        [Fact]
+        public void MustPassThroughStringValue()
+        {
+            RabbitMqHeaderMarshaller.DecodeHeaderValue("already-a-string").Should().Be("already-a-string");
+        }
+
+        [Fact]
+        public void MustReturnNullForNullValue()
+        {
+            RabbitMqHeaderMarshaller.DecodeHeaderValue(null).Should().BeNull(
+                "a null wire value returns null so the caller drops the key rather than stamping an empty string");
+        }
+
+        [Fact]
+        public void MustRenderNonStringNonByteArrayValueAsInvariantStringViaDefaultArm()
+        {
+            RabbitMqHeaderMarshaller.DecodeHeaderValue(42).Should().Be(
+                Convert.ToString(42, CultureInfo.InvariantCulture),
+                "a non-string, non-byte[] wire value is coerced to its invariant string form rather than passed through verbatim");
+            RabbitMqHeaderMarshaller.DecodeHeaderValue(true).Should().Be(
+                Convert.ToString(true, CultureInfo.InvariantCulture));
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/UsingRabbitMqPathBuilder/WhenBuildingPaths.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/UsingRabbitMqPathBuilder/WhenBuildingPaths.cs
@@ -1,0 +1,45 @@
+using Chatter.MessageBrokers;
+using FluentAssertions;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.UsingRabbitMqPathBuilder
+{
+    // Pins the RabbitMqPathBuilder default-exchange convention: RabbitMQ addresses receivers by queue name
+    // (routing key = Destination = queue name), so every path is the receiver/queue name verbatim — there is no
+    // topic/subscription or rule entity to compose into the path. The three methods are EXPLICIT interface
+    // implementations on an internal type, so the test instantiates the concrete builder and casts to
+    // IBrokeredMessagePathBuilder to reach them. GetMessageSendingPath returns its input; the receiving and
+    // receiving-rule paths return the receiver path verbatim (sending path and rule name ignored).
+    public class WhenBuildingPaths : Testing.Core.Context
+    {
+        private static IBrokeredMessagePathBuilder NewBuilder()
+            => new RabbitMqPathBuilder();
+
+        [Fact]
+        public void MustReturnSendingPathVerbatim()
+        {
+            var builder = NewBuilder();
+
+            builder.GetMessageSendingPath("orders-queue").Should().Be("orders-queue",
+                "RabbitMQ sends to the queue name verbatim under the default-exchange convention");
+        }
+
+        [Fact]
+        public void MustReturnReceiverPathForReceivingPathIgnoringSendingPath()
+        {
+            var builder = NewBuilder();
+
+            builder.GetMessageReceivingPath("orders-sending", "orders-receiver").Should().Be("orders-receiver",
+                "the receiving path is the receiver/queue name verbatim; the sending path is not composed in");
+        }
+
+        [Fact]
+        public void MustReturnReceiverPathForReceivingRulePathIgnoringSendingPathAndRule()
+        {
+            var builder = NewBuilder();
+
+            builder.GetMessageReceivingRulePath("orders-sending", "orders-receiver", "some-rule").Should().Be("orders-receiver",
+                "there is no rule entity in RabbitMQ addressing; the rule name and sending path are ignored");
+        }
+    }
+}


### PR DESCRIPTION
Test-only. Closes RabbitMQ adapter coverage gaps + hardens a vacuous safety-invariant assertion found in review. No product change, no version bump.

## Coverage tests (+40)
Targeted the uncovered branches via the existing broker-free doubles (no Docker, no new infra):
- **RabbitMqPathBuilder** — was 33% line, now exercised (explicit-interface path methods).
- **RabbitMqConnectionSource** — stop teardown (cancel+dispose+clear, AlreadyClosed/ODE swallow, idempotent double-stop, stop-after-dispose no-op), publish-channel acquire + re-pool + reuse, stale-connection replace, null-arg guards.
- **RabbitMqReceiver** — Nack/Deadletter no-`ReceivedMessage` false arms; `ReadHeaderAsLong` short/byte/uint/ushort/non-byte[]-string/unparseable arms.
- **RabbitMqHeaderMarshaller** — `CoerceOutboundValue` numeric-widening + Guid + default arms, `ExpiryTimeUtc` encode fallback, null-key/null-context drops, `DecodeHeaderValue` default arm.

Unit-only coverage: **line 84.8 → ~92%, branch 76.8 → ~87% (+10pt)**. With integration the totals are higher. RabbitMQ unit suite 244 → 284, green both TFMs.

## Review-found fixes (pre-PR local adversarial review)
The local Codex review caught **vacuous assertions on claimed invariants** and they were fixed:
- post-stop publish liveness now asserted via a real `AcquirePublishChannelAsync` (was asserting only retained field state).
- publisher-confirmation flags (ADR-0003 confirm-before-ack) now asserted on channel creation (was `It.IsAny`).
- **republish-before-ack ordering** (ADR-0001 data-loss guard) is now *genuinely* asserted: a shared monotonic `OperationSequencer` spans the publish + receive `RecordingChannel`s, so the 3 settlement tests assert `republish.Seq < ack.Seq` (strict). Previously publishes and acks were logged in separate per-channel lists with no shared clock — an ack-before-confirmed-republish regression would have passed. **Mutation-verified** (inverting the comparison fails the tests).

## Validation
`dotnet test ...RabbitMQ.Tests.csproj --filter Category!=Integration` — 284 green both net8.0+net10.0. Test-only; product code untouched.
