### PR TITLE
feat(asb): Azure Service Bus message session support (#209)

### DIFF
--- a/docs/architecture/asb-message-sessions.md
+++ b/docs/architecture/asb-message-sessions.md
@@ -1,0 +1,256 @@
+# Solution Architecture: Azure Service Bus Message Sessions
+
+- **Status:** Proposed
+- **Slug:** `asb-message-sessions`
+- **PRD:** [docs/prds/asb-message-sessions.md](../prds/asb-message-sessions.md)
+- **Issue:** [#209](https://github.com/brenpike/Chatter/issues/209)
+
+This document is the HOW companion to the WHAT-only PRD. It records the design decisions,
+component responsibilities, key flows, seam contracts, and risks for adding Azure Service Bus
+message-session support to `Chatter.MessageBrokers.AzureServiceBus`. It honors the module's
+ubiquitous language (`CONTEXT.md`): a session-enabled binding is still a **Queue Receiver**
+(Commands) or a **Topic Subscription** (Events); configuration lives in **Service Bus Options**;
+recovery uses the **Service Bus Retry** / **Service Bus Circuit Breaker** policies. The module
+avoids the aliases the suite's glossaries flag (consumer, listener, forwarder, read request).
+
+## Context & drivers
+
+Chatter's broker-agnostic core (`Chatter.MessageBrokers`) drives all receiving through one
+pull-based pump, `BrokeredMessageReceiver.MessageReceiverLoopAsync`, which repeatedly calls a
+broker's `IMessagingInfrastructureReceiver.ReceiveMessageAsync` and fans each received message
+out to a worker. The Azure Service Bus realization of that port,
+`ServiceBusReceiver`, delegates the actual SDK calls to a small internal port,
+`IServiceBusMessageReceiver`, whose production implementation,
+`AzureSdkMessageReceiverAdapter`, wraps the low-level SDK `ServiceBusReceiver` primitive created
+off a single shared `ServiceBusClient`.
+
+The driver (issue #209) is FIFO-per-`SessionId` ordering with durable per-session state, exposed
+through the same handler/recovery/reliability semantics the rest of the suite already provides —
+without introducing a session concept into the broker-agnostic core. The PRD fixes the WHAT;
+this document fixes the HOW within the adapter.
+
+## Decision
+
+**Add a single-session-at-a-time session adapter that plugs into the existing Chatter pull pump
+through the existing `IServiceBusMessageReceiver` port — not the native push processor.**
+
+A session-mode receiver accepts one session, holds it, serves that session's messages FIFO
+through the same `ReceiveAsync` contract the non-session adapter already satisfies, settles on the
+held session, and rolls to the next session when the current one drains, goes idle, or loses its
+lock. Cross-session parallelism is achieved operationally by running more receiver instances, not
+in-process.
+
+### Rationale and precedent
+
+The decision is the lowest-risk, highest-consistency option because the adapter **already**
+receives through the low-level primitive plus Chatter's own pump rather than a native processor:
+
+- `AzureSdkMessageReceiverAdapter` constructs the SDK `ServiceBusReceiver` primitive directly off
+  the shared `ServiceBusClient` and exposes `ReceiveAsync` / `CompleteAsync` / `AbandonAsync` /
+  `DeadLetterAsync` / `CloseAsync` — there is no `ServiceBusProcessor` anywhere in the receive path.
+- `BrokeredMessageReceiver.MessageReceiverLoopAsync` is the sole pull loop: it owns concurrency,
+  recovery (retry / circuit breaker), critical-fault notification, and teardown. A session adapter
+  that satisfies the same `IServiceBusMessageReceiver` shape inherits all of that unchanged.
+
+The session SDK provides a parallel primitive, `ServiceBusSessionReceiver`, obtained via
+`ServiceBusClient.AcceptNextSessionAsync`, that exposes the same settle methods plus session-state
+and session-lock-renewal operations. A session adapter is therefore a drop-in sibling of the
+existing adapter behind the same internal port, and the pump cannot tell the difference.
+
+## Alternatives considered & rejected
+
+**Native `ServiceBusSessionProcessor` (push model).** The SDK offers a higher-level processor that
+pushes session messages to a callback and manages accept/renew/settle internally. Rejected for
+this Initiative because:
+
+- It is a **push** model, whereas every receiver in Chatter is **pull**. Adopting it would force a
+  new push-dispatch seam into the broker-agnostic core (`Chatter.MessageBrokers`) so a pushed
+  message could reach the core's dispatch path — exactly the core change the PRD declares out of
+  scope.
+- It would **split the receive architecture**: the system would have one push receiver (sessions)
+  and pull receivers (everything else), each with separate concurrency, recovery, and teardown
+  behavior, doubling the surface that must be reasoned about and tested.
+- It **overlaps deferred #147** (the broader push/processor direction), which is itself unscheduled.
+
+This is recorded as a **possible future direction** — if Chatter ever adopts a push-dispatch core
+seam, the session processor becomes attractive — but that is a larger architectural shift that
+**needs its own ADR** and is not undertaken here.
+
+## Component & responsibility view
+
+All new components live inside `Chatter.MessageBrokers.AzureServiceBus`; none alter the core.
+
+1. **Session message receiver adapter** — a new `IServiceBusMessageReceiver` implementation that
+   wraps a held SDK `ServiceBusSessionReceiver`. It owns: accepting the next session, FIFO receive
+   for the held session via the existing `ReceiveAsync` contract, settle (complete / abandon /
+   dead-letter) on the held session, a bounded session-lock renewal loop, non-fatal handling of a
+   lost session lock and of "no session available," and rolling to the next session. It exposes the
+   held session receiver through an internal accessor so the session-state extension can reach it.
+
+2. **Receiver registry session opt-in** — `ServiceBusReceiverRegistry` records, per registered
+   receiver, whether the entity requires a session, alongside the top-level-entity and
+   transaction-mode it already captures. New session-aware registration entry points
+   (`AddSessionQueueReceiver` / `AddSessionTopicSubscription`) register a receiver as session-mode.
+   The registry stays write-at-registration / read-at-client-build, as today.
+
+3. **Receiver factory branch** — `ServiceBusReceiver.CreateProductionReceiver` branches on the
+   registry's session flag for the receiver's entity: the session adapter when session-mode, the
+   existing `AzureSdkMessageReceiverAdapter` otherwise. The registry is injected into
+   `ServiceBusReceiver` while **preserving the existing `receiverFactory` test seam** (the internal
+   ctor that lets tests substitute an in-memory `IServiceBusMessageReceiver`).
+
+4. **Inbound surfacing** — `InboundBrokeredMessageFactory` surfaces the received message's
+   `SessionId` onto the message context as the **Group Id** header (`MessageContext.GroupId`), and
+   `ServiceBusReceiver.ReceiveMessageAsync` includes the held session receiver in the transaction
+   context `Container` so the session-state extension can resolve it during handling.
+
+5. **Session-state extension** — handler-context extension methods (Get / Set / Clear) over the
+   held session receiver retrieved from the context `Container`, exposed alongside the existing
+   `IMessageHandlerContext.AzureServiceBus()` surface. Session-state header keys are pinned on
+   `ASBMessageContext` next to the existing ASB header constants.
+
+## Key flows
+
+**Accept → serve FIFO → settle → renew → roll.** The pump calls the session adapter's
+`ReceiveAsync` exactly as it calls the non-session adapter; the adapter internalizes the session
+lifecycle:
+
+1. **Accept session.** With no session held, the adapter calls `AcceptNextSessionAsync` on the
+   shared client for the receiver's entity, obtaining a held `ServiceBusSessionReceiver`. It starts
+   the bounded lock-renewal loop for that session.
+2. **Serve FIFO one-at-a-time.** Each `ReceiveAsync` returns the next message from the held session
+   via the held receiver's `ReceiveMessageAsync`, preserving the existing single-message
+   `IServiceBusMessageReceiver` contract. The pump's per-message worker handles it; ordering is FIFO
+   because all messages come from the one held session and the pull cadence is serialized on the
+   loop thread.
+3. **Settle on the held session receiver.** Complete / Abandon / DeadLetter route to the **held
+   session receiver**, not a plain receiver — settlement happens under the session lock, so the
+   session's lock token is honored. This mirrors the existing adapter's "settle by received-message
+   object" invariant.
+4. **Bounded lock renewal.** While a session is held, a renewal loop calls
+   `RenewSessionLockAsync` periodically up to the configured ceiling so long-running processing
+   does not lose the lock.
+5. **Roll to next session.** On session drain (an empty receive), idle timeout, or no session
+   available, the adapter releases the current session (cancel renewal, close the session receiver)
+   and **returns null** from `ReceiveAsync`, so the pump simply re-polls and the adapter accepts the
+   next session on the following turn. Returning null is the established "nothing received this
+   turn" signal the pump already understands (it releases the slot and continues).
+
+## Contracts & data shapes across seams
+
+- **`SessionId` ↔ `MessageContext.GroupId`.** `SessionId` is the Azure Service Bus realization of
+  the AMQP / core **Group Id** term. Inbound, `InboundBrokeredMessageFactory` stamps the received
+  `SessionId` into the context under `MessageContext.GroupId`. Outbound, the existing
+  `SendOptions.WithGroupId` → `MessageContext.GroupId` → `OutboundBrokeredMessageExtensions.GetGroupId`
+  → SDK `ServiceBusMessage.SessionId` mapping (already present) is reused. **No `WithSessionId`
+  alias is introduced** — Group Id is the single canonical surface, matching the existing
+  send-side mapping and the suite glossary.
+- **Held session receiver in the context `Container`.** `ServiceBusReceiver.ReceiveMessageAsync`
+  includes the held `ServiceBusSessionReceiver` (via the internal accessor) in the message's
+  transaction-context `Container`. The session-state extension resolves it from there, so a handler
+  reaches session state without an Azure-specific parameter on its own signature.
+- **`IServiceBusMessageReceiver` unchanged.** The session adapter satisfies the existing port shape
+  (receive returns one `ServiceBusReceivedMessage`; settle is by message object). The pump and
+  `ServiceBusReceiver` are agnostic to which adapter is behind the port.
+
+## Concurrency & lock-renewal design
+
+- A held session owns **one `CancellationTokenSource` and one renewal `Task`**. The renewal task
+  loops calling `RenewSessionLockAsync` on a cadence derived from the session lock duration, until
+  the ceiling is reached or the session is released.
+- The renewal CTS is **cancelled before the session receiver is closed** on every roll/release path
+  (drain, idle, lock loss, teardown), so no renewal call races a closing/closed session receiver.
+- The ceiling is the configured `MaxSessionLockRenewalDuration`; once reached, renewal stops and the
+  session is allowed to expire/roll naturally rather than being held forever.
+- **Option (a) fallback understanding:** if bounded programmatic renewal proves unworkable against a
+  given target, the documented fallback is to rely on the entity's `LockDuration` alone (no
+  programmatic renewal), accepting that a single message's processing must complete within
+  `LockDuration`. This is recorded as the fallback design, not the primary path.
+
+## Reliability & settlement
+
+- The existing reliability paths — `TransactionMode.FullAtomicityViaInfrastructure` and
+  `EnableCrossEntityTransactions` on the shared `ServiceBusClient` — are **reused unchanged**. A
+  session receiver still settles through the same code in `ServiceBusReceiver` (the `_receiveMode`
+  PeekLock/ReceiveAndDelete gate, the cross-entity-transaction enlistment, the dead-letter
+  description cap), with the held session receiver as the settlement target.
+- **Cross-entity transaction under session:** when cross-entity transactions are on, the send +
+  the session settle enlist in one transaction on the shared client exactly as for a non-session
+  receiver; the single-top-level-entity startup guard in
+  `ResolveEffectiveCrossEntityTransactions` continues to apply to session receivers.
+
+## Edge cases
+
+- **SessionLockLost.** Treated as **non-fatal**: the adapter releases the session (cancel renewal,
+  close session receiver) and recovers to accept the next session. It is **never** raised as
+  `CriticalReceiverException` — losing a lock is an expected operational event, not a
+  receiver-stopping fault. This deliberately differs from the cross-entity-transaction rejection,
+  which **is** critical.
+- **No session available.** `AcceptNextSessionAsync` failing to lock a session
+  (`SessionCannotBeLocked`) means the entity has no available session right now. The adapter
+  returns **null** from `ReceiveAsync` so the pump re-polls; no error, no fault.
+- **Idle rollover.** A held session that yields no message within the configured
+  `SessionIdleTimeout` is released and the adapter rolls to the next session (return null, re-poll).
+- **`TransactionMode.None` (ReceiveAndDelete).** Explicit settlement does not apply in
+  receive-and-delete mode; the existing `_receiveMode != PeekLock` guards in Ack/Nack/Deadletter
+  already short-circuit and are honored for the session adapter too, so no settle is attempted
+  against a session held in receive-and-delete mode.
+- **Non-session message invoking the session-state extension.** Calling Get/Set/Clear while
+  handling a message that was not received through a session (no session receiver in the
+  `Container`) fails with a **predictable `InvalidOperationException`** that names the misuse, rather
+  than silently no-op'ing or corrupting state.
+- **Teardown while a session is held.** On `StopReceiver` / dispose while a session is held, the
+  renewal CTS is cancelled and the held session receiver is closed as part of the adapter's
+  `CloseAsync`, mirroring the existing adapter's close-and-null discipline so the pump's
+  quiesce-before-dispose contract holds.
+
+## Configuration
+
+Two new knobs on **Service Bus Options** (`ServiceBusOptions` + `ServiceBusOptionsBuilder`),
+following the existing nullable-backing-field "fluent call wins over config in either direction"
+pattern used for `MaxConcurrentCalls` / `PrefetchCount` / `EnableCrossEntityTransactions`:
+
+- **`SessionIdleTimeout`** — how long a held session may yield no message before it is released and
+  the receiver rolls to the next session.
+- **`MaxSessionLockRenewalDuration`** — the ceiling on how long a held session's lock is renewed
+  for long-running processing.
+
+A **max-concurrent-sessions** knob is intentionally **N/A**: the model is one session at a time per
+receiver instance; cross-session concurrency scales by instance count, not configuration.
+
+## Testing strategy
+
+- **Unit (no Docker).** Prove SessionId → Group Id surfacing in `InboundBrokeredMessageFactory`;
+  prove the `CreateProductionReceiver` factory branch selects the session adapter for a session-mode
+  registry entry and the existing adapter otherwise; prove settle/roll behavior on the adapter where
+  the `receiverFactory` / `IServiceBusMessageReceiver` seam permits an in-memory double. These run in
+  PR CI.
+- **Emulator integration (Docker-gated, skip when unavailable).** A new `RequiresSession` queue in
+  the emulator `Config.json`; `PipelineSessionTests` proving FIFO ordering within a session and a
+  full session-state read/write/clear round-trip across messages in one session; reuse of the
+  existing `ServiceBusEmulatorFixture` / `RequiresDockerFact` skip-when-unavailable discipline so a
+  no-Docker run stays green.
+- **Sealed-type boundary.** The SDK `ServiceBusSessionReceiver` is **sealed** and cannot be mocked,
+  so adapter behavior that depends directly on it (accept, renew, settle on the concrete session
+  receiver) is covered at the emulator integration level rather than by a unit double. The unit
+  seam covers everything reachable through the `IServiceBusMessageReceiver` port.
+
+## Risks
+
+- **Renewal-loop concurrency.** A renewal task racing a session close/roll is the primary
+  concurrency risk; mitigated by the one-CTS-per-session design and cancelling renewal **before**
+  closing the session receiver on every release path.
+- **Sealed-SDK testability.** `ServiceBusSessionReceiver` being sealed limits unit isolation;
+  mitigated by pushing that coverage to emulator integration tests and keeping the unit-testable
+  logic behind the `IServiceBusMessageReceiver` port.
+- **Emulator session support.** Whether the Azure Service Bus emulator supports session-enabled
+  entities is an open verification item; if it does not, the session integration tests follow the
+  existing skip-when-unavailable pattern and FIFO/state coverage relies on the documented manual /
+  real-namespace path.
+
+## Version impact
+
+`Chatter.MessageBrokers.AzureServiceBus` is bumped **minor**, `1.3.0 → 1.4.0`. The change is
+**additive and backward compatible**: new opt-in session registration entry points, two new
+optional Service Bus Options knobs, and new handler-context session-state extensions. No existing
+public surface changes, and non-session receivers/senders behave identically.

--- a/docs/prds/asb-message-sessions.md
+++ b/docs/prds/asb-message-sessions.md
@@ -1,0 +1,81 @@
+# PRD: Azure Service Bus Message Sessions
+
+## Problem Statement
+Chatter's Azure Service Bus adapter receives brokered messages without any awareness of
+sessions. A consumer that needs related messages processed in strict FIFO order per a
+correlation key — the classic Azure Service Bus session guarantee — cannot get it through
+Chatter today: messages on a session-enabled queue or subscription are interleaved or
+rejected, the inbound `SessionId` is invisible to handlers, producers have no first-class
+way to address a session, and there is nowhere to keep per-session state across messages.
+Teams building stateful, ordered workflows on Azure Service Bus (issue #209) must drop out
+of Chatter's abstraction to use the raw SDK, losing the handler, recovery, and reliability
+semantics the rest of the suite provides. This matters now because session-ordered
+processing is a core Azure Service Bus capability that the adapter's existing pull-based
+receive model can support without disturbing the broker-agnostic core.
+
+## Solution
+Add Azure Service Bus message-session support entirely within the Azure Service Bus adapter,
+so a consumer can opt a queue receiver or topic subscription into session mode and have
+related messages delivered in FIFO order per `SessionId`. Inbound brokered messages surface
+their `SessionId` to handlers through the established Group Id term, so handlers correlate
+work by session with no new core concept. Producers set the session on an outbound message
+through the existing Group Id surface, routing it to the correct session. Handler authors can
+read, write, and clear durable per-session state during handling. Operators can tune session
+behavior — how long an idle session is held before rolling to the next, and the ceiling on how
+long a session lock is renewed for long-running work. A session-mode receiver processes one
+session at a time, holding it for FIFO delivery and then rolling to the next; broader
+throughput is achieved by running more receiver instances, not by in-process multi-session
+parallelism. The adapter provisions nothing: session-enabled entities are created externally,
+consistent with the module's existing no-auto-provision stance.
+
+## User Stories
+As a consumer, I want to configure a receiver for a session-enabled queue/subscription, so that related messages are processed FIFO per SessionId.
+As a consumer, I want inbound brokered messages to expose their SessionId, so that handlers can correlate work by session.
+As a producer, I want to set SessionId on outbound brokered messages, so that they route to the correct session.
+As a handler author, I want to read, write, and clear session state during handling, so that I can maintain stateful per-session processing.
+As an operator, I want to tune session behavior (idle timeout, lock-renewal ceiling), so that both short and long-running sessions behave correctly.
+
+## Acceptance Criteria
+- A queue receiver or topic subscription can be registered in session mode, and once registered it accepts and processes messages from a session-enabled entity.
+- Messages carrying the same SessionId are delivered to the handler in the order they were enqueued (FIFO within a session); only one session is processed at a time per receiver instance.
+- An inbound brokered message exposes its SessionId to the handler through the Group Id term, so a handler reads the session without referencing any Azure-specific session concept.
+- An outbound brokered message whose Group Id is set is routed to the matching session on the target entity.
+- During handling, a handler can read existing session state, write new session state, and clear session state, and those effects are durable for subsequent messages in the same session.
+- An operator can configure the idle timeout after which a held session with no further messages is released and the receiver rolls to the next session, and the ceiling on how long a held session's lock is renewed during long-running processing.
+- Settlement (complete, abandon, dead-letter) of a session message succeeds against the held session and honors the configured transaction mode, including the receive-and-delete mode where explicit settlement does not apply.
+- A lost session lock is treated as a recoverable condition: the receiver releases the session and resumes with the next session rather than failing fatally and stopping the receiver.
+- When no session is available to accept, the receiver yields without error and re-polls, so an empty session-enabled entity does not fault the receiver.
+- Invoking the session-state capability while handling a non-session message fails predictably with a clear error rather than corrupting state or silently succeeding.
+- Existing non-session receivers, senders, and reliability/atomicity behavior are unchanged; enabling sessions is additive and opt-in.
+
+## Implementation Decisions
+- Session support is realized entirely within the Azure Service Bus adapter. No change is made to the broker-agnostic core abstractions beyond carrying the already-existing Group Id term and surfacing session state through the handler context container. This is a hard boundary: pressure to add a core push-dispatch concept or a new core session contract is a signal to stop and re-evaluate, not to proceed.
+- A session-mode receiver processes a single session at a time: it accepts a session, delivers that session's messages FIFO through the adapter's existing pull-based receive contract, settles on the held session, and rolls to the next session on drain, idle, or lock loss. Cross-session concurrency is an operational concern solved by running additional receiver instances, not an in-process multi-session feature.
+- The Azure Service Bus `SessionId` is the broker realization of the suite's existing Group Id (AMQP group-id) term. Inbound, the received message's session is surfaced as the Group Id on the message context; outbound, the existing Group Id surface sets the session. No new "session id" alias is introduced on the producing or consuming API — Group Id is the single canonical term.
+- Per-session durable state is exposed to handlers through the held session, surfaced via the handler context container, so a handler reads, writes, and clears state without taking an Azure-specific dependency in its own signature. The session-state capability is only valid while handling a session message; using it outside that context is a predictable error.
+- Session lock renewal is bounded by an operator-configured ceiling so a long-running session is kept alive without renewing indefinitely. Idle session hold is bounded by an operator-configured timeout after which the receiver rolls to the next session.
+- A lost session lock is a non-fatal, recoverable condition — the session is released and the receiver recovers — and is never escalated to the fatal receiver-stopping failure class. "No session available to accept" is likewise non-fatal: the receiver yields nothing and re-polls.
+- Existing reliability and settlement behavior — including the full-atomicity-via-infrastructure and cross-entity-transaction paths — is reused unchanged for session receivers; settlement occurs against the held session.
+- A maximum-concurrent-sessions knob is intentionally not part of this Initiative; one session at a time per receiver is the model, and concurrency scales by instance count.
+
+## Testing Decisions
+- Contract/unit level (no broker, no Docker): prove that an inbound session message surfaces its SessionId as Group Id, that the receiver-factory selects the session path when a receiver is registered in session mode, and that settle/roll behavior holds where the test seam permits substituting the session receiver. These run in PR CI.
+- End-to-end level (Azure Service Bus emulator, gated on Docker availability and skipped when unavailable): prove FIFO ordering within a session, a full session-state read/write/clear round-trip across messages in one session, and correct behavior against a session-enabled (RequiresSession) entity. These are excluded from no-Docker runs so a plain test run stays green.
+- The testability boundary of the sealed SDK session-receiver type is acknowledged: behavior that cannot be unit-isolated because of that boundary is covered at the emulator integration level instead.
+
+## Success Metrics
+- A consumer can stand up session-ordered brokered messaging in a Chatter app using only the documented session-mode registration and externally-provisioned session-enabled entities, with no handler changes beyond reading the Group Id and using the session-state capability.
+- Messages within a session are observed in strict FIFO order, and per-session state survives across messages in the same session, in emulator integration tests.
+- A lost session lock or an empty session-enabled entity never stops the receiver in integration scenarios.
+- Existing non-session functionality shows no behavioral regression after the change ships.
+
+## Out of Scope
+- Sessions for other broker adapters (SQL Service Broker, RabbitMQ).
+- Core CQRS/MessageBrokers abstraction changes beyond carrying SessionId / session state.
+- Native ServiceBusSessionProcessor and in-process multi-session parallelism (explicitly rejected; cross-session parallelism is achieved by running more receiver instances).
+- Auto-provisioning of session-enabled entities (manual provisioning required, consistent with the module's existing no-auto-provision stance).
+
+## Further Notes
+- A push-based native `ServiceBusSessionProcessor` was considered and rejected for this Initiative because it would force a new push-dispatch seam into the broker-agnostic core and split the receive architecture; it is recorded as a possible future direction that would need its own ADR. The accompanying solution-architecture document captures that rationale in HOW terms.
+- Verification item carried into implementation: confirm the Azure Service Bus emulator supports session-enabled entities during the integration test run; if it does not, the session integration tests follow the same skip-when-unavailable discipline as the existing emulator suite.
+- Internal mechanics (single-session accept loop, the lock-renewal task, how the held session receiver is surfaced) are HOW and belong to the directive and the solution-architecture document, not this PRD.

--- a/src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/CONTEXT.md
@@ -6,27 +6,45 @@ Azure Service Bus implementation of the Chatter.MessageBrokers interfaces for se
 
 **Queue Receiver**: Receiver bound to an ASB queue for Commands (`AddQueueReceiver<TMessage>`).
 
+**Session Queue Receiver**: A Queue Receiver opted into session mode (`AddSessionQueueReceiver<TMessage>`). Processes one session at a time, delivering that session's messages in strict FIFO order per Group Id (SessionId). Broader throughput is achieved by running additional receiver instances; there is no in-process multi-session parallelism knob.
+
 **Topic Subscription**: Receiver bound to an ASB topic subscription for Events (`AddTopicSubscription<TMessage>`).
+
+**Session Topic Subscription**: A Topic Subscription opted into session mode (`AddSessionTopicSubscription<TMessage>`). Same single-session-at-a-time, FIFO-per-Group-Id semantics as the Session Queue Receiver.
 
 **Service Bus Sender**: Azure Service Bus realization of the message sender, publishing to queues/topics; outbound handler API via `IMessageHandlerContext.AzureServiceBus()`.
 
-**Service Bus Options**: Configuration (connection, paths, retry, circuit breaker) for the Azure Service Bus connection.
+**Service Bus Options**: Configuration (connection, paths, retry, circuit breaker, session knobs) for the Azure Service Bus connection.
 
 **Service Bus Retry**: ASB-specific Retry recovery policy applied during receiving.
 
 **Service Bus Circuit Breaker**: ASB-specific Circuit Breaker recovery policy applied during receiving.
 
+**Session**: An Azure Service Bus session-enabled receive mode. A held session owns the FIFO delivery of all messages sharing the same SessionId until the session is drained, released on idle timeout, or rolled due to a lost session lock. Sessions are provisioned externally; the adapter neither creates nor auto-enables session-capable entities.
+
+**Session State**: Durable, per-session binary payload stored on the Azure Service Bus entity for the currently held session. Readable and writable during handler execution via `GetSessionStateAsync` / `SetSessionStateAsync` / `ClearSessionStateAsync`. Only available while handling a message received through a Session Queue Receiver or Session Topic Subscription; invoking it for a non-session message throws `InvalidOperationException`.
+
+**Group Id ↔ SessionId realization**: The Azure Service Bus `SessionId` is the broker realization of the suite's existing Group Id (AMQP group-id) term. Inbound, a session message's `SessionId` is surfaced under `MessageContext.GroupId`; outbound, `SendOptions.WithGroupId` sets `ServiceBusMessage.SessionId`. No `WithSessionId` alias is introduced — Group Id is the single canonical surface.
+
+**Session Idle Timeout**: Operator knob (`SessionIdleTimeout` / `WithSessionIdleTimeout`) controlling how long a held session may yield no message before it is released and the receiver rolls to the next session. Default: 60 seconds. Fluent call wins over configuration.
+
+**Max Session Lock Renewal Duration**: Operator knob (`MaxSessionLockRenewalDuration` / `WithMaxSessionLockRenewalDuration`) setting the ceiling on how long a held session's lock is renewed for long-running processing. Once reached, renewal stops and the session is allowed to expire or roll naturally. Default: 5 minutes. Fluent call wins over configuration.
+
 ## Relationships
 
 - Implements the receiver/sender/path interfaces defined in the Message Brokers context.
-- Commands map to a Queue Receiver; Events map to a Topic Subscription.
-- Service Bus Options configure recovery (Retry, Circuit Breaker) for receiving.
+- Commands map to a Queue Receiver (or Session Queue Receiver in session mode); Events map to a Topic Subscription (or Session Topic Subscription in session mode).
+- Service Bus Options configure recovery (Retry, Circuit Breaker) and session behavior (Session Idle Timeout, Max Session Lock Renewal Duration) for receiving.
 - Authentication is supplied by the Azure Service Bus Auth context.
+- Session State and inbound Group Id (SessionId) surfacing are entirely within this adapter; no core Message Brokers or CQRS concept is changed.
 
 ## Example dialogue
 
 > **Dev:** "How do I point Chatter at my Service Bus namespace?"
 > **Domain expert:** "Configure Service Bus Options with the connection and paths; the Service Bus Receiver and Sender wire into the broker abstraction automatically."
+
+> **Dev:** "How do I process session messages in strict order per session?"
+> **Domain expert:** "Register the queue or subscription with `AddSessionQueueReceiver` or `AddSessionTopicSubscription`. The inbound SessionId is available in the handler as `MessageContext.GroupId`. For outbound messages targeting a session, set `WithGroupId` on `SendOptions` — and also set `WithPartitionKey` to the same value, because Azure Service Bus requires `PartitionKey == SessionId` for session messages."
 
 ## Flagged ambiguities
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/ASBMessageContext.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/ASBMessageContext.cs
@@ -8,5 +8,6 @@
         public static readonly string To = $"{MessageContext.ChatterBaseHeader}.To";
         public static readonly string ViaPartitionKey = $"{MessageContext.ChatterBaseHeader}.ViaPartitionKey";
         public static readonly string PartitionKey = $"{MessageContext.ChatterBaseHeader}.PartitionKey";
+        public static readonly string SessionState = $"{MessageContext.ChatterBaseHeader}.SessionState";
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -12,6 +12,17 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+## [1.4.0] - 2026-06-14
+
+### Added
+
+- Single-session-at-a-time receiver support via `AddSessionQueueReceiver` and `AddSessionTopicSubscription` — dispatches one Azure Service Bus session receiver per accepted session, guaranteeing FIFO ordering within a `SessionId`.
+- Inbound `SessionId` is surfaced on `MessageContext.GroupId` so handlers can read the session affinity without touching SDK types.
+- Durable per-session state via `GetSessionStateAsync`, `SetSessionStateAsync`, and `ClearSessionStateAsync` on the session context — backed by the Azure Service Bus session-state store.
+- `SessionIdleTimeout` and `MaxSessionLockRenewalDuration` knobs on the session receiver options to control how long an idle session is held open and how aggressively the session lock is renewed.
+
+### Fixed
+
 - (F6) A parked Azure Service Bus receive is now unblocked on teardown — the receive-loop `CancellationToken` is threaded through the internal receive port into the SDK `ReceiveMessageAsync(maxWaitTime, cancellationToken)` overload, and a shutdown-cancelled receive is swallowed quietly (returns `null`, no error log, no settle). Prevents teardown hangs when the broker or network is stalled.
 
 ## [1.3.0] - 2026-06-09

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/CHANGELOG.md
@@ -24,6 +24,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 ### Fixed
 
 - (F6) A parked Azure Service Bus receive is now unblocked on teardown — the receive-loop `CancellationToken` is threaded through the internal receive port into the SDK `ReceiveMessageAsync(maxWaitTime, cancellationToken)` overload, and a shutdown-cancelled receive is swallowed quietly (returns `null`, no error log, no settle). Prevents teardown hangs when the broker or network is stalled.
+- (F7) Session-enabled topic subscriptions now accept sessions via the correct `AcceptNextSessionAsync(topicName, subscriptionName)` overload. The session entity is carried as a structured `(topic, subscription)` identity through the session path so a topic-subscription receiver is never mis-addressed as a flat queue name.
 
 ## [1.3.0] - 2026-06-09
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.AzureServiceBus</PackageId>
-    <Version>1.3.0</Version>
+    <Version>1.4.0</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for Azure Service Bus.</Description>

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Context/MessageHandlerContextExtensions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Context/MessageHandlerContextExtensions.cs
@@ -1,5 +1,9 @@
-﻿using Chatter.MessageBrokers;
+﻿using Azure.Messaging.ServiceBus;
+using Chatter.MessageBrokers;
 using Chatter.MessageBrokers.Context;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Chatter.CQRS.Context
 {
@@ -14,6 +18,56 @@ namespace Chatter.CQRS.Context
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Gets the durable per-session state for the Azure Service Bus session that delivered the message
+        /// being handled. Only available while handling a message received through a session-enabled receiver.
+        /// </summary>
+        /// <param name="context">The context of the message handler</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+        /// <returns>The session state as <see cref="BinaryData"/>, or null if no session state has been set.</returns>
+        /// <exception cref="InvalidOperationException">Thrown when the message was not received through a session-enabled receiver.</exception>
+        public static Task<BinaryData> GetSessionStateAsync(this IMessageHandlerContext context, CancellationToken cancellationToken = default)
+            => GetHeldSessionReceiver(context).GetSessionStateAsync(cancellationToken);
+
+        /// <summary>
+        /// Sets the durable per-session state for the Azure Service Bus session that delivered the message
+        /// being handled. Only available while handling a message received through a session-enabled receiver.
+        /// </summary>
+        /// <param name="context">The context of the message handler</param>
+        /// <param name="sessionState">The session state to persist for the session.</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+        /// <returns>An awaitable <see cref="Task"/></returns>
+        /// <exception cref="InvalidOperationException">Thrown when the message was not received through a session-enabled receiver.</exception>
+        public static Task SetSessionStateAsync(this IMessageHandlerContext context, BinaryData sessionState, CancellationToken cancellationToken = default)
+            => GetHeldSessionReceiver(context).SetSessionStateAsync(sessionState, cancellationToken);
+
+        /// <summary>
+        /// Clears the durable per-session state for the Azure Service Bus session that delivered the message
+        /// being handled. Only available while handling a message received through a session-enabled receiver.
+        /// </summary>
+        /// <param name="context">The context of the message handler</param>
+        /// <param name="cancellationToken">A <see cref="CancellationToken"/></param>
+        /// <returns>An awaitable <see cref="Task"/></returns>
+        /// <exception cref="InvalidOperationException">Thrown when the message was not received through a session-enabled receiver.</exception>
+        public static Task ClearSessionStateAsync(this IMessageHandlerContext context, CancellationToken cancellationToken = default)
+            => GetHeldSessionReceiver(context).SetSessionStateAsync(null, cancellationToken);
+
+        // Resolves the held ServiceBusSessionReceiver that STEP-004 included in the transaction context
+        // Container for session messages. Non-session messages have no session receiver in the Container,
+        // so session-state access on them fails fast with a predictable misuse error rather than a no-op or NRE.
+        private static ServiceBusSessionReceiver GetHeldSessionReceiver(IMessageHandlerContext context)
+        {
+            var transactionContext = context.GetTransactionContext();
+            if (transactionContext != null
+                && transactionContext.Container.TryGet<ServiceBusSessionReceiver>(out var sessionReceiver)
+                && sessionReceiver != null)
+            {
+                return sessionReceiver;
+            }
+
+            throw new InvalidOperationException("Azure Service Bus session state is only available for session-enabled receivers.");
         }
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
@@ -192,6 +192,42 @@ namespace Microsoft.Extensions.DependencyInjection
             return builder;
         }
 
+        // Session-mode sibling of AddTopicSubscription: registers a session-enabled topic subscription. Mirrors
+        // AddTopicSubscription exactly, marking the receiver session-mode in the registry (RequiresSession=true)
+        // so ServiceBusReceiver.CreateProductionReceiver selects the session adapter for the topic.
+        public static ServiceBusOptionsBuilder AddSessionTopicSubscription<TMessage>(this ServiceBusOptionsBuilder builder,
+                                                                                     string topicName,
+                                                                                     string subscriptionName,
+                                                                                     string errorQueuePath = null,
+                                                                                     string description = null,
+                                                                                     TransactionMode? transactionMode = null,
+                                                                                     int maxReceiveAttempts = 10)
+            where TMessage : class, IEvent
+        {
+            // The TOPIC is the top-level entity Azure Service Bus pins a cross-entity transaction to; two
+            // subscriptions on the same topic share one top-level entity.
+            GetOrAddReceiverRegistry(builder.Services).Register(topicName, transactionMode, requiresSession: true);
+            builder.Services.AddReceiver<TMessage>(subscriptionName, errorQueuePath, description, topicName, transactionMode, ASBMessageContext.InfrastructureType, maxReceiveAttempts: maxReceiveAttempts);
+            return builder;
+        }
+
+        // Session-mode sibling of AddQueueReceiver: registers a session-enabled queue receiver. Mirrors
+        // AddQueueReceiver exactly, marking the receiver session-mode in the registry (RequiresSession=true) so
+        // ServiceBusReceiver.CreateProductionReceiver selects the session adapter for the queue.
+        public static ServiceBusOptionsBuilder AddSessionQueueReceiver<TMessage>(this ServiceBusOptionsBuilder builder,
+                                                                                 string queueName,
+                                                                                 string errorQueuePath = null,
+                                                                                 string description = null,
+                                                                                 TransactionMode? transactionMode = null,
+                                                                                 int maxReceiveAttempts = 10)
+            where TMessage : class, ICommand
+        {
+            // The QUEUE is itself the top-level entity Azure Service Bus pins a cross-entity transaction to.
+            GetOrAddReceiverRegistry(builder.Services).Register(queueName, transactionMode, requiresSession: true);
+            builder.Services.AddReceiver<TMessage>(queueName, errorQueuePath, description, queueName, transactionMode, ASBMessageContext.InfrastructureType, maxReceiveAttempts: maxReceiveAttempts);
+            return builder;
+        }
+
         // Resolves the single ServiceBusReceiverRegistry instance shared across all AddQueueReceiver/
         // AddTopicSubscription calls and the shared-client factory, registering it on first use. The instance
         // is captured directly into the singleton descriptor so the same object is both written here (at

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
@@ -172,8 +172,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class, IEvent
         {
             // The TOPIC is the top-level entity Azure Service Bus pins a cross-entity transaction to; two
-            // subscriptions on the same topic share one top-level entity.
-            GetOrAddReceiverRegistry(builder.Services).Register(topicName, transactionMode);
+            // subscriptions on the same topic share one top-level entity. The SUBSCRIPTION name is the
+            // receiver path that distinguishes this receiver from another subscription on the same topic for
+            // the per-receiver session lookup.
+            GetOrAddReceiverRegistry(builder.Services).Register(topicName, subscriptionName, transactionMode);
             builder.Services.AddReceiver<TMessage>(subscriptionName, errorQueuePath, description, topicName, transactionMode, ASBMessageContext.InfrastructureType, maxReceiveAttempts: maxReceiveAttempts);
             return builder;
         }
@@ -186,8 +188,9 @@ namespace Microsoft.Extensions.DependencyInjection
                                                                           int maxReceiveAttempts = 10)
             where TMessage : class, ICommand
         {
-            // The QUEUE is itself the top-level entity Azure Service Bus pins a cross-entity transaction to.
-            GetOrAddReceiverRegistry(builder.Services).Register(queueName, transactionMode);
+            // The QUEUE is itself the top-level entity Azure Service Bus pins a cross-entity transaction to,
+            // and is its own receiver path for the per-receiver session lookup.
+            GetOrAddReceiverRegistry(builder.Services).Register(queueName, queueName, transactionMode);
             builder.Services.AddReceiver<TMessage>(queueName, errorQueuePath, description, queueName, transactionMode, ASBMessageContext.InfrastructureType, maxReceiveAttempts: maxReceiveAttempts);
             return builder;
         }
@@ -205,8 +208,10 @@ namespace Microsoft.Extensions.DependencyInjection
             where TMessage : class, IEvent
         {
             // The TOPIC is the top-level entity Azure Service Bus pins a cross-entity transaction to; two
-            // subscriptions on the same topic share one top-level entity.
-            GetOrAddReceiverRegistry(builder.Services).Register(topicName, transactionMode, requiresSession: true);
+            // subscriptions on the same topic share one top-level entity. The SUBSCRIPTION name is the
+            // receiver path that marks THIS subscription session-mode without affecting a sibling normal
+            // subscription on the same topic.
+            GetOrAddReceiverRegistry(builder.Services).Register(topicName, subscriptionName, transactionMode, requiresSession: true);
             builder.Services.AddReceiver<TMessage>(subscriptionName, errorQueuePath, description, topicName, transactionMode, ASBMessageContext.InfrastructureType, maxReceiveAttempts: maxReceiveAttempts);
             return builder;
         }
@@ -222,8 +227,9 @@ namespace Microsoft.Extensions.DependencyInjection
                                                                                  int maxReceiveAttempts = 10)
             where TMessage : class, ICommand
         {
-            // The QUEUE is itself the top-level entity Azure Service Bus pins a cross-entity transaction to.
-            GetOrAddReceiverRegistry(builder.Services).Register(queueName, transactionMode, requiresSession: true);
+            // The QUEUE is itself the top-level entity Azure Service Bus pins a cross-entity transaction to,
+            // and is its own receiver path for the per-receiver session lookup.
+            GetOrAddReceiverRegistry(builder.Services).Register(queueName, queueName, transactionMode, requiresSession: true);
             builder.Services.AddReceiver<TMessage>(queueName, errorQueuePath, description, queueName, transactionMode, ASBMessageContext.InfrastructureType, maxReceiveAttempts: maxReceiveAttempts);
             return builder;
         }
@@ -300,7 +306,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 // registered BOTH via attribute and explicit AddQueueReceiver/AddTopicSubscription is not
                 // double-counted as a distinct top-level entity.
                 var topLevelEntity = InferTopLevelEntity(receiverOptions.SendingPath, receiverOptions.MessageReceiverPath);
-                receiverRegistry.Register(topLevelEntity, receiverOptions.TransactionMode);
+                receiverRegistry.Register(topLevelEntity, receiverOptions.MessageReceiverPath, receiverOptions.TransactionMode);
             }
         }
 

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ChatterAzureServiceBusExtensions.cs
@@ -294,7 +294,24 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 // (MaxConcurrentCalls) Stamp the finalized global value onto the retained live instance, before
                 // any hosted-service pumps. Visible at receiver init via ReceiverOptions.MaxConcurrentCalls.
-                receiverOptions.MaxConcurrentCalls = options.MaxConcurrentCalls;
+                //
+                // (P1 session-concurrency clamp) A session-mode receiver holds a SINGLE ServiceBusSessionReceiver
+                // and must serve at most ONE in-flight message at a time: the core BrokeredMessageReceiver spawns
+                // MaxConcurrentCalls workers that all call ReceiveAsync on that one held session receiver, so >1
+                // would pull from the single session concurrently and break FIFO-per-session ordering and
+                // session-state consistency. Clamp this receiver's live MaxConcurrentCalls to 1 (overriding the
+                // global value) so one worker maps to one in-flight message. Non-session receivers keep the global
+                // value. The clamp is a no-op when the global value is already 1. The session flag was recorded on
+                // receiverRegistry by AddSessionQueueReceiver/AddSessionTopicSubscription during the options
+                // delegate, which runs BEFORE this method, so the per-receiver lookup is populated here.
+                if (receiverRegistry.RequiresSession(receiverOptions.MessageReceiverPath, receiverOptions.SendingPath))
+                {
+                    receiverOptions.MaxConcurrentCalls = 1;
+                }
+                else
+                {
+                    receiverOptions.MaxConcurrentCalls = options.MaxConcurrentCalls;
+                }
 
                 // (F3) Infer the ASB top-level entity (queue vs topic) using the same SendingPath/ReceiverPath
                 // convention as AzureServiceBusEntityPathBuilder: a queue receiver has SendingPath empty or equal

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
@@ -18,9 +18,12 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
         // Records a configured receiver. topLevelEntity is the queue name for a queue receiver or the TOPIC
         // name for a subscription — the unit Azure Service Bus pins a cross-entity transaction to. Two
         // subscriptions on the same topic share one top-level entity and so do not count as distinct.
-        public void Register(string topLevelEntity, TransactionMode? transactionMode)
+        // requiresSession marks a receiver as session-mode (set true by AddSessionQueueReceiver/
+        // AddSessionTopicSubscription); the receiver factory reads it at client-build time to select the
+        // session adapter for the entity.
+        public void Register(string topLevelEntity, TransactionMode? transactionMode, bool requiresSession = false)
         {
-            _receivers.Add(new RegisteredReceiver(topLevelEntity, transactionMode));
+            _receivers.Add(new RegisteredReceiver(topLevelEntity, transactionMode, requiresSession));
         }
 
         // True when any configured receiver's EFFECTIVE transaction mode is FullAtomicityViaInfrastructure,
@@ -41,16 +44,26 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
+        // True when any receiver registered for the given top-level entity is session-mode, case-insensitive to
+        // match Azure Service Bus entity-name semantics (mirroring DistinctTopLevelEntities). The receiver
+        // factory (ServiceBusReceiver.CreateProductionReceiver) calls this at client-build time to select the
+        // session adapter for a session-mode entity and the existing adapter otherwise.
+        public bool RequiresSession(string topLevelEntity)
+            => _receivers.Any(r => r.RequiresSession
+                && string.Equals(r.TopLevelEntity, topLevelEntity, StringComparison.OrdinalIgnoreCase));
+
         private readonly struct RegisteredReceiver
         {
-            public RegisteredReceiver(string topLevelEntity, TransactionMode? transactionMode)
+            public RegisteredReceiver(string topLevelEntity, TransactionMode? transactionMode, bool requiresSession)
             {
                 TopLevelEntity = topLevelEntity;
                 TransactionMode = transactionMode;
+                RequiresSession = requiresSession;
             }
 
             public string TopLevelEntity { get; }
             public TransactionMode? TransactionMode { get; }
+            public bool RequiresSession { get; }
         }
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
@@ -1,5 +1,6 @@
 using Chatter.MessageBrokers.Receiving;
 using System;
+using Chatter.MessageBrokers;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -13,6 +14,16 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
     // never re-enters DI to inspect receivers.
     internal sealed class ServiceBusReceiverRegistry
     {
+        // INVARIANT: the per-receiver session key is the CANONICAL receiving path produced by
+        // AzureServiceBusEntityPathBuilder.GetMessageReceivingPath — the SAME shape core
+        // BrokeredMessageReceiver.StartReceiver rewrites options.MessageReceiverPath into before the ASB
+        // receiver factory runs. Storing and looking up under this single derived key closes the
+        // raw-(at-registration)-vs-formatted-(at-runtime) mismatch class by construction: a topic
+        // subscription's key is "<topic>/Subscriptions/<sub>" regardless of whether the receiver path
+        // arrived raw (registration / discovery clamp) or already formatted (runtime CreateProductionReceiver).
+        private static readonly IBrokeredMessagePathBuilder _pathBuilder = new AzureServiceBusEntityPathBuilder();
+        private const string SubscriptionsSegment = "Subscriptions";
+
         private readonly List<RegisteredReceiver> _receivers = new List<RegisteredReceiver>();
 
         // Records a configured receiver. topLevelEntity is the queue name for a queue receiver or the TOPIC
@@ -26,7 +37,8 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
         // THIS receiver (not every receiver sharing the top-level entity).
         public void Register(string topLevelEntity, string receiverPath, TransactionMode? transactionMode, bool requiresSession = false)
         {
-            _receivers.Add(new RegisteredReceiver(topLevelEntity, receiverPath, transactionMode, requiresSession));
+            var canonicalReceivingPath = CanonicalReceivingPath(topLevelEntity, receiverPath);
+            _receivers.Add(new RegisteredReceiver(topLevelEntity, canonicalReceivingPath, transactionMode, requiresSession));
         }
 
         // True when any configured receiver's EFFECTIVE transaction mode is FullAtomicityViaInfrastructure,
@@ -59,8 +71,9 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
         public bool RequiresSession(string receiverPath, string sendingPath)
         {
             var topLevelEntity = InferTopLevelEntity(sendingPath, receiverPath);
+            var canonicalReceivingPath = CanonicalReceivingPath(topLevelEntity, receiverPath);
             return _receivers.Any(r => r.RequiresSession
-                && string.Equals(r.MessageReceiverPath, receiverPath, StringComparison.OrdinalIgnoreCase)
+                && string.Equals(r.MessageReceiverPath, canonicalReceivingPath, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(r.TopLevelEntity, topLevelEntity, StringComparison.OrdinalIgnoreCase));
         }
 
@@ -69,6 +82,30 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
         // entity); a topic subscription's sending path is the distinct topic (the TOPIC is the top-level
         // entity). Used to derive the top-level component of the per-receiver session key from the receiver's
         // sending/receiver paths at lookup time.
+        // The single source of the per-receiver session key shape. Produces the CANONICAL receiving path for a
+        // receiver from its top-level entity (topic for a subscription; queue for a queue receiver) and its own
+        // receiver path, delegating to AzureServiceBusEntityPathBuilder.GetMessageReceivingPath so storage and
+        // lookup keys share ONE definition with the path core BrokeredMessageReceiver.StartReceiver rewrites
+        // MessageReceiverPath into at runtime. Queue / equal / blank top-level -> raw receiver name; topic
+        // subscription -> "<topic>/Subscriptions/<sub>".
+        //
+        // IDEMPOTENCY: GetMessageReceivingPath is NOT self-idempotent — re-formatting an already-formatted
+        // subscription path would yield "<topic>/Subscriptions/<topic>/Subscriptions/<sub>". The runtime
+        // CreateProductionReceiver lookup passes an ALREADY-FORMATTED receiver path (StartReceiver rewrote it),
+        // while registration / the discovery clamp pass a RAW subscription name. This guard short-circuits the
+        // already-formatted case so both inputs collapse to the same canonical key.
+        private static string CanonicalReceivingPath(string topLevelEntity, string receiverPath)
+        {
+            if (!string.IsNullOrWhiteSpace(topLevelEntity)
+                && receiverPath != null
+                && receiverPath.StartsWith($"{topLevelEntity}/{SubscriptionsSegment}/", StringComparison.OrdinalIgnoreCase))
+            {
+                return receiverPath;
+            }
+
+            return _pathBuilder.GetMessageReceivingPath(topLevelEntity, receiverPath);
+        }
+
         private static string InferTopLevelEntity(string sendingPath, string messageReceiverPath)
         {
             if (string.IsNullOrWhiteSpace(sendingPath) || string.Equals(sendingPath, messageReceiverPath, StringComparison.Ordinal))

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/DependencyInjection/ServiceBusReceiverRegistry.cs
@@ -18,12 +18,15 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
         // Records a configured receiver. topLevelEntity is the queue name for a queue receiver or the TOPIC
         // name for a subscription — the unit Azure Service Bus pins a cross-entity transaction to. Two
         // subscriptions on the same topic share one top-level entity and so do not count as distinct.
+        // receiverPath is the receiver's OWN path (queue name for a queue receiver; SUBSCRIPTION name for a
+        // subscription) — the discriminator that distinguishes two receivers sharing one top-level entity.
         // requiresSession marks a receiver as session-mode (set true by AddSessionQueueReceiver/
-        // AddSessionTopicSubscription); the receiver factory reads it at client-build time to select the
-        // session adapter for the entity.
-        public void Register(string topLevelEntity, TransactionMode? transactionMode, bool requiresSession = false)
+        // AddSessionTopicSubscription); the receiver factory reads it at client-build time via the
+        // per-receiver RequiresSession(receiverPath, sendingPath) lookup to select the session adapter for
+        // THIS receiver (not every receiver sharing the top-level entity).
+        public void Register(string topLevelEntity, string receiverPath, TransactionMode? transactionMode, bool requiresSession = false)
         {
-            _receivers.Add(new RegisteredReceiver(topLevelEntity, transactionMode, requiresSession));
+            _receivers.Add(new RegisteredReceiver(topLevelEntity, receiverPath, transactionMode, requiresSession));
         }
 
         // True when any configured receiver's EFFECTIVE transaction mode is FullAtomicityViaInfrastructure,
@@ -44,24 +47,50 @@ namespace Chatter.MessageBrokers.AzureServiceBus.DependencyInjection
                 .Distinct(StringComparer.OrdinalIgnoreCase)
                 .ToList();
 
-        // True when any receiver registered for the given top-level entity is session-mode, case-insensitive to
-        // match Azure Service Bus entity-name semantics (mirroring DistinctTopLevelEntities). The receiver
-        // factory (ServiceBusReceiver.CreateProductionReceiver) calls this at client-build time to select the
-        // session adapter for a session-mode entity and the existing adapter otherwise.
-        public bool RequiresSession(string topLevelEntity)
-            => _receivers.Any(r => r.RequiresSession
+        // True when the SPECIFIC receiver identified by (receiverPath, sendingPath) is session-mode. The match
+        // is PER-RECEIVER, not per-top-level-entity: a session-enabled subscription and a normal subscription
+        // on the SAME topic are distinct receivers, so the normal one is NOT routed through the session
+        // adapter. Both key components compare case-insensitively to match Azure Service Bus entity-name
+        // semantics (mirroring DistinctTopLevelEntities). receiverPath is the receiver's own path (queue name
+        // or subscription name) and sendingPath is the topic for a subscription (empty/equal-to-receiver-path
+        // for a queue); the same pair was supplied at registration. The receiver factory
+        // (ServiceBusReceiver.CreateProductionReceiver) calls this at client-build time, and STEP-002's
+        // concurrency clamp reuses it to ask "is this receiver path session-mode?".
+        public bool RequiresSession(string receiverPath, string sendingPath)
+        {
+            var topLevelEntity = InferTopLevelEntity(sendingPath, receiverPath);
+            return _receivers.Any(r => r.RequiresSession
+                && string.Equals(r.MessageReceiverPath, receiverPath, StringComparison.OrdinalIgnoreCase)
                 && string.Equals(r.TopLevelEntity, topLevelEntity, StringComparison.OrdinalIgnoreCase));
+        }
+
+        // Mirrors the registration-time top-level-entity inference (and ServiceBusReceiver.InferTopLevelEntity):
+        // a queue receiver's sending path is empty or equals its receiver path (the queue IS the top-level
+        // entity); a topic subscription's sending path is the distinct topic (the TOPIC is the top-level
+        // entity). Used to derive the top-level component of the per-receiver session key from the receiver's
+        // sending/receiver paths at lookup time.
+        private static string InferTopLevelEntity(string sendingPath, string messageReceiverPath)
+        {
+            if (string.IsNullOrWhiteSpace(sendingPath) || string.Equals(sendingPath, messageReceiverPath, StringComparison.Ordinal))
+            {
+                return messageReceiverPath;
+            }
+
+            return sendingPath;
+        }
 
         private readonly struct RegisteredReceiver
         {
-            public RegisteredReceiver(string topLevelEntity, TransactionMode? transactionMode, bool requiresSession)
+            public RegisteredReceiver(string topLevelEntity, string messageReceiverPath, TransactionMode? transactionMode, bool requiresSession)
             {
                 TopLevelEntity = topLevelEntity;
+                MessageReceiverPath = messageReceiverPath;
                 TransactionMode = transactionMode;
                 RequiresSession = requiresSession;
             }
 
             public string TopLevelEntity { get; }
+            public string MessageReceiverPath { get; }
             public TransactionMode? TransactionMode { get; }
             public bool RequiresSession { get; }
         }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptions.cs
@@ -1,5 +1,6 @@
 using Azure.Core;
 using Azure.Messaging.ServiceBus;
+using System;
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json.Serialization;
 
@@ -20,6 +21,17 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         // auto-enabled when a FullAtomicityViaInfrastructure receiver is registered; opt in explicitly here
         // only when a single-entity host needs cross-entity send+settle atomicity.
         public bool EnableCrossEntityTransactions { get; set; }
+        /// <summary>
+        /// How long a held session may yield no message before it is released and the receiver rolls
+        /// to the next session. Applies only to session-enabled receivers.
+        /// </summary>
+        public TimeSpan SessionIdleTimeout { get; set; } = TimeSpan.FromSeconds(60);
+        /// <summary>
+        /// The ceiling on how long a held session's lock is renewed for long-running processing.
+        /// Once reached, renewal stops and the session is allowed to expire or roll naturally.
+        /// Applies only to session-enabled receivers.
+        /// </summary>
+        public TimeSpan MaxSessionLockRenewalDuration { get; set; } = TimeSpan.FromMinutes(5);
         internal RetryPolicyConfiguation RetryPolicy { get; set; }
         [JsonIgnore]
         public ServiceBusRetryOptions RetryOptions { get; internal set; }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptionsBuilder.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Options/ServiceBusOptionsBuilder.cs
@@ -34,9 +34,19 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         // default value" — a plain bool defaulting to false could not tell those apart, which silently
         // dropped an explicit WithCrossEntityTransactions(false) when config bound true.
         private bool? _enableCrossEntityTransactions = null;
+        // INVARIANT: null means WithSessionIdleTimeout was never called, so the config-bound value is
+        // left untouched. A non-null value means the fluent method was called and its value overrides
+        // any config-bound value in EITHER direction (explicit 30 s overrides config 120 s).
+        private TimeSpan? _sessionIdleTimeout = null;
+        // INVARIANT: null means WithMaxSessionLockRenewalDuration was never called, so the config-bound
+        // value is left untouched. A non-null value means the fluent method was called and its value
+        // overrides any config-bound value in EITHER direction (explicit 2 min overrides config 10 min).
+        private TimeSpan? _maxSessionLockRenewalDuration = null;
 
         private const int _defaultMaxConcurrentCalls = 1;
         private const int _defaultPrefetchCount = 0;
+        private static readonly TimeSpan _defaultSessionIdleTimeout = TimeSpan.FromSeconds(60);
+        private static readonly TimeSpan _defaultMaxSessionLockRenewalDuration = TimeSpan.FromMinutes(5);
 
         public static ServiceBusOptionsBuilder Create(IServiceCollection services, IConfiguration configuration)
             => new ServiceBusOptionsBuilder(services, configuration);
@@ -93,6 +103,28 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
         public ServiceBusOptionsBuilder WithCrossEntityTransactions(bool enabled = true)
         {
             _enableCrossEntityTransactions = enabled;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides how long a held session may yield no message before it is released and the
+        /// receiver rolls to the next session. Applies only to session-enabled receivers.
+        /// Default: 60 seconds.
+        /// </summary>
+        public ServiceBusOptionsBuilder WithSessionIdleTimeout(TimeSpan timeout)
+        {
+            _sessionIdleTimeout = timeout;
+            return this;
+        }
+
+        /// <summary>
+        /// Overrides the ceiling on how long a held session's lock is renewed for long-running
+        /// processing. Once reached, renewal stops and the session is allowed to expire or roll
+        /// naturally. Applies only to session-enabled receivers. Default: 5 minutes.
+        /// </summary>
+        public ServiceBusOptionsBuilder WithMaxSessionLockRenewalDuration(TimeSpan duration)
+        {
+            _maxSessionLockRenewalDuration = duration;
             return this;
         }
 
@@ -232,6 +264,22 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Options
             if (_enableCrossEntityTransactions.HasValue)
             {
                 options.EnableCrossEntityTransactions = _enableCrossEntityTransactions.Value;
+            }
+
+            // Explicit fluent call wins over configuration: apply the fluent value only when
+            // WithSessionIdleTimeout was actually called, leaving the config-bound value untouched
+            // otherwise.
+            if (_sessionIdleTimeout.HasValue)
+            {
+                options.SessionIdleTimeout = _sessionIdleTimeout.Value;
+            }
+
+            // Explicit fluent call wins over configuration: apply the fluent value only when
+            // WithMaxSessionLockRenewalDuration was actually called, leaving the config-bound value
+            // untouched otherwise.
+            if (_maxSessionLockRenewalDuration.HasValue)
+            {
+                options.MaxSessionLockRenewalDuration = _maxSessionLockRenewalDuration.Value;
             }
 
             Services.AddSingleton(options);

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/AzureSdkSessionMessageReceiverAdapter.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/AzureSdkSessionMessageReceiverAdapter.cs
@@ -26,7 +26,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
     {
         readonly object _syncLock = new object();
         private readonly ServiceBusClient _client;
-        private readonly string _messageReceiverPath;
+        private readonly ServiceBusSessionEntityPath _entityPath;
         private readonly ServiceBusReceiveMode _receiveMode;
         private readonly int _prefetchCount;
         private readonly TimeSpan _sessionIdleTimeout;
@@ -39,7 +39,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
         private bool _closed;
 
         public AzureSdkSessionMessageReceiverAdapter(ServiceBusClient client,
-                                                     string messageReceiverPath,
+                                                     ServiceBusSessionEntityPath entityPath,
                                                      ServiceBusReceiveMode receiveMode,
                                                      int prefetchCount,
                                                      TimeSpan sessionIdleTimeout,
@@ -47,7 +47,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                                                      ILogger logger)
         {
             _client = client ?? throw new ArgumentNullException(nameof(client));
-            _messageReceiverPath = messageReceiverPath;
+            _entityPath = entityPath;
             _receiveMode = receiveMode;
             _prefetchCount = prefetchCount;
             _sessionIdleTimeout = sessionIdleTimeout;
@@ -93,7 +93,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
             {
                 // No session available right now. Non-fatal: return null so the pump re-polls and the
                 // adapter attempts to accept the next session on the following turn.
-                _logger.LogTrace($"No Azure Service Bus session available for '{_messageReceiverPath}'; re-polling");
+                _logger.LogTrace($"No Azure Service Bus session available for '{_entityPath}'; re-polling");
                 return null;
             }
 
@@ -122,7 +122,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                 // Losing a session lock is an expected operational event, NOT a receiver-stopping fault.
                 // Release the session and return null so the pump re-polls — deliberately NOT raised as
                 // CriticalReceiverException (unlike the cross-entity-transaction rejection).
-                _logger.LogWarning(sbe, $"Azure Service Bus session lock lost for '{_messageReceiverPath}'; releasing session and re-polling");
+                _logger.LogWarning(sbe, $"Azure Service Bus session lock lost for '{_entityPath}'; releasing session and re-polling");
                 await ReleaseSessionAsync().ConfigureAwait(false);
                 return null;
             }
@@ -197,11 +197,18 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                 return existing;
             }
 
-            var accepted = await _client.AcceptNextSessionAsync(_messageReceiverPath, new ServiceBusSessionReceiverOptions
+            var sessionOptions = new ServiceBusSessionReceiverOptions
             {
                 ReceiveMode = _receiveMode,
                 PrefetchCount = _prefetchCount,
-            }, cancellationToken).ConfigureAwait(false);
+            };
+
+            // INVARIANT: address the entity through the structured identity so the correct AcceptNextSessionAsync
+            // overload is chosen — the (topic, subscription) overload for a subscription, the (queue) overload for a
+            // queue — rather than feeding a composite "<topic>/Subscriptions/<sub>" string to the queue-only overload.
+            var accepted = _entityPath.IsSubscription
+                ? await _client.AcceptNextSessionAsync(_entityPath.TopicName, _entityPath.SubscriptionName, sessionOptions, cancellationToken).ConfigureAwait(false)
+                : await _client.AcceptNextSessionAsync(_entityPath.QueueName, sessionOptions, cancellationToken).ConfigureAwait(false);
 
             CancellationTokenSource renewalCts;
             lock (_syncLock)
@@ -250,7 +257,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                     }
 
                     await session.RenewSessionLockAsync(renewalToken).ConfigureAwait(false);
-                    _logger.LogTrace($"Renewed Azure Service Bus session lock for session '{session.SessionId}' on '{_messageReceiverPath}'");
+                    _logger.LogTrace($"Renewed Azure Service Bus session lock for session '{session.SessionId}' on '{_entityPath}'");
                 }
             }
             catch (OperationCanceledException) when (renewalToken.IsCancellationRequested)
@@ -262,7 +269,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
             {
                 // The lock was lost out from under the renewal loop. ReceiveAsync observes the same loss on
                 // its next receive and releases the session there; the loop simply stops renewing.
-                _logger.LogTrace(sbe, $"Azure Service Bus session lock lost during renewal for '{_messageReceiverPath}'; stopping renewal");
+                _logger.LogTrace(sbe, $"Azure Service Bus session lock lost during renewal for '{_entityPath}'; stopping renewal");
             }
             catch (ObjectDisposedException)
             {

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/AzureSdkSessionMessageReceiverAdapter.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/AzureSdkSessionMessageReceiverAdapter.cs
@@ -1,0 +1,329 @@
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
+{
+    /// <summary>
+    /// Session-mode <see cref="IServiceBusMessageReceiver"/> adapter. It holds ONE
+    /// <see cref="ServiceBusSessionReceiver"/> at a time (accepted via
+    /// <see cref="ServiceBusClient.AcceptNextSessionAsync(string, ServiceBusSessionReceiverOptions, CancellationToken)"/>),
+    /// serves that session's messages FIFO through the same single-message
+    /// <see cref="IServiceBusMessageReceiver.ReceiveAsync(CancellationToken)"/> contract the non-session
+    /// <see cref="AzureSdkMessageReceiverAdapter"/> satisfies, settles on the held session receiver, and
+    /// rolls to the next session on drain, idle, or lock loss by releasing the session and returning null
+    /// so the pump re-polls.
+    /// </summary>
+    /// <remarks>
+    /// INVARIANT: a held session owns exactly ONE renewal <see cref="CancellationTokenSource"/> and ONE
+    /// renewal <see cref="Task"/>; the renewal CTS is cancelled BEFORE the held session receiver is closed
+    /// on every release path (drain, idle, lock loss, teardown) so no renewal call races a closing receiver.
+    /// </remarks>
+    internal class AzureSdkSessionMessageReceiverAdapter : IServiceBusMessageReceiver
+    {
+        readonly object _syncLock = new object();
+        private readonly ServiceBusClient _client;
+        private readonly string _messageReceiverPath;
+        private readonly ServiceBusReceiveMode _receiveMode;
+        private readonly int _prefetchCount;
+        private readonly TimeSpan _sessionIdleTimeout;
+        private readonly TimeSpan _maxSessionLockRenewalDuration;
+        private readonly ILogger _logger;
+
+        private ServiceBusSessionReceiver _sessionReceiver;
+        private CancellationTokenSource _renewalCts;
+        private Task _renewalTask;
+        private bool _closed;
+
+        public AzureSdkSessionMessageReceiverAdapter(ServiceBusClient client,
+                                                     string messageReceiverPath,
+                                                     ServiceBusReceiveMode receiveMode,
+                                                     int prefetchCount,
+                                                     TimeSpan sessionIdleTimeout,
+                                                     TimeSpan maxSessionLockRenewalDuration,
+                                                     ILogger logger)
+        {
+            _client = client ?? throw new ArgumentNullException(nameof(client));
+            _messageReceiverPath = messageReceiverPath;
+            _receiveMode = receiveMode;
+            _prefetchCount = prefetchCount;
+            _sessionIdleTimeout = sessionIdleTimeout;
+            _maxSessionLockRenewalDuration = maxSessionLockRenewalDuration;
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        /// <summary>
+        /// The currently held SDK session receiver, or null when no session is held. Later steps include
+        /// this in the transaction <c>Container</c> and resolve it for session-state Get/Set/Clear.
+        /// </summary>
+        internal ServiceBusSessionReceiver HeldSessionReceiver
+        {
+            get
+            {
+                lock (_syncLock)
+                {
+                    return _sessionReceiver;
+                }
+            }
+        }
+
+        public bool IsClosedOrClosing
+        {
+            get
+            {
+                lock (_syncLock)
+                {
+                    return _closed || (_sessionReceiver != null && _sessionReceiver.IsClosed);
+                }
+            }
+        }
+
+        public async Task<ServiceBusReceivedMessage> ReceiveAsync(CancellationToken cancellationToken)
+        {
+            ServiceBusSessionReceiver session;
+            try
+            {
+                session = await AcquireSessionAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (ServiceBusException sbe) when (sbe.Reason == ServiceBusFailureReason.ServiceTimeout
+                                                  || sbe.Reason == ServiceBusFailureReason.SessionCannotBeLocked)
+            {
+                // No session available right now. Non-fatal: return null so the pump re-polls and the
+                // adapter attempts to accept the next session on the following turn.
+                _logger.LogTrace($"No Azure Service Bus session available for '{_messageReceiverPath}'; re-polling");
+                return null;
+            }
+
+            if (session == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                // Idle rollover: a held session that yields no message within SessionIdleTimeout is released
+                // and the adapter rolls to the next session (return null, re-poll).
+                var message = await session.ReceiveMessageAsync(maxWaitTime: _sessionIdleTimeout, cancellationToken).ConfigureAwait(false);
+
+                if (message == null)
+                {
+                    // Drain or idle: the held session yielded nothing this turn. Release it and roll.
+                    await ReleaseSessionAsync().ConfigureAwait(false);
+                    return null;
+                }
+
+                return message;
+            }
+            catch (ServiceBusException sbe) when (sbe.Reason == ServiceBusFailureReason.SessionLockLost)
+            {
+                // Losing a session lock is an expected operational event, NOT a receiver-stopping fault.
+                // Release the session and return null so the pump re-polls — deliberately NOT raised as
+                // CriticalReceiverException (unlike the cross-entity-transaction rejection).
+                _logger.LogWarning(sbe, $"Azure Service Bus session lock lost for '{_messageReceiverPath}'; releasing session and re-polling");
+                await ReleaseSessionAsync().ConfigureAwait(false);
+                return null;
+            }
+        }
+
+        public Task CompleteAsync(ServiceBusReceivedMessage message)
+        {
+            if (_receiveMode != ServiceBusReceiveMode.PeekLock)
+            {
+                return Task.CompletedTask;
+            }
+
+            var session = HeldSessionReceiver;
+            if (session == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return session.CompleteMessageAsync(message);
+        }
+
+        public Task AbandonAsync(ServiceBusReceivedMessage message, IDictionary<string, object> propertiesToModify)
+        {
+            if (_receiveMode != ServiceBusReceiveMode.PeekLock)
+            {
+                return Task.CompletedTask;
+            }
+
+            var session = HeldSessionReceiver;
+            if (session == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return session.AbandonMessageAsync(message, propertiesToModify);
+        }
+
+        public Task DeadLetterAsync(ServiceBusReceivedMessage message, string deadLetterReason, string deadLetterErrorDescription)
+        {
+            if (_receiveMode != ServiceBusReceiveMode.PeekLock)
+            {
+                return Task.CompletedTask;
+            }
+
+            var session = HeldSessionReceiver;
+            if (session == null)
+            {
+                return Task.CompletedTask;
+            }
+
+            return session.DeadLetterMessageAsync(message, deadLetterReason, deadLetterErrorDescription);
+        }
+
+        public async Task CloseAsync()
+        {
+            lock (_syncLock)
+            {
+                _closed = true;
+            }
+
+            await ReleaseSessionAsync().ConfigureAwait(false);
+        }
+
+        // Returns the held session if one is already held, otherwise accepts the next available session
+        // and starts its bounded lock-renewal loop. Lets SessionCannotBeLocked / ServiceTimeout propagate
+        // to the caller's non-fatal guard.
+        private async Task<ServiceBusSessionReceiver> AcquireSessionAsync(CancellationToken cancellationToken)
+        {
+            var existing = HeldSessionReceiver;
+            if (existing != null)
+            {
+                return existing;
+            }
+
+            var accepted = await _client.AcceptNextSessionAsync(_messageReceiverPath, new ServiceBusSessionReceiverOptions
+            {
+                ReceiveMode = _receiveMode,
+                PrefetchCount = _prefetchCount,
+            }, cancellationToken).ConfigureAwait(false);
+
+            CancellationTokenSource renewalCts;
+            lock (_syncLock)
+            {
+                if (_closed)
+                {
+                    // Raced with CloseAsync — do not hold the just-accepted session.
+                    renewalCts = null;
+                }
+                else
+                {
+                    _sessionReceiver = accepted;
+                    _renewalCts = renewalCts = new CancellationTokenSource();
+                }
+            }
+
+            if (renewalCts == null)
+            {
+                await accepted.CloseAsync().ConfigureAwait(false);
+                return null;
+            }
+
+            _renewalTask = RenewSessionLockLoopAsync(accepted, renewalCts.Token);
+            return accepted;
+        }
+
+        // Bounded session-lock renewal loop: renews the held session's lock on a cadence derived from the
+        // session lock duration, bounded by MaxSessionLockRenewalDuration. Once the ceiling is reached,
+        // renewal stops and the session is allowed to expire/roll naturally rather than being held forever.
+        private async Task RenewSessionLockLoopAsync(ServiceBusSessionReceiver session, CancellationToken renewalToken)
+        {
+            var ceiling = DateTimeOffset.UtcNow + _maxSessionLockRenewalDuration;
+
+            try
+            {
+                while (!renewalToken.IsCancellationRequested && DateTimeOffset.UtcNow < ceiling)
+                {
+                    var lockedUntil = session.SessionLockedUntil;
+                    var delay = ComputeRenewalDelay(lockedUntil);
+
+                    await Task.Delay(delay, renewalToken).ConfigureAwait(false);
+
+                    if (renewalToken.IsCancellationRequested || DateTimeOffset.UtcNow >= ceiling)
+                    {
+                        break;
+                    }
+
+                    await session.RenewSessionLockAsync(renewalToken).ConfigureAwait(false);
+                    _logger.LogTrace($"Renewed Azure Service Bus session lock for session '{session.SessionId}' on '{_messageReceiverPath}'");
+                }
+            }
+            catch (OperationCanceledException) when (renewalToken.IsCancellationRequested)
+            {
+                // Expected: the session is being released/closed. The release path cancels this CTS before
+                // closing the receiver, so a cancelled renewal is normal teardown, not a fault.
+            }
+            catch (ServiceBusException sbe) when (sbe.Reason == ServiceBusFailureReason.SessionLockLost)
+            {
+                // The lock was lost out from under the renewal loop. ReceiveAsync observes the same loss on
+                // its next receive and releases the session there; the loop simply stops renewing.
+                _logger.LogTrace(sbe, $"Azure Service Bus session lock lost during renewal for '{_messageReceiverPath}'; stopping renewal");
+            }
+            catch (ObjectDisposedException)
+            {
+                // The session receiver was closed concurrently with renewal. Stop renewing; the release path
+                // owns teardown.
+            }
+        }
+
+        // Renews at the halfway point between now and the lock expiry, clamped to a small positive floor so a
+        // near-expired or already-expired lock renews promptly rather than spinning or waiting a negative span.
+        private static TimeSpan ComputeRenewalDelay(DateTimeOffset lockedUntil)
+        {
+            var remaining = lockedUntil - DateTimeOffset.UtcNow;
+            var half = TimeSpan.FromTicks(remaining.Ticks / 2);
+            var floor = TimeSpan.FromSeconds(1);
+            return half < floor ? floor : half;
+        }
+
+        // Cancels the renewal CTS BEFORE closing the held session receiver, then awaits the renewal task so
+        // no renewal call races a closing/closed session receiver. Idempotent across repeated release paths.
+        private async Task ReleaseSessionAsync()
+        {
+            ServiceBusSessionReceiver toClose;
+            CancellationTokenSource renewalCts;
+            Task renewalTask;
+            lock (_syncLock)
+            {
+                toClose = _sessionReceiver;
+                renewalCts = _renewalCts;
+                renewalTask = _renewalTask;
+                _sessionReceiver = null;
+                _renewalCts = null;
+                _renewalTask = null;
+            }
+
+            if (renewalCts != null)
+            {
+                renewalCts.Cancel();
+            }
+
+            if (renewalTask != null)
+            {
+                try
+                {
+                    await renewalTask.ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    // Renewal task observed its cancellation — expected on the release path.
+                }
+            }
+
+            if (renewalCts != null)
+            {
+                renewalCts.Dispose();
+            }
+
+            if (toClose != null)
+            {
+                await toClose.CloseAsync().ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/InboundBrokeredMessageFactory.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/InboundBrokeredMessageFactory.cs
@@ -69,6 +69,14 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                 headers[MessageContext.InfrastructureType] = ASBMessageContext.InfrastructureType;
                 headers[MessageContext.ReceiveAttempts] = message.DeliveryCount;
 
+                // SessionId is the Azure Service Bus realization of the core Group Id term, so a session
+                // message's SessionId is surfaced under the existing GroupId header — no ASB-specific alias.
+                // Only stamped when present (session messages); non-session messages are unchanged.
+                if (!string.IsNullOrEmpty(message.SessionId))
+                {
+                    headers[MessageContext.GroupId] = message.SessionId;
+                }
+
                 messageContext = new MessageBrokerContext(message.MessageId, message.Body.ToArray(), headers, messageReceiverPath, cancellationToken, bodyConverter);
 
                 messageContext.Container.Include(message);

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
@@ -100,8 +100,9 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
         {
             if (_receiverRegistry != null && _receiverRegistry.RequiresSession(options.MessageReceiverPath, options.SendingPath))
             {
+                var sessionEntityPath = ServiceBusSessionEntityPath.Create(options.SendingPath, options.MessageReceiverPath);
                 return new AzureSdkSessionMessageReceiverAdapter(_client,
-                                                                 options.MessageReceiverPath,
+                                                                 sessionEntityPath,
                                                                  receiveMode,
                                                                  _serviceBusOptions.PrefetchCount,
                                                                  _serviceBusOptions.SessionIdleTimeout,

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
@@ -1,3 +1,4 @@
+using Chatter.MessageBrokers.AzureServiceBus.DependencyInjection;
 using Chatter.MessageBrokers.AzureServiceBus.Options;
 using Chatter.MessageBrokers.Configuration;
 using Chatter.MessageBrokers.Context;
@@ -31,6 +32,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
         private readonly InboundBrokeredMessageFactory _inboundFactory;
         private readonly Func<ReceiverOptions, ServiceBusReceiveMode, IServiceBusMessageReceiver> _receiverFactory;
         private readonly ServiceBusOptions _serviceBusOptions;
+        private readonly ServiceBusReceiverRegistry _receiverRegistry;
         private ServiceBusReceiveMode _receiveMode;
         // INVARIANT: the receiver and sender MUST share ONE ServiceBusClient per namespace so the send and
         // the receiver's settle enlist in one cross-entity transaction (EnableCrossEntityTransactions). The
@@ -40,11 +42,16 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
         private bool _disposedValue;
         private ReceiverOptions _options;
 
+        // receiverRegistry is optional so existing callers/tests that construct via the five-argument shape
+        // keep compiling; DI always supplies the registered singleton on the production path, and the
+        // production session-vs-non-session branch null-guards it. When null, only the non-session adapter
+        // is ever selected (the prior behavior).
         public ServiceBusReceiver(ServiceBusClient client,
                                   ServiceBusOptions serviceBusOptions,
                                   MessageBrokerOptions messageBrokerOptions,
                                   ILogger<ServiceBusReceiver> logger,
-                                  IBodyConverterFactory bodyConverterFactory)
+                                  IBodyConverterFactory bodyConverterFactory,
+                                  ServiceBusReceiverRegistry receiverRegistry = null)
             : this(client,
                    serviceBusOptions,
                    messageBrokerOptions,
@@ -52,18 +59,22 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                    new InboundBrokeredMessageFactory(
                        bodyConverterFactory ?? throw new ArgumentNullException(nameof(bodyConverterFactory)),
                        logger ?? throw new ArgumentNullException(nameof(logger))),
-                   receiverFactory: null)
+                   receiverFactory: null,
+                   receiverRegistry: receiverRegistry)
         { }
 
         // Internal seam ctor: an IServiceBusMessageReceiver factory (path + receive-mode -> port) can be
         // injected to drive receive/ack behavior with an in-memory double in tests. When null, the
-        // production AzureSdkMessageReceiverAdapter source (off the shared client) is used.
+        // production CreateProductionReceiver source (off the shared client) is used; that production path
+        // is the only caller that reads receiverRegistry, so a test supplying its own receiverFactory may
+        // leave receiverRegistry null.
         internal ServiceBusReceiver(ServiceBusClient client,
                                     ServiceBusOptions serviceBusOptions,
                                     MessageBrokerOptions messageBrokerOptions,
                                     ILogger<ServiceBusReceiver> logger,
                                     InboundBrokeredMessageFactory inboundFactory,
-                                    Func<ReceiverOptions, ServiceBusReceiveMode, IServiceBusMessageReceiver> receiverFactory)
+                                    Func<ReceiverOptions, ServiceBusReceiveMode, IServiceBusMessageReceiver> receiverFactory,
+                                    ServiceBusReceiverRegistry receiverRegistry = null)
         {
             if (serviceBusOptions is null)
             {
@@ -76,15 +87,49 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
             _inboundFactory = inboundFactory ?? throw new ArgumentNullException(nameof(inboundFactory));
             _receiveMode = messageBrokerOptions?.TransactionMode == TransactionMode.None ? ServiceBusReceiveMode.ReceiveAndDelete : ServiceBusReceiveMode.PeekLock;
+            _receiverRegistry = receiverRegistry;
             _receiverFactory = receiverFactory ?? CreateProductionReceiver;
         }
 
+        // Selects the production IServiceBusMessageReceiver for the receiver's entity: the session adapter
+        // when the registry marks the entity session-mode, otherwise the existing non-session adapter. The
+        // top-level entity is inferred from SendingPath/MessageReceiverPath exactly as registration does
+        // (queue receiver -> receiver path; topic subscription -> sending path), so the case-insensitive
+        // registry lookup keys on the same value the receiver was registered under.
         private IServiceBusMessageReceiver CreateProductionReceiver(ReceiverOptions options, ServiceBusReceiveMode receiveMode)
-            => new AzureSdkMessageReceiverAdapter(_client,
-                                                  options.MessageReceiverPath,
-                                                  receiveMode,
-                                                  _serviceBusOptions.PrefetchCount,
-                                                  _logger);
+        {
+            var topLevelEntity = InferTopLevelEntity(options.SendingPath, options.MessageReceiverPath);
+
+            if (_receiverRegistry != null && _receiverRegistry.RequiresSession(topLevelEntity))
+            {
+                return new AzureSdkSessionMessageReceiverAdapter(_client,
+                                                                 options.MessageReceiverPath,
+                                                                 receiveMode,
+                                                                 _serviceBusOptions.PrefetchCount,
+                                                                 _serviceBusOptions.SessionIdleTimeout,
+                                                                 _serviceBusOptions.MaxSessionLockRenewalDuration,
+                                                                 _logger);
+            }
+
+            return new AzureSdkMessageReceiverAdapter(_client,
+                                                      options.MessageReceiverPath,
+                                                      receiveMode,
+                                                      _serviceBusOptions.PrefetchCount,
+                                                      _logger);
+        }
+
+        // Mirrors the registration-time top-level-entity inference: a queue receiver's sending path is empty
+        // or equals its receiver path (the queue IS the top-level entity); a topic subscription's sending
+        // path is the distinct topic (the TOPIC is the top-level entity).
+        private static string InferTopLevelEntity(string sendingPath, string messageReceiverPath)
+        {
+            if (string.IsNullOrWhiteSpace(sendingPath) || string.Equals(sendingPath, messageReceiverPath, StringComparison.Ordinal))
+            {
+                return messageReceiverPath;
+            }
+
+            return sendingPath;
+        }
 
         internal IServiceBusMessageReceiver InnerReceiver
         {
@@ -180,6 +225,15 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
             var messageContext = _inboundFactory.CreateContext(message, _options.MessageReceiverPath, cancellationToken);
 
             transactionContext.Container.Include(this.InnerReceiver);
+
+            // Session path only: include the held SDK session receiver so the session-state extension and
+            // session settlement can resolve it during handling. Non-session receivers leave the container
+            // unchanged (the held receiver is null when no session adapter is in use).
+            if (this.InnerReceiver is AzureSdkSessionMessageReceiverAdapter sessionAdapter
+                && sessionAdapter.HeldSessionReceiver != null)
+            {
+                transactionContext.Container.Include(sessionAdapter.HeldSessionReceiver);
+            }
 
             if (_options.TransactionMode == TransactionMode.FullAtomicityViaInfrastructure)
             {

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusReceiver.cs
@@ -91,16 +91,14 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
             _receiverFactory = receiverFactory ?? CreateProductionReceiver;
         }
 
-        // Selects the production IServiceBusMessageReceiver for the receiver's entity: the session adapter
-        // when the registry marks the entity session-mode, otherwise the existing non-session adapter. The
-        // top-level entity is inferred from SendingPath/MessageReceiverPath exactly as registration does
-        // (queue receiver -> receiver path; topic subscription -> sending path), so the case-insensitive
-        // registry lookup keys on the same value the receiver was registered under.
+        // Selects the production IServiceBusMessageReceiver for THIS receiver: the session adapter when the
+        // registry marks this specific receiver session-mode, otherwise the existing non-session adapter. The
+        // session lookup is PER-RECEIVER, keyed on this receiver's own (MessageReceiverPath, SendingPath) pair
+        // — the SAME pair it was registered under — so a session subscription and a normal subscription on the
+        // same topic resolve to different adapters instead of colliding on the shared top-level entity.
         private IServiceBusMessageReceiver CreateProductionReceiver(ReceiverOptions options, ServiceBusReceiveMode receiveMode)
         {
-            var topLevelEntity = InferTopLevelEntity(options.SendingPath, options.MessageReceiverPath);
-
-            if (_receiverRegistry != null && _receiverRegistry.RequiresSession(topLevelEntity))
+            if (_receiverRegistry != null && _receiverRegistry.RequiresSession(options.MessageReceiverPath, options.SendingPath))
             {
                 return new AzureSdkSessionMessageReceiverAdapter(_client,
                                                                  options.MessageReceiverPath,
@@ -116,19 +114,6 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
                                                       receiveMode,
                                                       _serviceBusOptions.PrefetchCount,
                                                       _logger);
-        }
-
-        // Mirrors the registration-time top-level-entity inference: a queue receiver's sending path is empty
-        // or equals its receiver path (the queue IS the top-level entity); a topic subscription's sending
-        // path is the distinct topic (the TOPIC is the top-level entity).
-        private static string InferTopLevelEntity(string sendingPath, string messageReceiverPath)
-        {
-            if (string.IsNullOrWhiteSpace(sendingPath) || string.Equals(sendingPath, messageReceiverPath, StringComparison.Ordinal))
-            {
-                return messageReceiverPath;
-            }
-
-            return sendingPath;
         }
 
         internal IServiceBusMessageReceiver InnerReceiver

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusSessionEntityPath.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Receiving/ServiceBusSessionEntityPath.cs
@@ -1,0 +1,110 @@
+using Chatter.MessageBrokers;
+using System;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Receiving
+{
+    // INVARIANT: a STRUCTURED, CLOSED-SUM identity for the Azure Service Bus entity a session receiver opens.
+    // It is EITHER a queue (one name) XOR a topic subscription (topic + subscription) — never a flat
+    // "<topic>/Subscriptions/<sub>" composite string. The flat-string shape is the defect class this type
+    // eliminates: ServiceBusClient.AcceptNextSessionAsync(string, ...) treats its single string argument as a
+    // QUEUE name only, so feeding it a composite subscription path addresses the wrong entity. By forcing the
+    // overload decision through IsSubscription/TopicName/SubscriptionName vs QueueName, the wrong-overload bug
+    // cannot be expressed. STEP-002 selects the SDK overload from this shape; STEP-003 consumes the same seam.
+    internal readonly struct ServiceBusSessionEntityPath
+    {
+        // Mirrors the canonical "Subscriptions" segment literal that lives in AzureServiceBusEntityPathBuilder
+        // and ServiceBusReceiverRegistry. Re-declared here (not edited into a shared helper) to keep this the
+        // ONLY file touched in this step; the same single-literal-duplication pattern the registry already uses.
+        private const string SubscriptionsSegment = "Subscriptions";
+        private static readonly IBrokeredMessagePathBuilder _pathBuilder = new AzureServiceBusEntityPathBuilder();
+
+        private ServiceBusSessionEntityPath(bool isSubscription, string queueName, string topicName, string subscriptionName)
+        {
+            IsSubscription = isSubscription;
+            _queueName = queueName;
+            _topicName = topicName;
+            _subscriptionName = subscriptionName;
+        }
+
+        private readonly string _queueName;
+        private readonly string _topicName;
+        private readonly string _subscriptionName;
+
+        // True when this identity is a topic subscription (use the (topic, subscription) overload); false when it
+        // is a queue (use the (queue) overload). This is the unit-observable overload-selection seam.
+        public bool IsSubscription { get; }
+
+        // The queue name for a QUEUE identity. Throws for a subscription identity — reading the queue name of a
+        // subscription is a programming error (the wrong-overload bug this type prevents), so it fails loudly
+        // rather than returning a sentinel that erases the distinction.
+        public string QueueName
+            => IsSubscription
+                ? throw new InvalidOperationException("QueueName is not valid for a topic-subscription session entity; use TopicName and SubscriptionName.")
+                : _queueName;
+
+        // The topic name for a SUBSCRIPTION identity. Throws for a queue identity.
+        public string TopicName
+            => IsSubscription
+                ? _topicName
+                : throw new InvalidOperationException("TopicName is not valid for a queue session entity; use QueueName.");
+
+        // The trailing subscription name ("sub") for a SUBSCRIPTION identity — never the formatted
+        // "<topic>/Subscriptions/<sub>" composite. Throws for a queue identity.
+        public string SubscriptionName
+            => IsSubscription
+                ? _subscriptionName
+                : throw new InvalidOperationException("SubscriptionName is not valid for a queue session entity; use QueueName.");
+
+        // Derives the structured shape from the receiver's sending path and its OWN receiver path, mirroring
+        // ServiceBusReceiverRegistry.InferTopLevelEntity:
+        //   QUEUE when sendingPath is null/empty OR equals messageReceiverPath -> QueueName = messageReceiverPath.
+        //   SUBSCRIPTION when sendingPath is a distinct topic -> TopicName = sendingPath; SubscriptionName = the
+        //   trailing subscription.
+        //
+        // IDEMPOTENCY: messageReceiverPath may arrive RAW ("sub") OR already FORMATTED ("<topic>/Subscriptions/<sub>")
+        // — the runtime path the core BrokeredMessageReceiver.StartReceiver rewrites MessageReceiverPath into is
+        // already formatted, while registration / discovery pass a raw subscription name. Both MUST collapse to
+        // SubscriptionName = "sub". This mirrors ServiceBusReceiverRegistry.CanonicalReceivingPath's guard: when the
+        // receiver path is already "<topic>/Subscriptions/...", strip that prefix instead of re-formatting (which
+        // would otherwise nest a second "<topic>/Subscriptions/" segment).
+        public static ServiceBusSessionEntityPath Create(string sendingPath, string messageReceiverPath)
+        {
+            if (string.IsNullOrWhiteSpace(sendingPath) || string.Equals(sendingPath, messageReceiverPath, StringComparison.Ordinal))
+            {
+                return new ServiceBusSessionEntityPath(isSubscription: false, queueName: messageReceiverPath, topicName: null, subscriptionName: null);
+            }
+
+            var subscriptionName = ExtractSubscriptionName(sendingPath, messageReceiverPath);
+            return new ServiceBusSessionEntityPath(isSubscription: true, queueName: null, topicName: sendingPath, subscriptionName: subscriptionName);
+        }
+
+        // Collapses a raw-or-formatted receiver path to the bare trailing subscription name. The formatted prefix
+        // ("<topic>/Subscriptions/") is derived from the path builder rather than re-hardcoded: formatting a
+        // sentinel subscription yields "<topic>/Subscriptions/<sentinel>", and the prefix is everything before
+        // that sentinel. Comparison is OrdinalIgnoreCase to match Azure Service Bus entity-name semantics
+        // (consistent with the registry).
+        private static string ExtractSubscriptionName(string topicName, string messageReceiverPath)
+        {
+            if (string.IsNullOrEmpty(messageReceiverPath))
+            {
+                return messageReceiverPath;
+            }
+
+            var formattedPrefix = $"{topicName}/{SubscriptionsSegment}/";
+            if (messageReceiverPath.StartsWith(formattedPrefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return messageReceiverPath.Substring(formattedPrefix.Length);
+            }
+
+            return messageReceiverPath;
+        }
+
+        // INVARIANT: a human-readable rendering for log messages (STEP-002 preserves existing LogTrace/LogWarning
+        // text that referenced the flat path). A subscription renders via the path builder so the logged shape
+        // matches the canonical "<topic>/Subscriptions/<sub>" receiving path; a queue renders as its bare name.
+        public override string ToString()
+            => IsSubscription
+                ? _pathBuilder.GetMessageReceivingPath(_topicName, _subscriptionName)
+                : _queueName;
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/src/README.md
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/src/README.md
@@ -130,6 +130,8 @@ public class OrderCreatedHandler : IMessageHandler<OrderCreated>
 | `PrefetchCount` | `0` | Number of messages eagerly fetched from the broker. |
 | `Policy` (`RetryPolicy`) | `RetryPolicy.Default` | ASB client-level retry policy derived from the `RetryPolicy` config section. |
 | `TokenProvider` | `NullTokenProvider` | AAD/token credential (see [Authentication](#authentication)). |
+| `SessionIdleTimeout` | `00:01:00` (60 s) | How long a held session may yield no message before it is released and the receiver rolls. Applies only to session-enabled receivers. |
+| `MaxSessionLockRenewalDuration` | `00:05:00` (5 min) | Ceiling on how long a held session's lock is renewed for long-running processing. Applies only to session-enabled receivers. |
 
 The `RetryPolicy` configuration section maps to an ASB `RetryExponential` policy via `MinimumBackoffInSeconds`, `MaximumBackoffInSeconds`, `DeltaBackoffInSeconds`, and `MaximumRetryCount`. When all values are `0`, `RetryPolicy.NoRetry` is used; when the section is absent, `RetryPolicy.Default` applies.
 
@@ -146,8 +148,12 @@ The `AddAzureServiceBus(asb => ...)` delegate exposes a `ServiceBusOptionsBuilde
 | `WithExponentialDelay(maximumRetryCount, maximumBackoffInSeconds, minimumBackoffInSeconds, deltaBackoffInSeconds)` | Configures a `RetryExponential` client retry policy. |
 | `UseConfig(configSectionName)` | Binds `ServiceBusOptions` from the given configuration section (default `Chatter:Infrastructure:AzureServiceBus`). |
 | `AddTokenProvider(ITokenProvider)` / `AddTokenProvider(Func<ITokenProvider>)` | Supplies an AAD token provider (see [Authentication](#authentication)). |
+| `WithSessionIdleTimeout(TimeSpan)` | Overrides how long a held session may yield no message before rolling to the next. Default: 60 s. See [Sessions](#sessions). |
+| `WithMaxSessionLockRenewalDuration(TimeSpan)` | Overrides the ceiling on held-session lock renewal. Default: 5 min. See [Sessions](#sessions). |
 | `AddQueueReceiver<TMessage>(...)` | Registers a queue receiver for an `ICommand`. |
+| `AddSessionQueueReceiver<TMessage>(...)` | Registers a session-enabled queue receiver for an `ICommand`. See [Sessions](#sessions). |
 | `AddTopicSubscription<TMessage>(...)` | Registers a topic subscription receiver for an `IEvent`. |
+| `AddSessionTopicSubscription<TMessage>(...)` | Registers a session-enabled topic subscription receiver for an `IEvent`. See [Sessions](#sessions). |
 
 ### Retry and Circuit Breaker (receiving)
 
@@ -181,8 +187,131 @@ When the variable is unset (or blank) the tests are skipped at discovery time.
 
 **Run in CI:** the `real-namespace-integration` job in `.github/workflows/ci.yml` runs this lane. Configure a GitHub Actions **repository secret** named `CHATTER_ASB_REAL_NAMESPACE_CONNECTION_STRING` (Manage-claim connection string) for it to execute. Without the secret (forks, or repos that have not configured it) the job is a clean no-op and never fails CI.
 
+## Sessions
+
+Azure Service Bus message sessions deliver messages sharing the same `SessionId` to a single receiver in strict FIFO order. Chatter surfaces this through the existing Group Id term: inbound `SessionId` appears as `MessageContext.GroupId`; outbound session addressing reuses `SendOptions.WithGroupId`. No new session-specific API is introduced on the core.
+
+Session-enabled entities (queues or subscriptions with `RequiresSession = true`) must be provisioned externally. The adapter does not auto-create or auto-enable them, consistent with the module's no-auto-provision stance.
+
+### Registering a session-enabled receiver
+
+Use `AddSessionQueueReceiver` for Commands and `AddSessionTopicSubscription` for Events in place of their non-session counterparts:
+
+```csharp
+services
+    .AddChatterCqrs(configuration)
+    .AddMessageBrokers()
+    .AddAzureServiceBus(asb =>
+    {
+        asb.WithConnectionString(configuration.GetConnectionString("ServiceBus"));
+
+        // session-enabled queue (Commands)
+        asb.AddSessionQueueReceiver<ProcessOrder>("orders-session-queue");
+
+        // session-enabled topic subscription (Events)
+        asb.AddSessionTopicSubscription<OrderPlaced>("order-events-topic", "order-placed-session-sub");
+    });
+```
+
+Each registered receiver processes one session at a time, holding it for FIFO delivery and rolling to the next when it is drained or goes idle. To increase throughput, run additional receiver instances; there is no max-concurrent-sessions knob.
+
+### Reading the session id in a handler
+
+The inbound `SessionId` is surfaced as `MessageContext.GroupId`. Handlers read it through the broker-agnostic `GroupId` property — no Azure-specific import is required:
+
+```csharp
+public class ProcessOrderHandler : IMessageHandler<ProcessOrder>
+{
+    public Task Handle(ProcessOrder message, IMessageHandlerContext context)
+    {
+        var sessionId = context.BrokeredMessage?.GetBrokeredMessageDetail()?.GroupId;
+        // use sessionId to correlate work within this session
+        return Task.CompletedTask;
+    }
+}
+```
+
+### Sending a message to a session
+
+Set `WithGroupId` on `SendOptions` to route the outbound message to the target session. Azure Service Bus requires `PartitionKey == SessionId` for session messages on partitioned entities; set `WithPartitionKey` to the same value, otherwise the broker will reject the message with `ArgumentOutOfRangeException`:
+
+```csharp
+public class DispatchOrderHandler : IMessageHandler<DispatchOrder>
+{
+    public async Task Handle(DispatchOrder message, IMessageHandlerContext context)
+    {
+        var options = new SendOptions()
+            .WithGroupId(message.OrderId)        // sets ServiceBusMessage.SessionId
+            .WithPartitionKey(message.OrderId);  // must equal SessionId for session messages
+
+        await context.AzureServiceBus()
+                     .Send(new ProcessOrder { OrderId = message.OrderId }, "orders-session-queue", options);
+    }
+}
+```
+
+`WithGroupId` and `WithPartitionKey` are both on the core `SendOptions` type; `WithPartitionKey` writes to `ASBMessageContext.PartitionKey`, which `OutboundBrokeredMessageExtensions` maps to `ServiceBusMessage.PartitionKey` when the message is sent.
+
+### Durable per-session state
+
+During handler execution a handler can read, write, and clear durable session state stored on the Azure Service Bus entity for the currently held session:
+
+```csharp
+using Chatter.CQRS.Context;
+
+public class ProcessOrderHandler : IMessageHandler<ProcessOrder>
+{
+    public async Task Handle(ProcessOrder message, IMessageHandlerContext context)
+    {
+        // read existing state (null when no state has been set)
+        var stateBytes = await context.GetSessionStateAsync();
+
+        // compute and persist new state
+        var newState = BinaryData.FromString($"last-processed:{message.OrderId}");
+        await context.SetSessionStateAsync(newState);
+
+        // clear state when the session is complete
+        // await context.ClearSessionStateAsync();
+    }
+}
+```
+
+`GetSessionStateAsync`, `SetSessionStateAsync`, and `ClearSessionStateAsync` are extension methods on `IMessageHandlerContext` provided by this package. Invoking them while handling a message that was not received through a session-enabled receiver throws `InvalidOperationException`.
+
+### Tuning session behavior
+
+Two `ServiceBusOptions` knobs control how long a session is held. Both support fluent-or-config, with the fluent call winning in either direction:
+
+| Knob | Fluent method | Config property | Default | Description |
+| --- | --- | --- | --- | --- |
+| Session idle timeout | `WithSessionIdleTimeout(TimeSpan)` | `SessionIdleTimeout` | 60 s | How long a held session may yield no message before it is released and the receiver rolls to the next session. |
+| Max session lock renewal duration | `WithMaxSessionLockRenewalDuration(TimeSpan)` | `MaxSessionLockRenewalDuration` | 5 min | Ceiling on how long a held session's lock is renewed for long-running processing. Once reached, renewal stops and the session is allowed to expire or roll naturally. |
+
+```csharp
+asb.AddSessionQueueReceiver<ProcessOrder>("orders-session-queue");
+asb.WithSessionIdleTimeout(TimeSpan.FromSeconds(30));
+asb.WithMaxSessionLockRenewalDuration(TimeSpan.FromMinutes(10));
+```
+
+Or via configuration:
+
+```json
+{
+  "Chatter": {
+    "Infrastructure": {
+      "AzureServiceBus": {
+        "SessionIdleTimeout": "00:00:30",
+        "MaxSessionLockRenewalDuration": "00:10:00"
+      }
+    }
+  }
+}
+```
+
+These knobs apply only to session-enabled receivers. Non-session receivers are unaffected.
+
 ## Domain Language
 
-See the [domain glossary](../CONTEXT.md) for definitions of Service Bus Receiver, Service Bus Sender, Service Bus Options, Service Bus Retry, and Service Bus Circuit Breaker.
+See the [domain glossary](../CONTEXT.md) for definitions of Service Bus Receiver, Session Queue Receiver, Session Topic Subscription, Service Bus Sender, Service Bus Options, Service Bus Retry, Service Bus Circuit Breaker, Session, Session State, and Group Id ↔ SessionId realization.
 
 [← All Chatter modules](../../../README.md)

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
@@ -508,6 +508,75 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
             asbReceiver.MaxConcurrentCalls.Should().Be(1);
         }
 
+        // ----------------------------------------------------------------- (P1) session-mode concurrency clamp
+
+        [Fact]
+        public async Task MustClampSessionReceiverMaxConcurrentCallsToOneWhileNonSessionKeepsGlobal()
+        {
+            // (P1) A session-mode receiver holds a SINGLE ServiceBusSessionReceiver and must serve at most ONE
+            // in-flight message at a time, so PopulateFromDiscoveredReceivers clamps its live ReceiverOptions
+            // .MaxConcurrentCalls to 1 — overriding the global value (set fluently to 7) — while a NON-session
+            // receiver in the same host keeps the global 7. Asserted on the live ReceiverOptions held in
+            // IDiscoveredReceiverRegistry, the same instance BrokeredMessageReceiver reads at init: one worker ->
+            // one in-flight message from the single held session receiver, FIFO-per-session preserved.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.WithMaxConcurrentCalls(7);
+                sb.AddSessionQueueReceiver<FirstCommand>("session-queue");
+                sb.AddQueueReceiver<SecondCommand>("normal-queue");
+            }).BuildServiceProvider();
+
+            var discoveredRegistry = provider.GetRequiredService<IDiscoveredReceiverRegistry>();
+            var sessionReceiver = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "session-queue");
+            var normalReceiver = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "normal-queue");
+
+            sessionReceiver.MaxConcurrentCalls.Should().Be(1);
+            normalReceiver.MaxConcurrentCalls.Should().Be(7);
+        }
+
+        [Fact]
+        public async Task MustClampSessionTopicSubscriptionWhileSiblingSubscriptionOnSameTopicKeepsGlobal()
+        {
+            // (P1) The clamp is PER-RECEIVER, not per-top-level-entity: a session-enabled subscription and a
+            // normal subscription on the SAME topic are distinct receivers, so only the session one is clamped to
+            // 1 while the sibling normal subscription keeps the global 7. Proves the clamp branches on the
+            // per-receiver session flag via RequiresSession(receiverPath, sendingPath), matching the registry's
+            // per-receiver session attribution.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.WithMaxConcurrentCalls(7);
+                sb.AddSessionTopicSubscription<FirstEvent>("shared-topic", "session-sub");
+                sb.AddTopicSubscription<SecondEvent>("shared-topic", "normal-sub");
+            }).BuildServiceProvider();
+
+            var discoveredRegistry = provider.GetRequiredService<IDiscoveredReceiverRegistry>();
+            var sessionSubscription = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "session-sub");
+            var normalSubscription = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "normal-sub");
+
+            sessionSubscription.MaxConcurrentCalls.Should().Be(1);
+            normalSubscription.MaxConcurrentCalls.Should().Be(7);
+        }
+
+        [Fact]
+        public async Task MustLeaveSessionReceiverAtOneWhenGlobalMaxConcurrentCallsAlreadyOne()
+        {
+            // (P1) The clamp is a no-op when the global MaxConcurrentCalls is already 1 (the default): a session
+            // receiver stays at 1, identical to its non-clamped state — the override neither raises nor changes a
+            // host that never configured concurrency.
+            await using var provider = BuildServices(sb =>
+                sb.AddSessionQueueReceiver<FirstCommand>("session-queue")).BuildServiceProvider();
+
+            var discoveredRegistry = provider.GetRequiredService<IDiscoveredReceiverRegistry>();
+            var sessionReceiver = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "session-queue");
+
+            sessionReceiver.MaxConcurrentCalls.Should().Be(1);
+        }
+
         // ----------------------------------------------------------------- default-infrastructure resolution (multi-broker)
 
         // A non-ASB IMessagingInfrastructure whose Type is a distinct key. Registering this BEFORE AddAzureServiceBus

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/DependencyInjection/UsingChatterAzureServiceBusExtensions/WhenConfiguringCrossEntityTransactions.cs
@@ -562,6 +562,52 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.DependencyInjection.Using
         }
 
         [Fact]
+        public async Task MustClampSessionTopicSubscriptionStandaloneToOneWithGlobalAboveOne()
+        {
+            // (P1-topic) Regression for the raw-path-to-canonical-key path: a session topic subscription has
+            // MessageReceiverPath = raw subscription name at discovery time (before the core runtime rewrite to
+            // "<topic>/Subscriptions/<sub>"). RequiresSession must still resolve the session flag via the
+            // canonical key so the clamp fires correctly. This is the standalone case — no sibling subscription
+            // — proving the clamp is not accidentally gated on a sibling being present.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.WithMaxConcurrentCalls(7);
+                sb.AddSessionTopicSubscription<FirstEvent>("session-topic", "session-sub");
+            }).BuildServiceProvider();
+
+            var discoveredRegistry = provider.GetRequiredService<IDiscoveredReceiverRegistry>();
+            var sessionSubscription = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "session-sub");
+
+            sessionSubscription.MaxConcurrentCalls.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task MustClampSessionTopicSubscriptionAndLeaveNormalSubscriptionOnDifferentTopicAtGlobal()
+        {
+            // (P1-topic) The clamp is PER-RECEIVER and does not spill across topics: a session subscription on
+            // one topic is clamped to 1 while a normal subscription on a DISTINCT topic keeps the global 7.
+            // This complements MustClampSessionTopicSubscriptionWhileSiblingSubscriptionOnSameTopicKeepsGlobal
+            // (same-topic siblings) and confirms the per-receiver session flag is isolated by canonical key,
+            // not by topic membership.
+            await using var provider = BuildServices(sb =>
+            {
+                sb.WithMaxConcurrentCalls(7);
+                sb.AddSessionTopicSubscription<FirstEvent>("session-topic", "session-sub");
+                sb.AddTopicSubscription<SecondEvent>("normal-topic", "normal-sub");
+            }).BuildServiceProvider();
+
+            var discoveredRegistry = provider.GetRequiredService<IDiscoveredReceiverRegistry>();
+            var sessionSubscription = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "session-sub");
+            var normalSubscription = discoveredRegistry.DiscoveredReceivers
+                .Single(r => r.MessageReceiverPath == "normal-sub");
+
+            sessionSubscription.MaxConcurrentCalls.Should().Be(1);
+            normalSubscription.MaxConcurrentCalls.Should().Be(7);
+        }
+
+        [Fact]
         public async Task MustLeaveSessionReceiverAtOneWhenGlobalMaxConcurrentCallsAlreadyOne()
         {
             // (P1) The clamp is a no-op when the global MaxConcurrentCalls is already 1 (the default): a session

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/Config.json
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/Config.json
@@ -168,6 +168,17 @@
               "RequiresDuplicateDetection": false,
               "RequiresSession": false
             }
+          },
+          {
+            "Name": "chatter.session",
+            "Properties": {
+              "DeadLetteringOnMessageExpiration": false,
+              "DefaultMessageTimeToLive": "PT1H",
+              "LockDuration": "PT10S",
+              "MaxDeliveryCount": 10,
+              "RequiresDuplicateDetection": false,
+              "RequiresSession": true
+            }
           }
         ],
         "Topics": [

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineSessionTests.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Integration/PipelineSessionTests.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Chatter.CQRS;
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.AzureServiceBus.Options;
+using Chatter.MessageBrokers.Routing.Options;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Integration
+{
+    // Session coverage driven THROUGH Chatter's real pipeline against a session-enabled emulator queue
+    // (Config.json "chatter.session" with RequiresSession=true). The SYSTEM UNDER TEST is Chatter's session
+    // adapter behind the existing IServiceBusMessageReceiver port plus the held-session-receiver surfaced into
+    // the handler context: a session-mode receiver (AddSessionQueueReceiver) accepts ONE session at a time,
+    // serves its messages FIFO through Chatter's pull pump, and exposes durable per-session state via the
+    // held ServiceBusSessionReceiver. The SessionId is set on the send side as the Group Id
+    // (SendOptions.WithGroupId, which the existing mapping forwards to ServiceBusMessage.SessionId) — no
+    // WithSessionId alias exists. Raw Azure.Messaging.ServiceBus never appears as the system under test: send
+    // is via IBrokeredMessageDispatcher and receipt is via Chatter's pump and handler context.
+    //
+    // EMULATOR SESSION SUPPORT: the Azure Service Bus emulator supports session-enabled entities
+    // (RequiresSession=true) and the message-session APIs (accept-next-session, session state). These facts
+    // are still gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green; the emulator CI lane (`--filter Category=Integration`) runs them for real.
+    //
+    // Concurrency is pinned to 1 (WithMaxConcurrentCalls(1)) so the pump's per-message worker gate cannot
+    // interleave handling of two messages from the held session — the FIFO assertion observes the order
+    // Chatter handed messages to the handler, not a race in the test's own observation.
+    [Trait("Category", "Integration")]
+    [Collection(ServiceBusEmulatorCollection.Name)]
+    public class PipelineSessionTests
+    {
+        private const string SessionQueue = "chatter.session";
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(60);
+
+        private readonly ServiceBusEmulatorFixture _emulator;
+
+        public PipelineSessionTests(ServiceBusEmulatorFixture emulator)
+            => _emulator = emulator;
+
+        // A command carrying a monotonically increasing sequence number so the FIFO assertion can compare the
+        // order Chatter delivered messages to the handler against the order they were sent.
+        public sealed class SessionOrderedCommand : ICommand
+        {
+            public int Sequence { get; set; }
+        }
+
+        // A command that drives the session-state round-trip: each message instructs the handler what to read
+        // and write on the held session's durable state, and the handler records what it observed BEFORE its
+        // own write so the test can assert state set on an earlier message is visible to a later one.
+        public sealed class SessionStateCommand : ICommand
+        {
+            public int Step { get; set; }
+        }
+
+        // FIFO within a single session: N commands published with the SAME SessionId (Group Id) must be handled
+        // in send order. With concurrency pinned to 1 and a single held session served one-at-a-time, the
+        // recorder's arrival-ordered Records must equal the sent sequence 0..N-1. A regression that broke
+        // session FIFO ordering (or served multiple sessions/messages out of order) would produce a different
+        // ordering and fail this assertion.
+        [RequiresDockerFact]
+        public async Task MessagesInOneSessionAreHandledInSendOrder()
+        {
+            const int messageCount = 5;
+            var sessionId = Guid.NewGuid().ToString();
+
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb =>
+                {
+                    // Pin concurrency to 1 so the pump cannot interleave two messages from the held session;
+                    // FIFO is then the order Chatter handed messages to the handler.
+                    sb.WithMaxConcurrentCalls(1);
+                    sb.AddSessionQueueReceiver<SessionOrderedCommand>(SessionQueue);
+                },
+                typeof(SessionOrderedCommand));
+            await harness.StartAsync();
+
+            var dispatcher = harness.CreateDispatcher(out var scope);
+            using (scope)
+            {
+                for (var i = 0; i < messageCount; i++)
+                {
+                    await dispatcher.Send(new SessionOrderedCommand { Sequence = i }, SessionQueue, options: SessionSend(sessionId));
+                }
+            }
+
+            var signal = harness.GetSignal<SessionOrderedCommand>();
+            var observed = await WaitForRecordCountAsync(signal, messageCount, HandlerWait);
+            observed.Should().Be(
+                messageCount,
+                $"all {messageCount} messages sent to the one session must be delivered through Chatter's pump");
+
+            var deliveredOrder = signal.Records.Select(record => record.Message.Sequence).ToList();
+            deliveredOrder.Should().Equal(
+                Enumerable.Range(0, messageCount),
+                "messages within a single Azure Service Bus session must be handled FIFO in send order");
+
+            // The SessionId set as Group Id on send is surfaced back onto the inbound context's Group Id header.
+            var firstContext = signal.Records.First().Context;
+            firstContext.BrokeredMessage.MessageContext.Should().ContainKey(MessageContext.GroupId);
+            firstContext.BrokeredMessage.MessageContext[MessageContext.GroupId].Should().Be(
+                sessionId, "the inbound message's Group Id must carry the SessionId the message was sent with");
+        }
+
+        // Session-state round-trip across messages in ONE session: the handler reads the held session's durable
+        // state at the start of each message and writes new state before returning. Message 1 sees no prior
+        // state and sets "state-1"; message 2 sees "state-1" (proving durable per-session state persisted across
+        // messages via the held session receiver) and then CLEARS it; message 3 sees no state again (proving
+        // Clear took effect). This exercises Get/Set/Clear against the real held ServiceBusSessionReceiver.
+        [RequiresDockerFact]
+        public async Task SessionStateRoundTripsAcrossMessagesInOneSession()
+        {
+            const int messageCount = 3;
+            var sessionId = Guid.NewGuid().ToString();
+            var observer = new SessionStateObserver();
+
+            await using var harness = ChatterPipelineHarness.Build(
+                _emulator.GetConnectionString(),
+                sb =>
+                {
+                    // One-at-a-time handling so each message's read observes the previous message's write, not a
+                    // concurrent in-flight write.
+                    sb.WithMaxConcurrentCalls(1);
+                    sb.AddSessionQueueReceiver<SessionStateCommand>(SessionQueue);
+                },
+                services =>
+                {
+                    // Registered AFTER the harness's default RecordingMessageHandler<SessionStateCommand>, so this
+                    // state-driving handler wins on GetRequiredService and is the one Chatter invokes.
+                    services.AddSingleton(observer);
+                    services.AddTransient<IMessageHandler<SessionStateCommand>, SessionStateHandler>();
+                },
+                typeof(SessionStateCommand));
+            await harness.StartAsync();
+
+            var dispatcher = harness.CreateDispatcher(out var scope);
+            using (scope)
+            {
+                for (var step = 1; step <= messageCount; step++)
+                {
+                    await dispatcher.Send(new SessionStateCommand { Step = step }, SessionQueue, options: SessionSend(sessionId));
+                }
+            }
+
+            var handledSteps = await observer.WaitForHandledAsync(messageCount, HandlerWait);
+            handledSteps.Should().Be(
+                messageCount,
+                $"all {messageCount} session-state messages must be delivered through Chatter's pump");
+
+            // Step 1: no prior state (the session starts empty).
+            observer.StateSeenAt(1).Should().BeNull(
+                "the first message in a fresh session must observe no durable session state");
+
+            // Step 2: the state SET on step 1 must be durably visible — this is the proof of per-session state
+            // persisting across messages via the held session receiver.
+            observer.StateSeenAt(2).Should().Be(
+                "state-1", "session state set while handling an earlier message must persist to a later message in the same session");
+
+            // Step 3: after step 2 CLEARED the state, it must be gone again — proving Clear took effect.
+            observer.StateSeenAt(3).Should().BeNull(
+                "clearing session state while handling a message must remove it for later messages in the same session");
+        }
+
+        // Builds the SendOptions that route a message to the given session. SendOptions.WithGroupId stamps
+        // MessageContext.GroupId, which the existing ASB mapping forwards to ServiceBusMessage.SessionId. The
+        // mapping (OutboundBrokeredMessageExtensions.AsAzureServiceBusMessage) assigns SessionId then
+        // PartitionKey on the SDK message, and the SDK requires PartitionKey == SessionId for a session/
+        // partitioned message — so the matching PartitionKey must be set alongside the Group Id or the setter
+        // throws (this is the documented send-side contract, pinned by the unit test
+        // MustMapSessionIdFromGroupIdWhenPartitionKeyMatches). Set both to the session id here.
+        private static SendOptions SessionSend(string sessionId)
+        {
+            var options = new SendOptions().WithGroupId(sessionId);
+            options.WithMessageContext(ASBMessageContext.PartitionKey, sessionId);
+            return options;
+        }
+
+        // Bounded poll until the recorder has captured at least minCount invocations, returning the observed
+        // count (which may be below minCount if the timeout elapses — the caller asserts on it so a
+        // never-reached threshold fails fast instead of hanging CI).
+        private static async Task<int> WaitForRecordCountAsync<TMessage>(
+            HandlerSignal<TMessage> signal, int minCount, TimeSpan timeout)
+            where TMessage : IMessage
+        {
+            var deadline = DateTime.UtcNow + timeout;
+            while (DateTime.UtcNow < deadline)
+            {
+                if (signal.Records.Count >= minCount)
+                {
+                    return signal.Records.Count;
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+            }
+
+            return signal.Records.Count;
+        }
+
+        // Shared observer the state-driving handler reports through: records, per step, the durable session
+        // state the handler READ before performing its own write/clear, so the test can assert that state set
+        // on an earlier message is visible to (or cleared for) a later message in the same session.
+        private sealed class SessionStateObserver
+        {
+            private readonly ConcurrentDictionary<int, string> _stateSeen = new ConcurrentDictionary<int, string>();
+            private int _handledCount;
+
+            // Sentinel for "the handler read null session state at this step" so a recorded null is
+            // distinguishable from "this step was never handled" (a missing key).
+            private const string NullStateSentinel = "\0__null-session-state__";
+
+            public void RecordStateSeen(int step, string stateSeen)
+            {
+                _stateSeen[step] = stateSeen ?? NullStateSentinel;
+                System.Threading.Interlocked.Increment(ref _handledCount);
+            }
+
+            // The durable session state the handler observed at the start of the given step, or null if it read
+            // no state. Throws if the step was never handled so a missed delivery surfaces clearly.
+            public string StateSeenAt(int step)
+            {
+                if (!_stateSeen.TryGetValue(step, out var seen))
+                {
+                    throw new InvalidOperationException($"Step {step} was never handled.");
+                }
+
+                return seen == NullStateSentinel ? null : seen;
+            }
+
+            // Bounded poll until at least minCount steps have been handled, returning the observed count (which
+            // may be below minCount on timeout — the caller asserts on it so a stalled receive fails fast).
+            public async Task<int> WaitForHandledAsync(int minCount, TimeSpan timeout)
+            {
+                var deadline = DateTime.UtcNow + timeout;
+                while (DateTime.UtcNow < deadline)
+                {
+                    if (System.Threading.Volatile.Read(ref _handledCount) >= minCount)
+                    {
+                        return System.Threading.Volatile.Read(ref _handledCount);
+                    }
+
+                    await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+                }
+
+                return System.Threading.Volatile.Read(ref _handledCount);
+            }
+        }
+
+        // The state-driving handler Chatter resolves on the session receive path. Each message reads the held
+        // session's durable state (Get), records what it saw, then writes the next state (Set) or clears it
+        // (Clear) depending on its step, exercising the full Get/Set/Clear surface over the held session.
+        private sealed class SessionStateHandler : IMessageHandler<SessionStateCommand>
+        {
+            private readonly SessionStateObserver _observer;
+
+            public SessionStateHandler(SessionStateObserver observer)
+                => _observer = observer;
+
+            public async Task Handle(SessionStateCommand message, IMessageHandlerContext context)
+            {
+                var existing = await context.GetSessionStateAsync().ConfigureAwait(false);
+                _observer.RecordStateSeen(message.Step, existing is null ? null : existing.ToString());
+
+                if (message.Step == 1)
+                {
+                    await context.SetSessionStateAsync(BinaryData.FromString("state-1")).ConfigureAwait(false);
+                }
+                else if (message.Step == 2)
+                {
+                    await context.ClearSessionStateAsync().ConfigureAwait(false);
+                }
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingInboundBrokeredMessageFactory/WhenCreatingContextForSessionMessage.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingInboundBrokeredMessageFactory/WhenCreatingContextForSessionMessage.cs
@@ -1,0 +1,74 @@
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.AzureServiceBus.Receiving;
+using Azure.Messaging.ServiceBus;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Threading;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingInboundBrokeredMessageFactory
+{
+    // Pins InboundBrokeredMessageFactory's SessionId -> GroupId stamp: a session message's SessionId is
+    // surfaced under the existing core MessageContext.GroupId header, and a non-session message (SessionId
+    // absent/empty) leaves GroupId unstamped. SessionId is a received-state field on ServiceBusReceivedMessage,
+    // so messages are built via ServiceBusModelFactory.ServiceBusReceivedMessage(sessionId: ...) — the same
+    // no-reflection received-message construction the shared ServiceBusMessageFactory uses.
+    public class WhenCreatingContextForSessionMessage : Testing.Core.Context
+    {
+        private static InboundBrokeredMessageFactory CreateSut()
+        {
+            var bodyConverterFactory = new Mock<IBodyConverterFactory>();
+            bodyConverterFactory.Setup(f => f.CreateBodyConverter(It.IsAny<string>())).Returns(new JsonBodyConverter());
+            return new InboundBrokeredMessageFactory(bodyConverterFactory.Object, Mock.Of<ILogger>());
+        }
+
+        private static ServiceBusReceivedMessage ReceivedMessage(string sessionId)
+            => ServiceBusModelFactory.ServiceBusReceivedMessage(
+                body: new BinaryData(new byte[] { 1 }),
+                messageId: "message-id",
+                contentType: "application/json",
+                timeToLive: TimeSpan.FromMinutes(5),
+                deliveryCount: 1,
+                lockTokenGuid: Guid.NewGuid(),
+                enqueuedTime: DateTimeOffset.UtcNow,
+                sessionId: sessionId);
+
+        [Fact]
+        public void MustStampGroupIdFromSessionIdWhenSessionPresent()
+        {
+            var sut = CreateSut();
+            var message = ReceivedMessage(sessionId: "session-42");
+
+            var context = sut.CreateContext(message, "receiver", CancellationToken.None);
+
+            context.Should().NotBeNull();
+            context.BrokeredMessage.MessageContext[MessageContext.GroupId].Should().Be("session-42");
+        }
+
+        [Fact]
+        public void MustNotStampGroupIdWhenSessionIdAbsent()
+        {
+            var sut = CreateSut();
+            var message = ReceivedMessage(sessionId: null);
+
+            var context = sut.CreateContext(message, "receiver", CancellationToken.None);
+
+            context.Should().NotBeNull();
+            context.BrokeredMessage.MessageContext.Should().NotContainKey(MessageContext.GroupId);
+        }
+
+        [Fact]
+        public void MustNotStampGroupIdWhenSessionIdEmpty()
+        {
+            var sut = CreateSut();
+            var message = ReceivedMessage(sessionId: string.Empty);
+
+            var context = sut.CreateContext(message, "receiver", CancellationToken.None);
+
+            context.Should().NotBeNull();
+            context.BrokeredMessage.MessageContext.Should().NotContainKey(MessageContext.GroupId);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenSelectingProductionReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenSelectingProductionReceiver.cs
@@ -52,6 +52,17 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
             return sut;
         }
 
+        // The formatted subscription path core BrokeredMessageReceiver.StartReceiver rewrites
+        // options.MessageReceiverPath into (line 261:
+        // PathBuilder.GetMessageReceivingPath(SendingPath, MessageReceiverPath)) BEFORE the ASB receiver factory
+        // runs its RequiresSession lookup. Reproducing that rewrite here is what makes these tests exercise the
+        // runtime lookup path: the registry is registered with the RAW subscription name, but the production
+        // factory is handed this FORMATTED path as MessageReceiverPath — the exact raw-vs-formatted mismatch the
+        // canonical key closes.
+        private const string SubscriptionsSegment = "Subscriptions";
+        private static string FormattedSubscriptionPath(string topic, string subscription)
+            => $"{topic}/{SubscriptionsSegment}/{subscription}";
+
         [Fact]
         public async Task MustSelectSessionAdapterWhenRegistryMarksEntitySessionMode()
         {
@@ -93,22 +104,77 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
         }
 
         [Fact]
-        public async Task MustRouteEachSubscriptionOnSharedTopicToItsOwnAdapter()
+        public async Task MustResolveSessionAdapterForTopicSubscriptionRegisteredRawAfterRuntimeFormattedRewrite()
         {
-            // The exact P2 collision case: a session subscription and a normal subscription on the SAME topic.
-            // The session flag is keyed PER-RECEIVER (subscription + topic), so the session subscription routes
-            // to the session adapter while the normal subscription on the same topic routes to the non-session
-            // adapter — they no longer collide on the shared top-level entity (the topic).
+            // The exact iter-2 P1 failing case. A topic session subscription is REGISTERED with the raw
+            // subscription name (as AddSessionTopicSubscription does: Register(topic, sub, ...)), but at runtime
+            // core StartReceiver rewrites MessageReceiverPath to the FORMATTED "<topic>/Subscriptions/<sub>"
+            // BEFORE CreateProductionReceiver's RequiresSession lookup. The canonical-key derivation must map the
+            // formatted lookup back to the raw registration so the session adapter is selected. Before STEP-001
+            // the formatted path failed the lookup and fell through to the non-session adapter, so this test
+            // would have FAILED.
+            const string topic = "orders-topic";
+            const string subscription = "orders-session-sub";
+            var registry = new ServiceBusReceiverRegistry();
+            registry.Register(topic, subscription, transactionMode: null, requiresSession: true);
+
+            var sut = await InitializedSutAsync(registry, receiverPath: FormattedSubscriptionPath(topic, subscription), sendingPath: topic);
+
+            sut.InnerReceiver.Should().BeOfType<AzureSdkSessionMessageReceiverAdapter>();
+        }
+
+        [Fact]
+        public async Task MustRouteEachSubscriptionOnSharedTopicToItsOwnAdapterAtRuntimeFormattedPaths()
+        {
+            // The exact P2 collision case, exercised through the RUNTIME formatted path. A session subscription
+            // and a normal subscription on the SAME topic are registered with their raw subscription names, but
+            // each arrives at the lookup with its formatted "<topic>/Subscriptions/<sub>" path (StartReceiver's
+            // rewrite). The session flag is keyed PER-RECEIVER (subscription + topic), so the session
+            // subscription routes to the session adapter while the normal subscription on the same topic routes
+            // to the non-session adapter — they no longer collide on the shared top-level entity (the topic).
             const string sharedTopic = "shared-topic";
             var registry = new ServiceBusReceiverRegistry();
             registry.Register(sharedTopic, "session-subscription", transactionMode: null, requiresSession: true);
             registry.Register(sharedTopic, "normal-subscription", transactionMode: null, requiresSession: false);
 
-            var sessionSut = await InitializedSutAsync(registry, receiverPath: "session-subscription", sendingPath: sharedTopic);
-            var normalSut = await InitializedSutAsync(registry, receiverPath: "normal-subscription", sendingPath: sharedTopic);
+            var sessionSut = await InitializedSutAsync(registry, receiverPath: FormattedSubscriptionPath(sharedTopic, "session-subscription"), sendingPath: sharedTopic);
+            var normalSut = await InitializedSutAsync(registry, receiverPath: FormattedSubscriptionPath(sharedTopic, "normal-subscription"), sendingPath: sharedTopic);
 
             sessionSut.InnerReceiver.Should().BeOfType<AzureSdkSessionMessageReceiverAdapter>();
             normalSut.InnerReceiver.Should().BeOfType<AzureSdkMessageReceiverAdapter>();
+        }
+
+        [Fact]
+        public async Task MustSelectSessionAdapterForQueueReceiverWithNoRuntimeRewrite()
+        {
+            // Queue session receivers have no formatted rewrite: SendingPath == MessageReceiverPath, so
+            // StartReceiver's GetMessageReceivingPath returns the raw queue name unchanged. The raw registration
+            // and the (unchanged) runtime path must still resolve to the session adapter.
+            const string sessionQueue = "session-queue";
+            var registry = new ServiceBusReceiverRegistry();
+            registry.Register(sessionQueue, sessionQueue, transactionMode: null, requiresSession: true);
+
+            var sut = await InitializedSutAsync(registry, receiverPath: sessionQueue);
+
+            sut.InnerReceiver.Should().BeOfType<AzureSdkSessionMessageReceiverAdapter>();
+        }
+
+        [Fact]
+        public async Task MustResolveSessionAdapterWithoutDoubleFormattingWhenLookupPathAlreadyFormatted()
+        {
+            // Idempotency guard. The canonical-key derivation must NOT re-format an already-formatted
+            // subscription path into "<topic>/Subscriptions/<topic>/Subscriptions/<sub>". Feeding the
+            // already-formatted runtime path must collapse to the SAME canonical key the raw registration
+            // produced, so the session adapter is still selected. A double-format would miss the registration and
+            // fall through to the non-session adapter.
+            const string topic = "events-topic";
+            const string subscription = "events-session-sub";
+            var registry = new ServiceBusReceiverRegistry();
+            registry.Register(topic, subscription, transactionMode: null, requiresSession: true);
+
+            var sut = await InitializedSutAsync(registry, receiverPath: FormattedSubscriptionPath(topic, subscription), sendingPath: topic);
+
+            sut.InnerReceiver.Should().BeOfType<AzureSdkSessionMessageReceiverAdapter>();
         }
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenSelectingProductionReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenSelectingProductionReceiver.cs
@@ -40,13 +40,15 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
         }
 
         // Constructs the SUT on the PRODUCTION receiver factory (the five-argument ctor leaves
-        // receiverFactory null, so CreateProductionReceiver is used) with the supplied registry.
-        private static async Task<ServiceBusReceiver> InitializedSutAsync(ServiceBusReceiverRegistry registry, string receiverPath)
+        // receiverFactory null, so CreateProductionReceiver is used) with the supplied registry. sendingPath
+        // defaults to receiverPath (the queue-receiver shape); a subscription supplies its topic explicitly so
+        // the per-receiver session key carries (subscription, topic).
+        private static async Task<ServiceBusReceiver> InitializedSutAsync(ServiceBusReceiverRegistry registry, string receiverPath, string sendingPath = null)
         {
             var serviceBusOptions = new ServiceBusOptions { ConnectionString = _connectionString };
             var logger = new Mock<ILogger<ServiceBusReceiver>>();
             var sut = new ServiceBusReceiver(CreateClient(), serviceBusOptions, new MessageBrokerOptions(), logger.Object, JsonFactory(), registry);
-            await sut.InitializeAsync(new ReceiverOptions { MessageReceiverPath = receiverPath, SendingPath = receiverPath }, CancellationToken.None);
+            await sut.InitializeAsync(new ReceiverOptions { MessageReceiverPath = receiverPath, SendingPath = sendingPath ?? receiverPath }, CancellationToken.None);
             return sut;
         }
 
@@ -54,7 +56,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
         public async Task MustSelectSessionAdapterWhenRegistryMarksEntitySessionMode()
         {
             var registry = new ServiceBusReceiverRegistry();
-            registry.Register("session-queue", transactionMode: null, requiresSession: true);
+            registry.Register("session-queue", "session-queue", transactionMode: null, requiresSession: true);
             var sut = await InitializedSutAsync(registry, "session-queue");
 
             sut.InnerReceiver.Should().BeOfType<AzureSdkSessionMessageReceiverAdapter>();
@@ -64,7 +66,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
         public async Task MustSelectNonSessionAdapterWhenRegistryEntryIsNotSessionMode()
         {
             var registry = new ServiceBusReceiverRegistry();
-            registry.Register("plain-queue", transactionMode: null, requiresSession: false);
+            registry.Register("plain-queue", "plain-queue", transactionMode: null, requiresSession: false);
             var sut = await InitializedSutAsync(registry, "plain-queue");
 
             sut.InnerReceiver.Should().BeOfType<AzureSdkMessageReceiverAdapter>();
@@ -74,7 +76,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
         public async Task MustSelectNonSessionAdapterWhenRegistryHasNoMatchingEntity()
         {
             var registry = new ServiceBusReceiverRegistry();
-            registry.Register("some-other-queue", transactionMode: null, requiresSession: true);
+            registry.Register("some-other-queue", "some-other-queue", transactionMode: null, requiresSession: true);
             var sut = await InitializedSutAsync(registry, "plain-queue");
 
             sut.InnerReceiver.Should().BeOfType<AzureSdkMessageReceiverAdapter>();
@@ -88,6 +90,25 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBus
             var sut = await InitializedSutAsync(registry: null, receiverPath: "plain-queue");
 
             sut.InnerReceiver.Should().BeOfType<AzureSdkMessageReceiverAdapter>();
+        }
+
+        [Fact]
+        public async Task MustRouteEachSubscriptionOnSharedTopicToItsOwnAdapter()
+        {
+            // The exact P2 collision case: a session subscription and a normal subscription on the SAME topic.
+            // The session flag is keyed PER-RECEIVER (subscription + topic), so the session subscription routes
+            // to the session adapter while the normal subscription on the same topic routes to the non-session
+            // adapter — they no longer collide on the shared top-level entity (the topic).
+            const string sharedTopic = "shared-topic";
+            var registry = new ServiceBusReceiverRegistry();
+            registry.Register(sharedTopic, "session-subscription", transactionMode: null, requiresSession: true);
+            registry.Register(sharedTopic, "normal-subscription", transactionMode: null, requiresSession: false);
+
+            var sessionSut = await InitializedSutAsync(registry, receiverPath: "session-subscription", sendingPath: sharedTopic);
+            var normalSut = await InitializedSutAsync(registry, receiverPath: "normal-subscription", sendingPath: sharedTopic);
+
+            sessionSut.InnerReceiver.Should().BeOfType<AzureSdkSessionMessageReceiverAdapter>();
+            normalSut.InnerReceiver.Should().BeOfType<AzureSdkMessageReceiverAdapter>();
         }
     }
 }

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenSelectingProductionReceiver.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingServiceBusReceiver/WhenSelectingProductionReceiver.cs
@@ -1,0 +1,93 @@
+using Chatter.MessageBrokers.AzureServiceBus.DependencyInjection;
+using Chatter.MessageBrokers.AzureServiceBus.Options;
+using Chatter.MessageBrokers.AzureServiceBus.Receiving;
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Receiving;
+using FluentAssertions;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+// Disambiguate the local ServiceBusReceiver (system under test) from the SDK type of the same name
+// pulled in by `using Azure.Messaging.ServiceBus;` (CS0104).
+using ServiceBusReceiver = Chatter.MessageBrokers.AzureServiceBus.Receiving.ServiceBusReceiver;
+using ServiceBusClient = Azure.Messaging.ServiceBus.ServiceBusClient;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingServiceBusReceiver
+{
+    // Pins ServiceBusReceiver.CreateProductionReceiver's session-vs-non-session branch. This uses the
+    // PRODUCTION receiver factory (no test receiverFactory seam supplied) so the real branch runs, and
+    // observes the chosen adapter directly through the internal InnerReceiver accessor. Neither adapter
+    // ctor opens a connection (the non-session adapter lazily creates its SDK receiver only on first
+    // ReceiveAsync; the session adapter accepts a session only on ReceiveAsync), so resolving InnerReceiver
+    // is connection-free and the concrete adapter TYPE is the observable proof of the registry branch.
+    public class WhenSelectingProductionReceiver : Testing.Core.Context
+    {
+        private const string _connectionString =
+            "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=secret";
+
+        // A placeholder SAS connection string opens no connection (the SDK connects lazily), so this is a
+        // valid stand-in for the DI-provided shared client.
+        private static ServiceBusClient CreateClient() => new ServiceBusClient(_connectionString);
+
+        private static IBodyConverterFactory JsonFactory()
+        {
+            var factory = new Mock<IBodyConverterFactory>();
+            factory.Setup(f => f.CreateBodyConverter(It.IsAny<string>())).Returns(new JsonBodyConverter());
+            return factory.Object;
+        }
+
+        // Constructs the SUT on the PRODUCTION receiver factory (the five-argument ctor leaves
+        // receiverFactory null, so CreateProductionReceiver is used) with the supplied registry.
+        private static async Task<ServiceBusReceiver> InitializedSutAsync(ServiceBusReceiverRegistry registry, string receiverPath)
+        {
+            var serviceBusOptions = new ServiceBusOptions { ConnectionString = _connectionString };
+            var logger = new Mock<ILogger<ServiceBusReceiver>>();
+            var sut = new ServiceBusReceiver(CreateClient(), serviceBusOptions, new MessageBrokerOptions(), logger.Object, JsonFactory(), registry);
+            await sut.InitializeAsync(new ReceiverOptions { MessageReceiverPath = receiverPath, SendingPath = receiverPath }, CancellationToken.None);
+            return sut;
+        }
+
+        [Fact]
+        public async Task MustSelectSessionAdapterWhenRegistryMarksEntitySessionMode()
+        {
+            var registry = new ServiceBusReceiverRegistry();
+            registry.Register("session-queue", transactionMode: null, requiresSession: true);
+            var sut = await InitializedSutAsync(registry, "session-queue");
+
+            sut.InnerReceiver.Should().BeOfType<AzureSdkSessionMessageReceiverAdapter>();
+        }
+
+        [Fact]
+        public async Task MustSelectNonSessionAdapterWhenRegistryEntryIsNotSessionMode()
+        {
+            var registry = new ServiceBusReceiverRegistry();
+            registry.Register("plain-queue", transactionMode: null, requiresSession: false);
+            var sut = await InitializedSutAsync(registry, "plain-queue");
+
+            sut.InnerReceiver.Should().BeOfType<AzureSdkMessageReceiverAdapter>();
+        }
+
+        [Fact]
+        public async Task MustSelectNonSessionAdapterWhenRegistryHasNoMatchingEntity()
+        {
+            var registry = new ServiceBusReceiverRegistry();
+            registry.Register("some-other-queue", transactionMode: null, requiresSession: true);
+            var sut = await InitializedSutAsync(registry, "plain-queue");
+
+            sut.InnerReceiver.Should().BeOfType<AzureSdkMessageReceiverAdapter>();
+        }
+
+        [Fact]
+        public async Task MustSelectNonSessionAdapterWhenRegistryAbsent()
+        {
+            // The five-argument production ctor allows a null registry (existing callers/tests); the
+            // session-vs-non-session branch null-guards it and selects the non-session adapter.
+            var sut = await InitializedSutAsync(registry: null, receiverPath: "plain-queue");
+
+            sut.InnerReceiver.Should().BeOfType<AzureSdkMessageReceiverAdapter>();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingSessionEntityPath/WhenResolvingSessionEntityPath.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingSessionEntityPath/WhenResolvingSessionEntityPath.cs
@@ -1,0 +1,104 @@
+using Chatter.MessageBrokers.AzureServiceBus.Receiving;
+using FluentAssertions;
+using System;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingSessionEntityPath
+{
+    // Pins the structured overload-selection seam of ServiceBusSessionEntityPath WITHOUT a live Azure Service Bus
+    // namespace. The defect class this type eliminates is feeding a flat "<topic>/Subscriptions/<sub>" composite
+    // to the queue-only AcceptNextSessionAsync(string, ...) overload; these tests prove the closed-sum resolution
+    // (queue XOR subscription), the raw-vs-formatted idempotency at the boundary, and that wrong-arm access fails
+    // loudly rather than returning a sentinel.
+    public class WhenResolvingSessionEntityPath : Testing.Core.Context
+    {
+        // (a) Topic subscription resolved from the RUNTIME FORMATTED receiver path — the exact iter-3 defect case.
+        // The core receiver rewrites MessageReceiverPath to "<topic>/Subscriptions/<sub>" before the adapter sees
+        // it; the structured identity must strip the formatted prefix down to the bare subscription name.
+        [Fact]
+        public void MustResolveSubscriptionFromFormattedReceiverPath()
+        {
+            var entityPath = ServiceBusSessionEntityPath.Create("my-topic", "my-topic/Subscriptions/my-sub");
+
+            entityPath.IsSubscription.Should().BeTrue();
+            entityPath.TopicName.Should().Be("my-topic");
+            entityPath.SubscriptionName.Should().Be("my-sub");
+        }
+
+        // (b) Topic subscription resolved from the RAW receiver path — registration/discovery pass a bare
+        // subscription name. Idempotent with (a): no double-format, no leftover "<topic>/Subscriptions/" prefix.
+        [Fact]
+        public void MustResolveSubscriptionFromRawReceiverPath()
+        {
+            var entityPath = ServiceBusSessionEntityPath.Create("my-topic", "my-sub");
+
+            entityPath.IsSubscription.Should().BeTrue();
+            entityPath.TopicName.Should().Be("my-topic");
+            entityPath.SubscriptionName.Should().Be("my-sub");
+        }
+
+        // (c) Queue receiver — sendingPath null/empty OR equal to the receiver path both collapse to the single-arg
+        // queue overload (IsSubscription false, QueueName = receiver path).
+        [Fact]
+        public void MustResolveQueueWhenSendingPathEmpty()
+        {
+            var entityPath = ServiceBusSessionEntityPath.Create(string.Empty, "my-queue");
+
+            entityPath.IsSubscription.Should().BeFalse();
+            entityPath.QueueName.Should().Be("my-queue");
+        }
+
+        [Fact]
+        public void MustResolveQueueWhenSendingPathEqualsReceiverPath()
+        {
+            var entityPath = ServiceBusSessionEntityPath.Create("my-queue", "my-queue");
+
+            entityPath.IsSubscription.Should().BeFalse();
+            entityPath.QueueName.Should().Be("my-queue");
+        }
+
+        // (d) Prefix stripping is case-insensitive (Azure Service Bus entity-name semantics): a mixed-case formatted
+        // prefix still strips to the bare subscription name.
+        [Fact]
+        public void MustStripFormattedPrefixCaseInsensitively()
+        {
+            var entityPath = ServiceBusSessionEntityPath.Create("my-topic", "My-Topic/Subscriptions/my-sub");
+
+            entityPath.IsSubscription.Should().BeTrue();
+            entityPath.TopicName.Should().Be("my-topic");
+            entityPath.SubscriptionName.Should().Be("my-sub");
+        }
+
+        // (e) Wrong-arm access fails loudly rather than returning a sentinel that erases the queue/subscription
+        // distinction — reading the queue name of a subscription (or vice versa) is a programming error.
+        [Fact]
+        public void MustThrowWhenReadingQueueNameOfSubscription()
+        {
+            var entityPath = ServiceBusSessionEntityPath.Create("my-topic", "my-sub");
+
+            Action act = () => _ = entityPath.QueueName;
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void MustThrowWhenReadingTopicNameOfQueue()
+        {
+            var entityPath = ServiceBusSessionEntityPath.Create(string.Empty, "my-queue");
+
+            Action act = () => _ = entityPath.TopicName;
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void MustThrowWhenReadingSubscriptionNameOfQueue()
+        {
+            var entityPath = ServiceBusSessionEntityPath.Create(string.Empty, "my-queue");
+
+            Action act = () => _ = entityPath.SubscriptionName;
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingSessionMessageReceiverAdapter/WhenSettlingWithoutHeldSession.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingSessionMessageReceiverAdapter/WhenSettlingWithoutHeldSession.cs
@@ -29,7 +29,7 @@ namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingSessionMes
 
         private static AzureSdkSessionMessageReceiverAdapter CreateSut(ServiceBusReceiveMode receiveMode = ServiceBusReceiveMode.PeekLock)
             => new AzureSdkSessionMessageReceiverAdapter(CreateClient(),
-                                                         _receiverPath,
+                                                         ServiceBusSessionEntityPath.Create(string.Empty, _receiverPath),
                                                          receiveMode,
                                                          prefetchCount: 0,
                                                          sessionIdleTimeout: TimeSpan.FromSeconds(1),

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingSessionMessageReceiverAdapter/WhenSettlingWithoutHeldSession.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingSessionMessageReceiverAdapter/WhenSettlingWithoutHeldSession.cs
@@ -1,0 +1,128 @@
+using Chatter.MessageBrokers.AzureServiceBus.Receiving;
+using FluentAssertions;
+using Azure.Messaging.ServiceBus;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingSessionMessageReceiverAdapter
+{
+    // Pins the connection-free behavior of AzureSdkSessionMessageReceiverAdapter that is reachable without a
+    // live Azure Service Bus namespace. ServiceBusSessionReceiver is SEALED and is only acquired via the live
+    // client's AcceptNextSessionAsync, so the held-session settle/roll paths cannot be exercised here; what is
+    // observable is the guard behavior BEFORE a session is held: no session is held on construction, settle
+    // calls short-circuit (no held session and/or ReceiveAndDelete mode), and CloseAsync flips IsClosedOrClosing
+    // without touching a session. The held-session FIFO/idle/lock-loss rollover paths require a live session and
+    // are documented in the worker report as untestable behind this seam.
+    public class WhenSettlingWithoutHeldSession : Testing.Core.Context
+    {
+        private const string _receiverPath = "session-queue";
+        private const string _connectionString =
+            "Endpoint=sb://test.servicebus.windows.net/;SharedAccessKeyName=key;SharedAccessKey=secret";
+
+        // A placeholder SAS connection string opens no connection (the SDK connects lazily), so this is a valid
+        // stand-in for the shared client the adapter would receive from DI.
+        private static ServiceBusClient CreateClient() => new ServiceBusClient(_connectionString);
+
+        private static AzureSdkSessionMessageReceiverAdapter CreateSut(ServiceBusReceiveMode receiveMode = ServiceBusReceiveMode.PeekLock)
+            => new AzureSdkSessionMessageReceiverAdapter(CreateClient(),
+                                                         _receiverPath,
+                                                         receiveMode,
+                                                         prefetchCount: 0,
+                                                         sessionIdleTimeout: TimeSpan.FromSeconds(1),
+                                                         maxSessionLockRenewalDuration: TimeSpan.FromMinutes(5),
+                                                         Mock.Of<ILogger>());
+
+        private static ServiceBusReceivedMessage AnyMessage()
+            => ServiceBusModelFactory.ServiceBusReceivedMessage(
+                body: new BinaryData(new byte[] { 1 }),
+                messageId: "message-id",
+                lockTokenGuid: Guid.NewGuid());
+
+        [Fact]
+        public void MustHoldNoSessionOnConstruction()
+        {
+            var sut = CreateSut();
+            sut.HeldSessionReceiver.Should().BeNull();
+        }
+
+        [Fact]
+        public void MustNotReportClosedOnConstruction()
+        {
+            var sut = CreateSut();
+            sut.IsClosedOrClosing.Should().BeFalse();
+        }
+
+        [Fact]
+        public async Task MustReportClosedAfterClose()
+        {
+            var sut = CreateSut();
+
+            await sut.CloseAsync();
+
+            sut.IsClosedOrClosing.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task MustNoOpCompleteWhenNoSessionHeld()
+        {
+            var sut = CreateSut();
+
+            // No held session: CompleteAsync short-circuits to a completed task rather than touching a session
+            // receiver (which would require a live connection).
+            Func<Task> act = () => sut.CompleteAsync(AnyMessage());
+
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task MustNoOpAbandonWhenNoSessionHeld()
+        {
+            var sut = CreateSut();
+
+            Func<Task> act = () => sut.AbandonAsync(AnyMessage(), new Dictionary<string, object>());
+
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task MustNoOpDeadLetterWhenNoSessionHeld()
+        {
+            var sut = CreateSut();
+
+            Func<Task> act = () => sut.DeadLetterAsync(AnyMessage(), "reason", "description");
+
+            await act.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task MustNoOpSettleInReceiveAndDeleteMode()
+        {
+            // In ReceiveAndDelete the settle calls short-circuit on receive-mode before any session lookup,
+            // so they complete without a connection even conceptually.
+            var sut = CreateSut(ServiceBusReceiveMode.ReceiveAndDelete);
+
+            Func<Task> complete = () => sut.CompleteAsync(AnyMessage());
+            Func<Task> abandon = () => sut.AbandonAsync(AnyMessage(), new Dictionary<string, object>());
+            Func<Task> deadLetter = () => sut.DeadLetterAsync(AnyMessage(), "reason", "description");
+
+            await complete.Should().NotThrowAsync();
+            await abandon.Should().NotThrowAsync();
+            await deadLetter.Should().NotThrowAsync();
+        }
+
+        [Fact]
+        public async Task MustCloseIdempotentlyWhenNoSessionHeld()
+        {
+            var sut = CreateSut();
+
+            await sut.CloseAsync();
+            Func<Task> secondClose = () => sut.CloseAsync();
+
+            await secondClose.Should().NotThrowAsync();
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingSessionStateExtensions/WhenInvokedOnNonSessionContext.cs
+++ b/src/Chatter.MessageBrokers.AzureServiceBus/tests/Receiving/UsingSessionStateExtensions/WhenInvokedOnNonSessionContext.cs
@@ -1,0 +1,60 @@
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.Context;
+using FluentAssertions;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.AzureServiceBus.Tests.Receiving.UsingSessionStateExtensions
+{
+    // Pins the session-state misuse guard: invoking Get/Set/ClearSessionStateAsync while handling a message
+    // that was NOT received through a session-enabled receiver fails fast with InvalidOperationException and
+    // the documented message, rather than a silent no-op or a NullReferenceException. A non-session context is
+    // modeled by a MessageBrokerContext whose container holds no TransactionContext (and therefore no held
+    // ServiceBusSessionReceiver) — exactly the shape a non-session receive produces.
+    public class WhenInvokedOnNonSessionContext : Testing.Core.Context
+    {
+        private const string _expectedMessage =
+            "Azure Service Bus session state is only available for session-enabled receivers.";
+
+        private static MessageBrokerContext NonSessionContext()
+        {
+            var bodyConverter = new Mock<IBrokeredMessageBodyConverter>();
+            bodyConverter.SetupGet(c => c.ContentType).Returns("application/json");
+            return new MessageBrokerContext("message-id", new byte[] { 1 }, new Dictionary<string, object>(), "receiver-path", CancellationToken.None, bodyConverter.Object);
+        }
+
+        [Fact]
+        public async Task MustThrowOnGetSessionState()
+        {
+            var context = NonSessionContext();
+
+            Func<Task> act = () => context.GetSessionStateAsync();
+
+            (await act.Should().ThrowAsync<InvalidOperationException>()).WithMessage(_expectedMessage);
+        }
+
+        [Fact]
+        public async Task MustThrowOnSetSessionState()
+        {
+            var context = NonSessionContext();
+
+            Func<Task> act = () => context.SetSessionStateAsync(new BinaryData(new byte[] { 1 }));
+
+            (await act.Should().ThrowAsync<InvalidOperationException>()).WithMessage(_expectedMessage);
+        }
+
+        [Fact]
+        public async Task MustThrowOnClearSessionState()
+        {
+            var context = NonSessionContext();
+
+            Func<Task> act = () => context.ClearSessionStateAsync();
+
+            (await act.Should().ThrowAsync<InvalidOperationException>()).WithMessage(_expectedMessage);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds Azure Service Bus message-session support entirely within `Chatter.MessageBrokers.AzureServiceBus` — **no core `Chatter.MessageBrokers` changes**. Single PR, additive ASB minor bump **1.3.0 → 1.4.0**.

## What's delivered
- **Single-session-at-a-time receiver adapter** (`AzureSdkSessionMessageReceiverAdapter : IServiceBusMessageReceiver`) over the existing Chatter pull pump — native `ServiceBusSessionProcessor` (push) deliberately rejected. FIFO per `SessionId`; settle on the held session receiver; bounded lock renewal (one CTS + one renewal task per session, ceiling `MaxSessionLockRenewalDuration`, cancelled before close); `SessionLockLost` / no-session non-fatal (release + re-poll).
- **Opt-in registration**: `AddSessionQueueReceiver` / `AddSessionTopicSubscription`; `ServiceBusReceiverRegistry` captures a per-receiver `RequiresSession` flag; `CreateProductionReceiver` branches on it (test seam preserved). Parallelism comes from more receiver instances — no `max-concurrent-sessions` knob.
- **Inbound `SessionId` surfaces as `MessageContext.GroupId`** (the core Group Id term — no `WithSessionId` alias). Outbound session addressing reuses `WithGroupId`. **Send-side contract**: ASB requires `PartitionKey == SessionId`; pair `WithGroupId` with a matching `PartitionKey` (documented to avoid `ArgumentOutOfRangeException`).
- **Durable per-session state**: `GetSessionStateAsync` / `SetSessionStateAsync` / `ClearSessionStateAsync` handler-context extensions; non-session use throws a predictable `InvalidOperationException`.
- **Operator knobs**: `SessionIdleTimeout` (release idle held session and roll) and `MaxSessionLockRenewalDuration`; both fluent-or-config with fluent winning.

## Tests
- 18 no-Docker unit tests (surfacing, factory branch selection, adapter guards, session-state misuse).
- Emulator integration `PipelineSessionTests` (FIFO order + session-state round-trip/clear); emulator confirmed to support `RequiresSession` entities; `[RequiresDockerFact]` skip-when-unavailable preserved.
- `dotnet test` (whole solution) green. One pre-existing emulator atomicity test flaked on net10.0 only (non-session path, untouched); passed on net8.0 in the same run and on both TFMs on isolated re-run.

## Docs / versioning
- `CONTEXT.md` + README document session mode, session-state, send-side contract, and knobs.
- csproj `<Version>` 1.3.0 → 1.4.0; CHANGELOG 1.4.0 entry.

Closes #209
Closes #225
Closes #226
Closes #227