### PR TITLE
feat(sqlchangefeed): cancellable + genuinely-async migration/uninstall (#212)

### DIFF
--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/CHANGELOG.md
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/CHANGELOG.md
@@ -12,6 +12,18 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [0.11.0] - 2026-06-14
+
+### Added
+
+- `UseChangeFeedSqlMigrationsAsync` async/cancellable migration entry points (on `IApplicationBuilder` and `IServiceProvider`, generic and `Type` overloads) that genuinely `await` the install and observe a `CancellationToken`. (#212)
+- `CancellationToken` parameters on `ISqlDependencyManager.InstallSqlDependencies` / `UninstallSqlDependencies` and on `ExecutableSqlScript.ExecuteAsync`. All are defaulted (`= default`), so existing callers compile unchanged. (#212)
+
+### Changed
+
+- Migration install and uninstall are now genuinely asynchronous and cancellable: `ExecutableSqlScript.ExecuteAsync` awaits `OpenAsync`/`ExecuteNonQueryAsync` with the supplied token, and `SqlDependencyManager` awaits each script instead of running it synchronously. (#212)
+- The synchronous `UseChangeFeedSqlMigrations` boundary now awaits the install internally (`GetAwaiter().GetResult()`), closing a latent fire-and-forget that previously worked only because the install ran synchronously. (#212)
+
 ## [0.10.0] - 2026-06-14
 
 ### Changed

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.SqlChangeFeed</PackageId>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A library that leverags SQL Service Broker to send sql table changes (insert, update, delete) to a change feed queue for further processing by .NET code.</Description>

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/DependencyInjection/SqlChangeFeedExtensions.cs
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/DependencyInjection/SqlChangeFeedExtensions.cs
@@ -7,6 +7,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Chatter.SqlChangeFeed.DependencyInjection
 {
@@ -90,18 +92,20 @@ namespace Chatter.SqlChangeFeed.DependencyInjection
         /// </summary>
         /// <typeparam name="TRowChangedData">The row type to use Sql migrations for</typeparam>
         /// <param name="applicationBuilder">The application builder</param>
+        /// <param name="token">A token to observe while waiting for the migration to complete</param>
         /// <returns></returns>
-        public static IApplicationBuilder UseChangeFeedSqlMigrations<TRowChangedData>(this IApplicationBuilder applicationBuilder)
-            => applicationBuilder.UseChangeFeedSqlMigrations(typeof(TRowChangedData));
+        public static IApplicationBuilder UseChangeFeedSqlMigrations<TRowChangedData>(this IApplicationBuilder applicationBuilder, CancellationToken token = default)
+            => applicationBuilder.UseChangeFeedSqlMigrations(typeof(TRowChangedData), token);
 
         /// <summary>
         /// Deploys the SQL and SQL Service Broker dependencies required for the sql change feed
         /// </summary>
         /// <param name="applicationBuilder">The application builder</param>
         /// <param name="rowChangedDataType">The row type to use Sql migrations for</param>
-        public static IApplicationBuilder UseChangeFeedSqlMigrations(this IApplicationBuilder applicationBuilder, Type rowChangedDataType)
+        /// <param name="token">A token to observe while waiting for the migration to complete</param>
+        public static IApplicationBuilder UseChangeFeedSqlMigrations(this IApplicationBuilder applicationBuilder, Type rowChangedDataType, CancellationToken token = default)
         {
-            applicationBuilder.ApplicationServices.UseChangeFeedSqlMigrations(rowChangedDataType);
+            applicationBuilder.ApplicationServices.UseChangeFeedSqlMigrations(rowChangedDataType, token);
             return applicationBuilder;
         }
 
@@ -110,16 +114,18 @@ namespace Chatter.SqlChangeFeed.DependencyInjection
         /// </summary>
         /// <typeparam name="TRowChangedData">The row type to use Sql migrations for</typeparam>
         /// <param name="provider">The service provider</param>
+        /// <param name="token">A token to observe while waiting for the migration to complete</param>
         /// <returns></returns>
-        public static IServiceProvider UseChangeFeedSqlMigrations<TRowChangedData>(this IServiceProvider provider)
-            => provider.UseChangeFeedSqlMigrations(typeof(TRowChangedData));
+        public static IServiceProvider UseChangeFeedSqlMigrations<TRowChangedData>(this IServiceProvider provider, CancellationToken token = default)
+            => provider.UseChangeFeedSqlMigrations(typeof(TRowChangedData), token);
 
         /// <summary>
         /// Deploys the SQL and SQL Service Broker dependencies required for table changes to be emitted
         /// </summary>
         /// <param name="provider">The service provider</param>
         /// <param name="rowChangedDataType">The row type to use Sql migrations for</param>
-        public static IServiceProvider UseChangeFeedSqlMigrations(this IServiceProvider provider, Type rowChangedDataType)
+        /// <param name="token">A token to observe while waiting for the migration to complete</param>
+        public static IServiceProvider UseChangeFeedSqlMigrations(this IServiceProvider provider, Type rowChangedDataType, CancellationToken token = default)
         {
             using var scope = provider.CreateScope();
             var sdm = (ISqlDependencyManager)scope.ServiceProvider.GetRequiredService(typeof(ISqlDependencyManager<>).MakeGenericType(rowChangedDataType));
@@ -134,9 +140,63 @@ namespace Chatter.SqlChangeFeed.DependencyInjection
             var installChangeFeedStoredProcName = $"{ChatterServiceBrokerConstants.ChatterInstallChangeFeedPrefix}{receiverName}";
             var uninstallChangeFeedStoredProcName = $"{ChatterServiceBrokerConstants.ChatterUninstallChangeFeedPrefix}{receiverName}";
 
-            sdm.InstallSqlDependencies(installChangeFeedStoredProcName, uninstallChangeFeedStoredProcName, conversationQueueName, conversationServiceName, conversationTriggerName, conversationDeadLetterQueueName, conversationDeadLetterServiceName);
+            sdm.InstallSqlDependencies(installChangeFeedStoredProcName, uninstallChangeFeedStoredProcName, conversationQueueName, conversationServiceName, conversationTriggerName, conversationDeadLetterQueueName, conversationDeadLetterServiceName, token).GetAwaiter().GetResult();
 
             return provider;
+        }
+
+        /// <summary>
+        /// Asynchronously deploys the SQL and SQL Service Broker dependencies required for the sql change feed
+        /// </summary>
+        /// <typeparam name="TRowChangedData">The row type to use Sql migrations for</typeparam>
+        /// <param name="applicationBuilder">The application builder</param>
+        /// <param name="token">A token to observe while waiting for the migration to complete</param>
+        /// <returns>A task that completes when the migration has finished</returns>
+        public static Task UseChangeFeedSqlMigrationsAsync<TRowChangedData>(this IApplicationBuilder applicationBuilder, CancellationToken token = default)
+            => applicationBuilder.UseChangeFeedSqlMigrationsAsync(typeof(TRowChangedData), token);
+
+        /// <summary>
+        /// Asynchronously deploys the SQL and SQL Service Broker dependencies required for the sql change feed
+        /// </summary>
+        /// <param name="applicationBuilder">The application builder</param>
+        /// <param name="rowChangedDataType">The row type to use Sql migrations for</param>
+        /// <param name="token">A token to observe while waiting for the migration to complete</param>
+        /// <returns>A task that completes when the migration has finished</returns>
+        public static Task UseChangeFeedSqlMigrationsAsync(this IApplicationBuilder applicationBuilder, Type rowChangedDataType, CancellationToken token = default)
+            => applicationBuilder.ApplicationServices.UseChangeFeedSqlMigrationsAsync(rowChangedDataType, token);
+
+        /// <summary>
+        /// Asynchronously deploys the SQL and SQL Service Broker dependencies required for table changes to be emitted
+        /// </summary>
+        /// <typeparam name="TRowChangedData">The row type to use Sql migrations for</typeparam>
+        /// <param name="provider">The service provider</param>
+        /// <param name="token">A token to observe while waiting for the migration to complete</param>
+        /// <returns>A task that completes when the migration has finished</returns>
+        public static Task UseChangeFeedSqlMigrationsAsync<TRowChangedData>(this IServiceProvider provider, CancellationToken token = default)
+            => provider.UseChangeFeedSqlMigrationsAsync(typeof(TRowChangedData), token);
+
+        /// <summary>
+        /// Asynchronously deploys the SQL and SQL Service Broker dependencies required for table changes to be emitted
+        /// </summary>
+        /// <param name="provider">The service provider</param>
+        /// <param name="rowChangedDataType">The row type to use Sql migrations for</param>
+        /// <param name="token">A token to observe while waiting for the migration to complete</param>
+        /// <returns>A task that completes when the migration has finished</returns>
+        public static async Task UseChangeFeedSqlMigrationsAsync(this IServiceProvider provider, Type rowChangedDataType, CancellationToken token = default)
+        {
+            using var scope = provider.CreateScope();
+            var sdm = (ISqlDependencyManager)scope.ServiceProvider.GetRequiredService(typeof(ISqlDependencyManager<>).MakeGenericType(rowChangedDataType));
+
+            var receiverName = rowChangedDataType.Name;
+            var conversationQueueName = $"{ChatterServiceBrokerConstants.ChatterQueuePrefix}{receiverName}";
+            var conversationServiceName = $"{ChatterServiceBrokerConstants.ChatterServicePrefix}{receiverName}";
+            var conversationDeadLetterQueueName = $"{ChatterServiceBrokerConstants.ChatterDeadLetterQueuePrefix}{receiverName}";
+            var conversationDeadLetterServiceName = $"{ChatterServiceBrokerConstants.ChatterDeadLetterServicePrefix}{receiverName}";
+            var conversationTriggerName = $"{ChatterServiceBrokerConstants.ChatterTriggerPrefix}{receiverName}";
+            var installChangeFeedStoredProcName = $"{ChatterServiceBrokerConstants.ChatterInstallChangeFeedPrefix}{receiverName}";
+            var uninstallChangeFeedStoredProcName = $"{ChatterServiceBrokerConstants.ChatterUninstallChangeFeedPrefix}{receiverName}";
+
+            await sdm.InstallSqlDependencies(installChangeFeedStoredProcName, uninstallChangeFeedStoredProcName, conversationQueueName, conversationServiceName, conversationTriggerName, conversationDeadLetterQueueName, conversationDeadLetterServiceName, token);
         }
     }
 }

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/DependencyInjection/SqlChangeFeedExtensions.cs
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/DependencyInjection/SqlChangeFeedExtensions.cs
@@ -196,7 +196,7 @@ namespace Chatter.SqlChangeFeed.DependencyInjection
             var installChangeFeedStoredProcName = $"{ChatterServiceBrokerConstants.ChatterInstallChangeFeedPrefix}{receiverName}";
             var uninstallChangeFeedStoredProcName = $"{ChatterServiceBrokerConstants.ChatterUninstallChangeFeedPrefix}{receiverName}";
 
-            await sdm.InstallSqlDependencies(installChangeFeedStoredProcName, uninstallChangeFeedStoredProcName, conversationQueueName, conversationServiceName, conversationTriggerName, conversationDeadLetterQueueName, conversationDeadLetterServiceName, token);
+            await sdm.InstallSqlDependencies(installChangeFeedStoredProcName, uninstallChangeFeedStoredProcName, conversationQueueName, conversationServiceName, conversationTriggerName, conversationDeadLetterQueueName, conversationDeadLetterServiceName, token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/ISqlDependencyManager.cs
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/ISqlDependencyManager.cs
@@ -1,18 +1,20 @@
 ﻿using Chatter.CQRS;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Chatter.SqlChangeFeed
 {
     public interface ISqlDependencyManager
     {
-        Task UninstallSqlDependencies(string uninstallationProcedureName = "");
+        Task UninstallSqlDependencies(string uninstallationProcedureName = "", CancellationToken token = default);
         Task InstallSqlDependencies(string installationProcedureName = "",
                                     string uninstallationProcedureName = "",
                                     string conversationQueueName = "",
                                     string conversationServiceName = "",
                                     string conversationTriggerName = "",
                                     string deadLetterQueueName = "",
-                                    string deadLetterServiceName = "");
+                                    string deadLetterServiceName = "",
+                                    CancellationToken token = default);
     }
 
     public interface ISqlDependencyManager<TRowChangedData> : ISqlDependencyManager where TRowChangedData : class, IMessage, new() { }

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Scripts/ExecutableSqlScript.cs
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Scripts/ExecutableSqlScript.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Data;
 using Microsoft.Data.SqlClient;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Chatter.SqlChangeFeed.Scripts
@@ -28,14 +29,14 @@ namespace Chatter.SqlChangeFeed.Scripts
             command.ExecuteNonQuery();
         }
 
-        public virtual async Task ExecuteAsync()
+        public virtual async Task ExecuteAsync(CancellationToken token = default)
         {
             using SqlConnection conn = new SqlConnection(_connectionString);
             using (SqlCommand command = new SqlCommand(ToString(), conn))
             {
-                conn.Open();
+                await conn.OpenAsync(token);
                 command.CommandType = CommandType.Text;
-                await command.ExecuteNonQueryAsync();
+                await command.ExecuteNonQueryAsync(token);
             }
         }
     }

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Scripts/ExecutableSqlScript.cs
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Scripts/ExecutableSqlScript.cs
@@ -34,9 +34,9 @@ namespace Chatter.SqlChangeFeed.Scripts
             using SqlConnection conn = new SqlConnection(_connectionString);
             using (SqlCommand command = new SqlCommand(ToString(), conn))
             {
-                await conn.OpenAsync(token);
+                await conn.OpenAsync(token).ConfigureAwait(false);
                 command.CommandType = CommandType.Text;
-                await command.ExecuteNonQueryAsync(token);
+                await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
             }
         }
     }

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/SqlDependencyManager.cs
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/SqlDependencyManager.cs
@@ -48,9 +48,9 @@ namespace Chatter.SqlChangeFeed
                                                    deadLetterQueueName,
                                                    deadLetterServiceName);
 
-            await installChangeFeedScript.ExecuteAsync(token);
-            await uninstallChangeFeedScript.ExecuteAsync(token);
-            await execInstallationProcedureScript.ExecuteAsync(token);
+            await installChangeFeedScript.ExecuteAsync(token).ConfigureAwait(false);
+            await uninstallChangeFeedScript.ExecuteAsync(token).ConfigureAwait(false);
+            await execInstallationProcedureScript.ExecuteAsync(token).ConfigureAwait(false);
         }
 
         public async Task UninstallSqlDependencies(string uninstallationProcedureName = "", CancellationToken token = default)
@@ -62,7 +62,7 @@ namespace Chatter.SqlChangeFeed
                 uninstallationProcedureName,
                 Options.SchemaName);
 
-            await execUninstallationProcedureScript.ExecuteAsync(token);
+            await execUninstallationProcedureScript.ExecuteAsync(token).ConfigureAwait(false);
         }
     }
 }

--- a/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/SqlDependencyManager.cs
+++ b/src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/SqlDependencyManager.cs
@@ -2,6 +2,7 @@
 using Chatter.SqlChangeFeed.Configuration;
 using Chatter.SqlChangeFeed.Scripts;
 using Chatter.SqlChangeFeed.Scripts.StoredProcedures;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Chatter.SqlChangeFeed
@@ -13,13 +14,14 @@ namespace Chatter.SqlChangeFeed
         public SqlDependencyManager(SqlChangeFeedOptions options)
             => Options = options;
 
-        public Task InstallSqlDependencies(string installationProcedureName = "",
-                                           string uninstallationProcedureName = "",
-                                           string conversationQueueName = "",
-                                           string conversationServiceName = "",
-                                           string conversationTriggerName = "",
-                                           string deadLetterQueueName = "",
-                                           string deadLetterServiceName = "")
+        public async Task InstallSqlDependencies(string installationProcedureName = "",
+                                                 string uninstallationProcedureName = "",
+                                                 string conversationQueueName = "",
+                                                 string conversationServiceName = "",
+                                                 string conversationTriggerName = "",
+                                                 string deadLetterQueueName = "",
+                                                 string deadLetterServiceName = "",
+                                                 CancellationToken token = default)
         {
             var execInstallationProcedureScript
                 = new SafeExecuteStoredProcedure(Options.ConnectionString,
@@ -46,14 +48,12 @@ namespace Chatter.SqlChangeFeed
                                                    deadLetterQueueName,
                                                    deadLetterServiceName);
 
-            installChangeFeedScript.Execute();
-            uninstallChangeFeedScript.Execute();
-            execInstallationProcedureScript.Execute();
-
-            return Task.CompletedTask;
+            await installChangeFeedScript.ExecuteAsync(token);
+            await uninstallChangeFeedScript.ExecuteAsync(token);
+            await execInstallationProcedureScript.ExecuteAsync(token);
         }
 
-        public Task UninstallSqlDependencies(string uninstallationProcedureName = "")
+        public async Task UninstallSqlDependencies(string uninstallationProcedureName = "", CancellationToken token = default)
         {
             var execUninstallationProcedureScript =
                 new SafeExecuteStoredProcedure(
@@ -62,9 +62,7 @@ namespace Chatter.SqlChangeFeed
                 uninstallationProcedureName,
                 Options.SchemaName);
 
-            execUninstallationProcedureScript.Execute();
-
-            return Task.CompletedTask;
+            await execUninstallationProcedureScript.ExecuteAsync(token);
         }
     }
 }

--- a/src/Chatter.SqlChangeFeed/tests/Integration/ChatterChangeFeedHarness.cs
+++ b/src/Chatter.SqlChangeFeed/tests/Integration/ChatterChangeFeedHarness.cs
@@ -42,8 +42,8 @@ namespace Chatter.SqlChangeFeed.Tests.Integration
         private static readonly TimeSpan TeardownTimeout = TimeSpan.FromSeconds(30);
 
         // Bounds the production migration install so a wedged DDL (e.g. a non-rollback ENABLE_BROKER blocked
-        // behind another session) fails fast rather than hanging the test. The install runs synchronously on a
-        // worker thread; the await races it against this finite delay.
+        // behind another session) fails fast rather than hanging the test. The install is genuinely async and
+        // cancellable; a bounded linked token cancels the await when this ceiling is exceeded.
         private static readonly TimeSpan MigrationTimeout = TimeSpan.FromSeconds(60);
 
         private readonly ServiceProvider _provider;
@@ -133,22 +133,22 @@ namespace Chatter.SqlChangeFeed.Tests.Integration
             => services.AddTransient<IMessageHandler<TEvent>, RecordingChangeFeedHandler<TEvent>>();
 
         // Runs the PRODUCTION change-feed migration over the configured row type: resolves ISqlDependencyManager
-        // <TRow> via UseChangeFeedSqlMigrations<TRow> and installs the trigger + Service Broker objects + install/
-        // uninstall stored procs. Bounded so a wedged install DDL fails fast. The install executes synchronous
-        // ADO.NET internally, so it runs on a pool thread and is raced against MigrationTimeout.
+        // <TRow> via UseChangeFeedSqlMigrationsAsync<TRow> and installs the trigger + Service Broker objects +
+        // install/uninstall stored procs. Bounded so a wedged install DDL fails fast: the install is genuinely
+        // async and cancellable, so a bounded token cancels the await and the OperationCanceledException is
+        // surfaced as TimeoutException to preserve the timeout contract.
         public async Task RunMigrationsAsync()
         {
             using var migrationCts = new CancellationTokenSource(MigrationTimeout);
-            var install = Task.Run(() => _provider.UseChangeFeedSqlMigrations<TRow>());
-            var completed = await Task.WhenAny(install, Task.Delay(Timeout.Infinite, migrationCts.Token))
-                .ConfigureAwait(false);
-            if (completed != install)
+            try
+            {
+                await _provider.UseChangeFeedSqlMigrationsAsync<TRow>(migrationCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (migrationCts.IsCancellationRequested)
             {
                 throw new TimeoutException(
                     $"Timed out after {MigrationTimeout} running the change-feed migration for '{typeof(TRow).Name}'.");
             }
-
-            await install.ConfigureAwait(false);
         }
 
         // Runs the PRODUCTION change-feed uninstall: resolves ISqlDependencyManager<TRow> and executes the
@@ -162,16 +162,15 @@ namespace Chatter.SqlChangeFeed.Tests.Integration
             using var scope = _provider.CreateScope();
             var sdm = scope.ServiceProvider.GetRequiredService<ISqlDependencyManager<TRow>>();
 
-            var uninstall = Task.Run(() => sdm.UninstallSqlDependencies(uninstallProcName));
-            var completed = await Task.WhenAny(uninstall, Task.Delay(Timeout.Infinite, uninstallCts.Token))
-                .ConfigureAwait(false);
-            if (completed != uninstall)
+            try
+            {
+                await sdm.UninstallSqlDependencies(uninstallProcName, uninstallCts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (uninstallCts.IsCancellationRequested)
             {
                 throw new TimeoutException(
                     $"Timed out after {MigrationTimeout} running the change-feed uninstall for '{typeof(TRow).Name}'.");
             }
-
-            await uninstall.ConfigureAwait(false);
         }
 
         // Starts the receiver pump in-process on the pump token. The production BackgroundService.StartAsync gates

--- a/src/Chatter.SqlChangeFeed/tests/Scripts/UsingExecutableSqlScript/WhenCancelling.cs
+++ b/src/Chatter.SqlChangeFeed/tests/Scripts/UsingExecutableSqlScript/WhenCancelling.cs
@@ -1,0 +1,35 @@
+using Chatter.SqlChangeFeed.Scripts;
+using FluentAssertions;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.SqlChangeFeed.Tests.Scripts.UsingExecutableSqlScript
+{
+    /// <summary>
+    /// Pins that <see cref="ExecutableSqlScript.ExecuteAsync"/> observes a pre-cancelled token and
+    /// short-circuits before any network I/O. A pre-cancelled token makes <c>SqlConnection.OpenAsync</c>
+    /// return a cancelled task immediately, so no live database is required (no Integration trait).
+    /// </summary>
+    public class WhenCancelling : Testing.Core.Context
+    {
+        private sealed class TestScript : ExecutableSqlScript
+        {
+            public TestScript(string connectionString) : base(connectionString)
+            {
+            }
+
+            public override string ToString() => "SELECT 1";
+        }
+
+        [Fact]
+        public Task MustThrowOperationCanceledExceptionWhenTokenIsAlreadyCancelled()
+        {
+            var script = new TestScript("Server=.;Database=Db;");
+
+            return FluentActions.Awaiting(() => script.ExecuteAsync(new CancellationToken(canceled: true)))
+                .Should().ThrowAsync<OperationCanceledException>();
+        }
+    }
+}

--- a/src/Chatter.SqlChangeFeed/tests/UsingSqlDependencyManager/WhenCancelling.cs
+++ b/src/Chatter.SqlChangeFeed/tests/UsingSqlDependencyManager/WhenCancelling.cs
@@ -1,0 +1,50 @@
+using Chatter.SqlChangeFeed.Configuration;
+using FluentAssertions;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.SqlChangeFeed.Tests.UsingSqlDependencyManager
+{
+    /// <summary>
+    /// Pins that <see cref="SqlDependencyManager{TRowChangedData}"/> propagates a pre-cancelled token through
+    /// both install and uninstall, short-circuiting before any real DDL is executed. A pre-cancelled token
+    /// makes the underlying <c>OpenAsync</c> return cancelled immediately, so no live database is required
+    /// (no Integration trait).
+    /// </summary>
+    public class WhenCancelling : Testing.Core.Context
+    {
+        private static SqlDependencyManager<FakeRowData> CreateManager()
+            => new SqlDependencyManager<FakeRowData>(
+                new SqlChangeFeedOptions("Server=.;Database=Db;", "Db", "table"));
+
+        [Fact]
+        public async Task MustThrowOperationCanceledExceptionWhenInstallingWithCancelledToken()
+        {
+            var manager = CreateManager();
+
+            await FluentActions.Awaiting(() => manager.InstallSqlDependencies(
+                    "installProc",
+                    "uninstallProc",
+                    "queue",
+                    "service",
+                    "trigger",
+                    "deadLetterQueue",
+                    "deadLetterService",
+                    new CancellationToken(canceled: true)))
+                .Should().ThrowAsync<OperationCanceledException>();
+        }
+
+        [Fact]
+        public async Task MustThrowOperationCanceledExceptionWhenUninstallingWithCancelledToken()
+        {
+            var manager = CreateManager();
+
+            await FluentActions.Awaiting(() => manager.UninstallSqlDependencies(
+                    "uninstallProc",
+                    new CancellationToken(canceled: true)))
+                .Should().ThrowAsync<OperationCanceledException>();
+        }
+    }
+}


### PR DESCRIPTION
Closes #212. Production follow-up to #176. Backward-compatible. `Chatter.SqlChangeFeed` 0.10.0 → **0.11.0**.

## What
Make the SqlChangeFeed migration/uninstall path **genuinely async + cancellable**:
- `CancellationToken` (default) on `ExecutableSqlScript.ExecuteAsync`, `ISqlDependencyManager`/`SqlDependencyManager` `Install`/`UninstallSqlDependencies`, and `UseChangeFeedSqlMigrations` overloads; `await conn.OpenAsync(ct)` + `ExecuteNonQueryAsync(ct)`.
- The manager was **sync-over-Task** (returned `Task` but called the synchronous `.Execute()`); now genuinely `async` awaiting `ExecuteAsync(ct)`.
- **Fixed a latent fire-and-forget**: the `IServiceProvider` `UseChangeFeedSqlMigrations` overload discarded the returned `Task` (worked only because the work was sync); it now blocks correctly at the boundary, so the migration is guaranteed complete before it returns.
- Added additive **`UseChangeFeedSqlMigrationsAsync`** overloads (return `Task`, accept a token) for a truly-async cancellable startup path.
- **Deadlock-hardening** (local-review finding): `.ConfigureAwait(false)` on all 7 awaited library calls on the migration chain that the sync boundary blocks on — SqlChangeFeed was the only module missing it (siblings all use it).

## Backward-compatible
All new params default to `CancellationToken = default`; existing callers compile unchanged. Single in-repo `ISqlDependencyManager` implementer (source-compat).

## Tests
- Simplified the #176 integration harness (`RunMigrationsAsync`/`UninstallAsync`) to call the new async token API with a bounded linked CTS — **dropping the prior `Task.Run` + `Task.Delay(Infinite)` race** that could orphan a SQL task (the #176-review residual). Parameterless signatures kept; the 4 integration test files untouched; `TimeoutException` contract preserved.
- New broker-free cancellation unit tests: a pre-cancelled token throws `OperationCanceledException` before any SQL I/O.

## Validation (docker up)
Unit 272 both TFMs (incl. 3 cancellation tests); SqlChangeFeed integration **4/4 both TFMs**; `dotnet restore --locked-mode` green.

## Review note
Local review rejected a Codex `medium` "defaulted-param addition is binary-breaking" finding as not actionable: pre-1.0 (0.x grants no binary-stability guarantee), versioning governed by hivemind policy, and the CHANGELOG accurately claims source-compat. The actionable finding (deadlock-hardening) was fixed.
