### PR TITLE
test: cover core pipeline behaviors through RabbitMQ and SqlServiceBroker adapters

### DIFF
--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/ChatterRabbitMqPipelineHarness.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/ChatterRabbitMqPipelineHarness.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Chatter.CQRS;
 using Chatter.CQRS.Commands;
+using Chatter.CQRS.Events;
 using Chatter.MessageBrokers.RabbitMQ.Configuration;
 using Chatter.MessageBrokers.Routing.Options;
 using Chatter.MessageBrokers.Sending;
@@ -216,6 +217,39 @@ namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
             options.WithMessageContext(MessageContext.InfrastructureType, RabbitMqMessageContext.InfrastructureType);
             options.WithMessageContext(MessageContext.ContentType, contentType);
             return SendAsync(message, workQueueName, options);
+        }
+
+        // Publishes an event through Chatter's dispatcher under the default-exchange convention: destinationPath is
+        // the work-queue name and the publisher publishes to exchange "" with routing key = the queue name. Mirrors
+        // SendToQueueAsync but takes the IBrokeredMessageDispatcher.Publish (IEvent) path instead of Send (ICommand),
+        // stamping the SAME RabbitMQ InfrastructureType so the dispatcher routes to the RabbitMQ sender. Opens and
+        // disposes its own scope.
+        public Task PublishToQueueAsync<TEvent>(TEvent message, string workQueueName) where TEvent : class, IEvent
+        {
+            var options = new PublishOptions();
+            options.WithMessageContext(MessageContext.InfrastructureType, RabbitMqMessageContext.InfrastructureType);
+            return PublishAsync(message, workQueueName, options);
+        }
+
+        private async Task PublishAsync<TEvent>(TEvent message, string destinationPath, PublishOptions options)
+            where TEvent : class, IEvent
+        {
+            var dispatcher = CreateDispatcher(out var scope);
+            using (scope)
+            using (var publishCts = new CancellationTokenSource(TeardownTimeout))
+            {
+                // Bound the dispatcher publish so a wedged publish fails fast. The Publish overload takes no token,
+                // so race it against a finite delay rather than passing CancellationToken.None to an unbounded await.
+                var publish = dispatcher.Publish(message, destinationPath, options: options);
+                var completed = await Task.WhenAny(publish, Task.Delay(Timeout.Infinite, publishCts.Token)).ConfigureAwait(false);
+                if (completed != publish)
+                {
+                    throw new TimeoutException(
+                        $"Timed out after {TeardownTimeout} publishing a '{typeof(TEvent).Name}' through the dispatcher.");
+                }
+
+                await publish.ConfigureAwait(false);
+            }
         }
 
         private async Task SendAsync<TMessage>(TMessage message, string destinationPath, SendOptions options)

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqForwardingTests.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqForwardingTests.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS;
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.RabbitMQ.Configuration;
+using Chatter.MessageBrokers.Receiving;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
+{
+    // Proves RabbitMQ honors core behavior C10 (in-handler forward) end-to-end through Chatter's own send path: a
+    // command delivered to a handler on a SOURCE queue calls IMessageBrokerContext.Send to a SECOND (destination)
+    // queue, and a Chatter receiver on that destination queue delivers the forwarded payload to its handler. The
+    // forward is a Chatter call (the broker context's Send, NOT a raw RabbitMQ.Client publish), and the forwarded
+    // message is observed via a second Chatter receiver's RecordingMessageHandler<ForwardedCommand> — the whole
+    // path is Chatter's. Mirrors the Azure Service Bus PipelineForwardingTests analogue.
+    //
+    // TOPOLOGY NOTE (why TWO harness instances, not one): the RabbitMQ adapter rejects MORE THAN ONE RabbitMQ
+    // receiver per process at registration (Extensions.RejectMultipleReceivers throws NotSupportedException — the
+    // singleton connection source owns one receive channel). So the source receiver and the destination receiver
+    // CANNOT share a host. Each harness instance builds its OWN ServiceProvider with exactly ONE RabbitMQ receiver
+    // (satisfying RejectMultipleReceivers), and both target the SAME RabbitMqFixture broker via the SAME AMQP URI,
+    // so the forward published by harness A's source handler lands on the queue harness B consumes. Both receivers
+    // are ReceiveOnly (no FullAtomicity, which the adapter also rejects on RabbitMQ).
+    //
+    // Gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain `dotnet test`
+    // stays green; the nightly RabbitMQ CI lane (`--filter Category=Integration`) runs it for real.
+    [Trait("Category", "Integration")]
+    [Collection(RabbitMqCollection.Name)]
+    public class RabbitMqForwardingTests
+    {
+        // Generous on purpose: the forwarding chain (source-receive -> handler -> forward-send through Chatter ->
+        // dest-enqueue -> dest-receive) crosses two in-process Chatter hosts against a real broker. 30s gives
+        // headroom for the two-hop path without masking a real wiring failure.
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
+
+        private readonly RabbitMqFixture _fixture;
+
+        public RabbitMqForwardingTests(RabbitMqFixture fixture)
+            => _fixture = fixture;
+
+        // The command consumed on the source queue. Its handler forwards a ForwardedCommand to the destination
+        // queue through Chatter's broker-context Send.
+        public sealed class SourceCommand : ICommand
+        {
+            public string Value { get; set; }
+        }
+
+        // The command the source handler forwards to the destination queue. A second in-process Chatter receiver
+        // (harness B) delivers it to a RecordingMessageHandler, proving the forward landed through Chatter's send
+        // path with its payload intact.
+        public sealed class ForwardedCommand : ICommand
+        {
+            public string Value { get; set; }
+        }
+
+        // A Chatter IMessageHandler<SourceCommand> that, on receipt, forwards a ForwardedCommand to the destination
+        // queue via the broker context's Send — exercising Chatter's send path from inside a handler. No explicit
+        // InfrastructureType is stamped: RabbitMQ is the only (default) infrastructure in the source harness, so
+        // the dispatcher routes the forward to the RabbitMQ sender. The destination queue name is supplied at
+        // construction so the test can mint a per-scenario queue. Registered explicitly into the source harness DI
+        // graph as the IMessageHandler<SourceCommand> Chatter resolves on the source receive path.
+        private sealed class ForwardingSourceHandler : IMessageHandler<SourceCommand>
+        {
+            private readonly string _destinationQueueName;
+
+            public ForwardingSourceHandler(string destinationQueueName)
+                => _destinationQueueName = destinationQueueName;
+
+            public Task Handle(SourceCommand message, IMessageHandlerContext context)
+            {
+                var brokerContext = context as IMessageBrokerContext;
+                brokerContext.Should().NotBeNull(
+                    "the source handler runs on Chatter's broker receive path and must receive an IMessageBrokerContext");
+
+                return brokerContext.Send(
+                    new ForwardedCommand { Value = message.Value + "-forwarded" },
+                    _destinationQueueName);
+            }
+        }
+
+        // Forwarding through Chatter on RabbitMQ (C10): a command sent to the source queue is consumed by harness
+        // A's handler, which forwards a follow-up to the destination queue via the broker context's Send. Harness
+        // B's receiver on the destination queue delivers the forwarded command to its RecordingMessageHandler,
+        // proving the forward routed through Chatter's send path with the payload intact — end to end across two
+        // single-receiver hosts that share the broker.
+        [RequiresDockerFact]
+        public async Task HandlerForwardsToDestinationQueueThroughChatterSendPath()
+        {
+            var amqpUri = _fixture.GetAmqpConnectionString();
+
+            // Distinct per-scenario queue sets so the source and destination queues never share state. Declare both
+            // against the shared broker BEFORE either receiver starts — the adapter provisions no topology.
+            var sourceSet = RabbitMqTopology.CreateSet("forward_source", QueueType.Quorum);
+            var destSet = RabbitMqTopology.CreateSet("forward_dest", QueueType.Quorum);
+            await RabbitMqTopology.DeclareAsync(amqpUri, sourceSet, CancellationToken.None);
+            await RabbitMqTopology.DeclareAsync(amqpUri, destSet, CancellationToken.None);
+
+            // Harness A: hosts ONLY the source receiver. The forwarding handler is registered explicitly via
+            // configureServices as the IMessageHandler<SourceCommand> Chatter resolves on the source receive path
+            // (SourceCommand is deliberately NOT passed as a recording message type, so the forwarding handler is
+            // the sole registration). ReceiveOnly — no FullAtomicity, which the adapter rejects on RabbitMQ.
+            var sourceHarness = ChatterRabbitMqPipelineHarness.Build(
+                amqpUri,
+                QueueType.Quorum,
+                rmq => rmq.AddQueueReceiver<SourceCommand>(
+                    sourceSet.WorkQueueName,
+                    transactionMode: TransactionMode.ReceiveOnly,
+                    deadLetterQueuePath: sourceSet.DeadLetterQueueName),
+                services => services.AddTransient<IMessageHandler<SourceCommand>>(
+                    _ => new ForwardingSourceHandler(destSet.WorkQueueName)));
+
+            // Harness B: hosts ONLY the destination receiver, recording the forwarded command. Its own
+            // ServiceProvider means it registers exactly one RabbitMQ receiver, satisfying RejectMultipleReceivers.
+            // Same AMQP URI as harness A, so it consumes the queue harness A's handler forwards to.
+            var destHarness = ChatterRabbitMqPipelineHarness.Build(
+                amqpUri,
+                QueueType.Quorum,
+                rmq => rmq.AddQueueReceiver<ForwardedCommand>(
+                    destSet.WorkQueueName,
+                    transactionMode: TransactionMode.ReceiveOnly,
+                    deadLetterQueuePath: destSet.DeadLetterQueueName),
+                typeof(ForwardedCommand));
+
+            try
+            {
+                // Start the destination receiver first so it is consuming before the forward is published, then
+                // start the source receiver that drives the forward.
+                await destHarness.StartAsync();
+                await sourceHarness.StartAsync();
+
+                // Drive the chain: send a SourceCommand to the source queue via harness A's dispatcher. RabbitMQ is
+                // the only broker, so SendToQueueAsync stamps the RabbitMQ InfrastructureType and the in-process
+                // source pump delivers it to the forwarding handler.
+                var sent = new SourceCommand { Value = "origin" };
+                await sourceHarness.SendToQueueAsync(sent, sourceSet.WorkQueueName);
+
+                // The source handler's forward (Chatter's send path) must land the ForwardedCommand on the
+                // destination queue, where harness B's receiver delivers it to its RecordingMessageHandler.
+                var handled = await destHarness.WaitForHandledAsync<ForwardedCommand>(HandlerWait);
+
+                handled.Message.Should().NotBeNull(
+                    "the forwarded command must be delivered to the destination queue through Chatter's send path");
+                handled.Message.Value.Should().Be(
+                    "origin-forwarded",
+                    "the destination receiver's handler must receive the exact payload the source handler forwarded");
+
+                // The forwarded delivery arrived on Chatter's RabbitMQ receive path: the inbound context must carry
+                // the RabbitMQ InfrastructureType stamp the receiver applies.
+                handled.Context.Should().NotBeNull(
+                    "the destination handler context must be an IMessageBrokerContext on the broker receive path");
+                var inbound = handled.Context.BrokeredMessage;
+                inbound.MessageContext.Should().ContainKey(MessageContext.InfrastructureType);
+                inbound.MessageContext[MessageContext.InfrastructureType]
+                    .Should().Be(RabbitMqMessageContext.InfrastructureType);
+
+                destHarness.GetSignal<ForwardedCommand>().InvocationCount
+                    .Should().Be(1, "the forwarded command must be delivered to the destination handler exactly once");
+            }
+            finally
+            {
+                // Dispose both hosts so consumers/connections tear down cleanly. Dispose the source first so it
+                // stops forwarding before the destination receiver is torn down.
+                await sourceHarness.DisposeAsync();
+                await destHarness.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqPoisonMessageTests.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqPoisonMessageTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.RabbitMQ.Configuration;
+using Chatter.Testing.Core.Integration;
+using FluentAssertions;
+using RabbitMQ.Client;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
+{
+    // Poison-message integration proof for the RabbitMQ integration harness, PROVEN ON BOTH queue types per
+    // ADR-0001. The SYSTEM UNDER TEST is core behavior C8: a body that cannot DESERIALIZE to TMessage is
+    // deadlettered IMMEDIATELY (no MaxReceiveAttempts climb) and the handler is NEVER invoked.
+    //
+    // WHY THIS IS DISTINCT FROM RabbitMqDeadLetterTests: that suite proves the Max-Receives-Exceeded deadletter,
+    // which is the GENERIC processing-error ladder — the handler is invoked, throws, and only after the resolved
+    // delivery count reaches MaxReceiveAttempts does BrokeredMessageReceiver route to DeadletterMessageAsync. C8
+    // is the OTHER deadletter path: ProcessMessageAsync calls inboundMessage.GetMessageFromBody<TMessage>() BEFORE
+    // any handler dispatch; when the body cannot materialize to TMessage that throws, which the receiver wraps in a
+    // PoisonedMessageException, and the worker's catch (PoisonedMessageException) branch deadletters at once via
+    // TryDeadletterWithRecoveryAsync — bypassing the delivery-count probe entirely. So the poison message
+    // deadletters on the FIRST delivery REGARDLESS of MaxReceiveAttempts, and the handler is never reached.
+    //
+    // INJECTING THE POISON: Chatter's own Send path would serialize a VALID JSON envelope, which deserializes
+    // fine. To force the deserialize to throw we publish a malformed body DIRECTLY at the raw RabbitMQ.Client edge
+    // (reusing RabbitMqFixture's AMQP URI + RabbitMqTopology's declared work queue), bypassing Chatter's serializer.
+    // The RabbitMqBodyConverter deserializes via JsonSerializer.Deserialize<TMessage>(UTF8 body); a non-JSON byte
+    // payload throws a JsonException there, which surfaces as the PoisonedMessageException. We deliberately omit the
+    // AMQP content-type so the receiver falls back to the configured (JSON) MessageBodyType converter, exercising
+    // the same deserialize the production receive path uses.
+    //
+    // THE NO-RETRY-CLIMB PROOF: maxReceiveAttempts is set HIGH (5). A Max-Receives-Exceeded deadletter would
+    // therefore require the message to be delivered (and the handler invoked) up to 5 times before deadlettering.
+    // The poison path instead deadletters on the FIRST delivery with the handler never invoked, so:
+    //   - the DLQ envelope arrives promptly (first delivery), AND
+    //   - RecordingMessageHandler<TMessage>.InvocationCount stays 0 (the handler was never reached).
+    // Together these assert at the Chatter level (DLQ envelope + handler count) that there was no retry climb — it
+    // did not take MaxReceiveAttempts deliveries to deadletter — rather than reading any raw SDK delivery counter.
+    //
+    // The DLQ envelope's FailureDescription carries the deadletter error description, which for the poison path is
+    // the PoisonedMessageException.ToString() — asserting it names the poison exception confirms the deadletter
+    // came from the deserialize-failure path, not the generic handler-throw ladder.
+    //
+    // The facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green. Mirrors RabbitMqDeadLetterTests for harness setup.
+    [Trait("Category", "Integration")]
+    [Collection(RabbitMqCollection.Name)]
+    public class RabbitMqPoisonMessageTests
+    {
+        private static readonly TimeSpan PoisonWait = TimeSpan.FromSeconds(30);
+
+        // High enough that a Max-Receives-Exceeded deadletter would require several handler invocations; the poison
+        // path must deadletter on the FIRST delivery with zero invocations regardless of this value.
+        private const int MaxReceiveAttempts = 5;
+
+        private readonly RabbitMqFixture _fixture;
+
+        public RabbitMqPoisonMessageTests(RabbitMqFixture fixture)
+            => _fixture = fixture;
+
+        // Distinct command type per queue type so the two scenarios' queue state is independent.
+        public sealed class QuorumPoisonCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        public sealed class ClassicPoisonCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        // Quorum: a poison body deadletters immediately on the native-delivery-count strategy without the handler
+        // ever being invoked, regardless of maxReceiveAttempts.
+        [RequiresDockerFact]
+        public Task QuorumQueueDeadlettersPoisonMessageImmediatelyWithoutInvokingHandler()
+            => RunPoisonScenarioAsync<QuorumPoisonCommand>(QueueType.Quorum);
+
+        // Classic: a poison body deadletters immediately on the republish-counter strategy without the handler ever
+        // being invoked, regardless of maxReceiveAttempts.
+        [RequiresDockerFact]
+        public Task ClassicQueueDeadlettersPoisonMessageImmediatelyWithoutInvokingHandler()
+            => RunPoisonScenarioAsync<ClassicPoisonCommand>(QueueType.Classic);
+
+        // Shared scenario body driven for BOTH queue types: a malformed body published at the raw edge must cause
+        // the receive-side deserialize to throw PoisonedMessageException, which deadletters on the first delivery
+        // WITHOUT invoking the handler. The ONLY difference between the runs is the QueueType — the outcome
+        // assertions are identical, proving C8 holds independent of the delivery-count strategy.
+        private async Task RunPoisonScenarioAsync<TMessage>(QueueType queueType)
+            where TMessage : class, ICommand
+        {
+            var suffix = queueType == QueueType.Quorum ? "poison_quorum" : "poison_classic";
+            var set = RabbitMqTopology.CreateSet(suffix, queueType);
+            await RabbitMqTopology.DeclareAsync(_fixture.GetAmqpConnectionString(), set, CancellationToken.None);
+
+            var harness = ChatterRabbitMqPipelineHarness.Build(
+                _fixture.GetAmqpConnectionString(),
+                queueType,
+                // maxReceiveAttempts is set HIGH so the ONLY way a deadletter happens on the first delivery (with
+                // zero handler invocations) is the poison/deserialize-failure path, not a Max-Receives climb.
+                rmq => rmq.AddQueueReceiver<TMessage>(
+                    set.WorkQueueName,
+                    deadLetterQueuePath: set.DeadLetterQueueName,
+                    maxReceiveAttempts: MaxReceiveAttempts),
+                typeof(TMessage));
+            try
+            {
+                await harness.StartAsync();
+
+                // Inject the POISON: publish a malformed (non-JSON) body DIRECTLY at the raw RabbitMQ.Client edge,
+                // bypassing Chatter's serializer, so the receive-side JsonSerializer.Deserialize<TMessage> throws and
+                // the receiver wraps it in a PoisonedMessageException. No content-type is stamped so the receiver
+                // falls back to the configured JSON body converter — the same deserialize the production path runs.
+                await PublishPoisonBodyAsync(
+                    set.WorkQueueName,
+                    Encoding.UTF8.GetBytes("this-is-not-a-valid-json-envelope"));
+
+                // The poison message must land in the DLQ on the FIRST delivery (the deserialize failure deadletters
+                // before any handler dispatch). ReceiveAsync polls until the republished envelope arrives or fails
+                // fast via TimeoutException-equivalent null on the deadline.
+                var deadLettered = await DeadLetterQueueReader.ReceiveAsync(
+                    _fixture.GetAmqpConnectionString(), set.DeadLetterQueueName, PoisonWait);
+
+                deadLettered.Should().NotBeNull(
+                    "an undeserializable body must be deadlettered immediately via the PoisonedMessageException path, " +
+                    "republished to the dead-letter queue on the first delivery");
+
+                // The deadletter error description carries the deadletter-time exception ToString(); for the poison
+                // path that is the PoisonedMessageException, confirming the deadletter came from the deserialize
+                // failure rather than the generic handler-throw ladder.
+                deadLettered.Headers.Should().ContainKey(MessageContext.FailureDescription,
+                    "DeadletterMessageAsync merges FailureDescription (the deadletter error description) into the republished headers");
+                deadLettered.Headers[MessageContext.FailureDescription]
+                    .Should().Contain(nameof(Chatter.MessageBrokers.Exceptions.PoisonedMessageException),
+                        "the poison deadletter's error description is the PoisonedMessageException, identifying the deserialize-failure path");
+
+                // FailureDetails carries the poison deadletter reason. Unlike the InfrastructureType header — which
+                // is stamped by Chatter's SENDER and is therefore absent here because the poison body was published
+                // RAW (bypassing the sender) — the failure overrides are merged by DeadletterMessageAsync itself, so
+                // they are present on the republished envelope regardless of how the original was published.
+                deadLettered.Headers.Should().ContainKey(MessageContext.FailureDetails,
+                    "DeadletterMessageAsync merges FailureDetails (the deadletter reason) into the republished headers");
+                deadLettered.Headers[MessageContext.FailureDetails]
+                    .Should().Be("Poisoned message received",
+                        "the poison deadletter reason identifies the PoisonedMessageException path, not the Max-Receives ladder");
+
+                // C8 CORE ASSERTION: the handler was NEVER invoked. The poison deadletter happens in the
+                // catch (PoisonedMessageException) branch BEFORE any handler dispatch, so a correct adapter leaves
+                // the RecordingMessageHandler<TMessage> untouched. A non-zero count here would mean the body reached
+                // the handler (i.e. it deserialized, contradicting the poison premise) or that the deadletter came
+                // from the Max-Receives ladder after handler throws — either of which violates C8.
+                harness.GetSignal<TMessage>().InvocationCount.Should().Be(0,
+                    "a poison/undeserializable message is deadlettered before dispatch, so the handler is never invoked");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+
+        // Publishes a raw body DIRECTLY to the work queue via RabbitMQ.Client, bypassing Chatter's send/serialize
+        // path entirely so the body is whatever bytes the caller supplies (here, a non-JSON payload the receive-side
+        // deserialize cannot bind to TMessage). Default-exchange convention: routing key == work queue name, matching
+        // how the harness's own Send and the adapter's republish address the work queue. Persistent so the durable
+        // work queue retains it. No content-type is set so the receiver uses the configured JSON body converter.
+        private async Task PublishPoisonBodyAsync(string workQueueName, byte[] body)
+        {
+            using var operationCts = new CancellationTokenSource(PoisonWait);
+            var token = operationCts.Token;
+
+            var factory = new ConnectionFactory { Uri = new Uri(_fixture.GetAmqpConnectionString()) };
+            await using var connection = await factory.CreateConnectionAsync(token).ConfigureAwait(false);
+            await using var channel = await connection.CreateChannelAsync(cancellationToken: token).ConfigureAwait(false);
+
+            var properties = new BasicProperties { Persistent = true };
+
+            await channel.BasicPublishAsync(exchange: string.Empty,
+                                            routingKey: workQueueName,
+                                            mandatory: true,
+                                            basicProperties: properties,
+                                            body: new ReadOnlyMemory<byte>(body),
+                                            cancellationToken: token).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqPublishTests.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqPublishTests.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS.Events;
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.RabbitMQ.Configuration;
+using FluentAssertions;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
+{
+    // Core-behavior C2 proof for the RabbitMQ adapter: an IEvent published ONLY through Chatter's
+    // IBrokeredMessageDispatcher.Publish path (harness.PublishToQueueAsync) is delivered by the in-process
+    // receiver pump (ChatterRabbitMqPipelineHarness) to a Chatter-resolved RecordingMessageHandler<TEvent>, and
+    // every assertion reads the payload Chatter deserialized and the IMessageBrokerContext Chatter built — never a
+    // raw RabbitMQ.Client type. This is the publish/event analogue of the command Send round-trip in
+    // RabbitMqRoundTripTests, exercising the dispatcher's Publish (IEvent) overload rather than Send (ICommand).
+    //
+    // Gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain `dotnet test`
+    // stays green; the nightly RabbitMQ CI lane (`--filter Category=Integration`) runs it for real.
+    [Trait("Category", "Integration")]
+    [Collection(RabbitMqCollection.Name)]
+    public class RabbitMqPublishTests
+    {
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
+
+        private readonly RabbitMqFixture _fixture;
+
+        public RabbitMqPublishTests(RabbitMqFixture fixture)
+            => _fixture = fixture;
+
+        // An event carrying string/int fields so the body round-trip exercises Chatter's STJ body converter for the
+        // publish path (the on-receive materialization must restore the exact CLR values).
+        public sealed class TestIntegrationEvent : IEvent
+        {
+            public string Name { get; set; }
+            public int Count { get; set; }
+        }
+
+        // Default-exchange publish round-trip: an event PUBLISHED through Chatter's dispatcher to the work-queue
+        // name is delivered by Chatter's RabbitMQ pump to the registered handler exactly once with its string/int
+        // payload deserialized EXACTLY, and the inbound RabbitMqMessageContext InfrastructureType stamp is present.
+        [RequiresDockerFact]
+        public async Task PublishedEventRoundTripsToHandlerOverDefaultExchange()
+        {
+            var set = RabbitMqTopology.CreateSet("publish", QueueType.Quorum);
+            await RabbitMqTopology.DeclareAsync(_fixture.GetAmqpConnectionString(), set, CancellationToken.None);
+
+            var harness = ChatterRabbitMqPipelineHarness.Build(
+                _fixture.GetAmqpConnectionString(),
+                QueueType.Quorum,
+                rmq => rmq.AddQueueReceiver<TestIntegrationEvent>(set.WorkQueueName, deadLetterQueuePath: set.DeadLetterQueueName),
+                typeof(TestIntegrationEvent));
+            try
+            {
+                await harness.StartAsync();
+
+                var published = new TestIntegrationEvent { Name = "rmq-publish", Count = 17 };
+                await harness.PublishToQueueAsync(published, set.WorkQueueName);
+
+                var handled = await harness.WaitForHandledAsync<TestIntegrationEvent>(HandlerWait);
+
+                // Payload round-trip: the published event must survive the OutboundBrokeredMessage envelope
+                // round-trip through RabbitMQ verbatim.
+                handled.Message.Should().NotBeNull("Chatter's RabbitMQ pipeline must deliver the published event to the handler");
+                handled.Message.Name.Should().Be("rmq-publish");
+                handled.Message.Count.Should().Be(17);
+
+                // Inbound broker context: the handler must receive an IMessageBrokerContext on the RabbitMQ receive
+                // path, carrying the RabbitMQ InfrastructureType stamp the receiver applies in ReceiveMessageAsync.
+                handled.Context.Should().NotBeNull(
+                    "the handler context must be an IMessageBrokerContext on the broker receive path");
+                var inbound = handled.Context.BrokeredMessage;
+
+                inbound.MessageContext.Should().ContainKey(MessageContext.InfrastructureType);
+                inbound.MessageContext[MessageContext.InfrastructureType]
+                    .Should().Be(RabbitMqMessageContext.InfrastructureType);
+
+                harness.GetSignal<TestIntegrationEvent>().InvocationCount
+                    .Should().Be(1, "the event must be delivered to the handler exactly once on the happy path");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqTransactionModeTests.cs
+++ b/src/Chatter.MessageBrokers.RabbitMQ/tests/Integration/RabbitMqTransactionModeTests.cs
@@ -1,0 +1,183 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.RabbitMQ.Configuration;
+using Chatter.MessageBrokers.Receiving;
+using FluentAssertions;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.RabbitMQ.Tests.Integration
+{
+    // Integration proof that the RabbitMQ adapter honors core behavior C9 (TransactionMode) — the at-least-once
+    // vs at-most-once delivery divergence — against a REAL broker. RabbitMqReceiver sets _autoAck =
+    // (TransactionMode == None): with TransactionMode.None the delivery is acked the moment it is pulled
+    // (at-most-once), so a throwing handler loses the message with NO redelivery; with TransactionMode.ReceiveOnly
+    // the delivery stays unacked until the handler succeeds, so a throwing handler nacks/republishes and the
+    // broker REDELIVERS (at-least-once), climbing ReceiveAttempts. Asserts at the Chatter level — the handler's
+    // InvocationCount and the MessageContext.ReceiveAttempts stamp — never against raw RabbitMQ.Client.
+    //
+    // ANTI-INFINITE-LOOP (ReceiveOnly case): ThrowOnHandle is flipped to null once >= 2 invocations are observed
+    // so the message finally acks before DisposeAsync drains the pump. MaxReceiveAttempts is left at the default
+    // (10), well above the 2 redeliveries the test drives, so the message nacks/redelivers (never deadletters)
+    // in the window under test.
+    [Trait("Category", "Integration")]
+    [Collection(RabbitMqCollection.Name)]
+    public class RabbitMqTransactionModeTests
+    {
+        // Long enough that the broker redelivers the ReceiveOnly-mode nack within the window.
+        private static readonly TimeSpan RedeliveryWait = TimeSpan.FromSeconds(30);
+
+        // Bounded window in which the None-mode (at-most-once) message must NOT reappear. After the single
+        // delivery is acked-on-pull and the handler throws, no redelivery can occur — the absence is asserted by
+        // waiting this long and confirming the invocation count never climbed past 1. Generous enough that a
+        // genuine broker redelivery would have landed within it, so a still-1 count is a true negative.
+        private static readonly TimeSpan NoRedeliveryWait = TimeSpan.FromSeconds(10);
+
+        private readonly RabbitMqFixture _fixture;
+
+        public RabbitMqTransactionModeTests(RabbitMqFixture fixture)
+            => _fixture = fixture;
+
+        // Distinct command type so the ReceiveOnly scenario's queue state is independent of the None scenario and
+        // of every other integration test in the collection.
+        public sealed class ReceiveOnlyTxCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        // Distinct command type for the None (at-most-once) scenario so its queue state is independent.
+        public sealed class NoneTxCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        // C9 at-least-once: TransactionMode.ReceiveOnly keeps the delivery unacked until the handler succeeds, so a
+        // throwing handler causes a nack/republish and the broker REDELIVERS. Assert the handler is invoked >= 2
+        // times (at least one redelivery) and that ReceiveAttempts climbs (>= 2) across deliveries.
+        [RequiresDockerFact]
+        public async Task ReceiveOnlyTransactionModeRedeliversOnThrow()
+        {
+            var set = RabbitMqTopology.CreateSet("txmode_receiveonly", QueueType.Quorum);
+            await RabbitMqTopology.DeclareAsync(_fixture.GetAmqpConnectionString(), set, CancellationToken.None);
+
+            var harness = ChatterRabbitMqPipelineHarness.Build(
+                _fixture.GetAmqpConnectionString(),
+                QueueType.Quorum,
+                rmq => rmq.AddQueueReceiver<ReceiveOnlyTxCommand>(
+                    set.WorkQueueName,
+                    transactionMode: TransactionMode.ReceiveOnly,
+                    deadLetterQueuePath: set.DeadLetterQueueName),
+                typeof(ReceiveOnlyTxCommand));
+            try
+            {
+                await harness.StartAsync();
+
+                // Arm the throw BEFORE sending so the handler throws on the very first delivery. ThrowOnHandle is
+                // Func<Exception>: a fresh instance per invocation matches the RecordingMessageHandler<T> contract.
+                harness.GetSignal<ReceiveOnlyTxCommand>().ThrowOnHandle =
+                    () => new InvalidOperationException("transaction-mode receiveonly forced throw");
+
+                await harness.SendToQueueAsync(new ReceiveOnlyTxCommand { Marker = "txmode-receiveonly" }, set.WorkQueueName);
+
+                // Wait until at least 2 handler invocations have been observed (first delivery + at least one
+                // redelivery). WaitForInvocationCountAsync returns the last observed count, which may be below
+                // minCount when the timeout elapses — the assertion below catches that case explicitly.
+                var observedCount = await harness.WaitForInvocationCountAsync<ReceiveOnlyTxCommand>(
+                    minCount: 2, RedeliveryWait);
+
+                // ANTI-INFINITE-LOOP: stop throwing so the message is acked on the next receive before DisposeAsync
+                // drains the pump.
+                harness.GetSignal<ReceiveOnlyTxCommand>().ThrowOnHandle = null;
+
+                observedCount.Should().BeGreaterThanOrEqualTo(2,
+                    "TransactionMode.ReceiveOnly keeps the delivery unacked until the handler succeeds, so the " +
+                    "throwing handler nacks/republishes and the broker redelivers — the handler must be invoked at " +
+                    "least twice: the original delivery plus at least one redelivery (at-least-once)");
+
+                // ReceiveAttempts must climb: on a quorum queue attempts = native x-delivery-count + 1, which the
+                // broker advances on each redelivery. Capture the attempt stamp from each recorded invocation and
+                // assert the maximum observed value exceeds 1.
+                var records = harness.GetSignal<ReceiveOnlyTxCommand>().Records.ToList();
+                var maxAttempts = records
+                    .Where(r => r.Context?.BrokeredMessage?.MessageContext?.ContainsKey(MessageContext.ReceiveAttempts) == true)
+                    .Select(r => Convert.ToInt32(r.Context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts]))
+                    .DefaultIfEmpty(0)
+                    .Max();
+
+                maxAttempts.Should().BeGreaterThan(1,
+                    "the quorum native x-delivery-count must advance on each redelivery, so ReceiveAttempts " +
+                    "(x-delivery-count + 1) must exceed 1 after at least one ReceiveOnly-mode redelivery");
+            }
+            finally
+            {
+                harness.GetSignal<ReceiveOnlyTxCommand>().ThrowOnHandle = null;
+                await harness.DisposeAsync();
+            }
+        }
+
+        // C9 at-most-once: TransactionMode.None acks the delivery the moment it is pulled (RabbitMqReceiver sets
+        // _autoAck = (TransactionMode == None)), so a throwing handler LOSES the message with NO redelivery. Assert
+        // the handler is invoked EXACTLY once and that no further delivery arrives within a bounded wait window
+        // (the message was acked-on-delivery and dropped).
+        [RequiresDockerFact]
+        public async Task NoneTransactionModeDropsMessageOnThrowWithNoRedelivery()
+        {
+            var set = RabbitMqTopology.CreateSet("txmode_none", QueueType.Quorum);
+            await RabbitMqTopology.DeclareAsync(_fixture.GetAmqpConnectionString(), set, CancellationToken.None);
+
+            var harness = ChatterRabbitMqPipelineHarness.Build(
+                _fixture.GetAmqpConnectionString(),
+                QueueType.Quorum,
+                rmq => rmq.AddQueueReceiver<NoneTxCommand>(
+                    set.WorkQueueName,
+                    transactionMode: TransactionMode.None,
+                    deadLetterQueuePath: set.DeadLetterQueueName),
+                typeof(NoneTxCommand));
+            try
+            {
+                await harness.StartAsync();
+
+                // Throw on every delivery. Under TransactionMode.None the delivery is already acked when the handler
+                // runs, so the throw cannot trigger a nack/redelivery — it just surfaces as a faulted handle that
+                // the receiver loop swallows after the message is already gone. ThrowOnHandle stays armed for the
+                // whole window so that, were a redelivery to (wrongly) occur, the second invocation would still be
+                // recorded and climb the count past 1.
+                harness.GetSignal<NoneTxCommand>().ThrowOnHandle =
+                    () => new InvalidOperationException("transaction-mode none forced throw");
+
+                await harness.SendToQueueAsync(new NoneTxCommand { Marker = "txmode-none" }, set.WorkQueueName);
+
+                // First, wait until the single delivery has actually been handled (so the assertion below is not a
+                // vacuous "0 == 1 not yet delivered"). The handler IS invoked exactly once on the original delivery.
+                var firstInvocation = await harness.WaitForHandledAsync<NoneTxCommand>(RedeliveryWait);
+                firstInvocation.Should().NotBeNull();
+
+                // Then assert NON-OCCURRENCE the same way the suite proves a negative: poll for a SECOND invocation
+                // across the bounded no-redelivery window and confirm the count never reaches 2. Because the message
+                // was acked-on-pull and dropped on throw, no redelivery can land, so the count stays pinned at 1.
+                var observedCount = await harness.WaitForInvocationCountAsync<NoneTxCommand>(
+                    minCount: 2, NoRedeliveryWait);
+
+                observedCount.Should().Be(1,
+                    "TransactionMode.None acks the delivery the moment it is pulled (at-most-once), so the throwing " +
+                    "handler drops the message — it must be invoked EXACTLY once with no redelivery within the " +
+                    "bounded wait window");
+
+                // Corroborate from the recorded invocations: exactly one delivery was ever captured.
+                var records = harness.GetSignal<NoneTxCommand>().Records.ToList();
+                records.Count.Should().Be(1,
+                    "an at-most-once (acked-on-pull) delivery that throws is lost, so the recorder must hold exactly " +
+                    "one invocation and never a redelivered second copy");
+            }
+            finally
+            {
+                harness.GetSignal<NoneTxCommand>().ThrowOnHandle = null;
+                await harness.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Chatter.CQRS;
 using Chatter.CQRS.Commands;
+using Chatter.CQRS.Events;
 using Chatter.MessageBrokers.Routing.Options;
 using Chatter.MessageBrokers.Sending;
 using Chatter.MessageBrokers.SqlServiceBroker.Configuration;
@@ -176,31 +177,100 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         // class sends to its own service so a stale message can never bleed into another class's queue. The
         // initiator stamp + contract + message type stay shared (the send side is common across all classes).
         // Opens and disposes its own scope around the send.
-        public async Task SendAsync<TMessage>(TMessage message) where TMessage : ICommand
+        public Task SendAsync<TMessage>(TMessage message) where TMessage : ICommand
+            => SendAsync(message, _objectSet.TargetServiceName);
+
+        // Destination-override Send: routes the command to destinationServiceName instead of the owning object
+        // set's default TargetServiceName, so a forward/dest scenario (C10) can deliver to a service OTHER than
+        // the one the harness receives on (e.g. ServiceBrokerProvisioning.ForwardDestinationServiceName).
+        // destinationServiceName is the BARE target service name (no brackets): BeginDialogConversationCommand
+        // strips brackets and uses it as "TO SERVICE", so it must name the target SERVICE, not the queue. The
+        // SSB initiator stamp + contract + message type stay shared (the send side is common across all classes).
+        public async Task SendAsync<TMessage>(TMessage message, string destinationServiceName) where TMessage : ICommand
+        {
+            if (string.IsNullOrWhiteSpace(destinationServiceName))
+            {
+                throw new ArgumentException("A destination service name is required.", nameof(destinationServiceName));
+            }
+
+            var options = CreateSsbSendOptions();
+
+            var dispatcher = CreateDispatcher(out var scope);
+            using (scope)
+            {
+                // Bound the dispatcher send so a wedged BEGIN DIALOG / SEND fails fast. The dispatcher Send
+                // overload takes no token, so race it against a finite delay rather than passing CancellationToken
+                // .None to an unbounded await.
+                await AwaitBoundedAsync(
+                    dispatcher.Send(message, destinationServiceName, options: options),
+                    $"sending a '{typeof(TMessage).Name}' through the dispatcher").ConfigureAwait(false);
+            }
+        }
+
+        // The IEvent analogue of SendAsync: publishes an event through Chatter's dispatcher
+        // (IBrokeredMessageDispatcher.Publish) to the owning object set's target service, stamping the same SSB
+        // initiator/contract/message-type headers SendAsync stamps so the publish routes through Chatter's SSB
+        // BEGIN DIALOG / SEND path. Like SendAsync, destinationPath is the BARE target service name (brackets are
+        // stripped by BeginDialogConversationCommand). Opens and disposes its own scope around the publish.
+        public Task PublishAsync<TEvent>(TEvent message) where TEvent : class, IEvent
+            => PublishAsync(message, _objectSet.TargetServiceName);
+
+        // Destination-override Publish: routes the event to destinationServiceName instead of the owning object
+        // set's default TargetServiceName, mirroring the SendAsync override for the C10 forward/dest scenario.
+        public async Task PublishAsync<TEvent>(TEvent message, string destinationServiceName) where TEvent : class, IEvent
+        {
+            if (string.IsNullOrWhiteSpace(destinationServiceName))
+            {
+                throw new ArgumentException("A destination service name is required.", nameof(destinationServiceName));
+            }
+
+            var options = CreateSsbPublishOptions();
+
+            var dispatcher = CreateDispatcher(out var scope);
+            using (scope)
+            {
+                await AwaitBoundedAsync(
+                    dispatcher.Publish(message, destinationServiceName, options: options),
+                    $"publishing a '{typeof(TEvent).Name}' through the dispatcher").ConfigureAwait(false);
+            }
+        }
+
+        // Stamps the SSB headers the SqlServiceBrokerSender reads to BEGIN DIALOG / SEND on the SHARED initiator
+        // service + //Chatter contract + //Chatter/BrokeredMessage message type. Shared by both Send overloads.
+        private static SendOptions CreateSsbSendOptions()
         {
             var options = new SendOptions();
             options.WithMessageContext(SSBMessageContext.ServiceName, ServiceBrokerProvisioning.InitiatorServiceName);
             options.WithMessageContext(SSBMessageContext.ServiceContractName, ServiceBrokerProvisioning.ContractName);
             options.WithMessageContext(SSBMessageContext.MessageTypeName, ServiceBrokerProvisioning.MessageTypeName);
+            return options;
+        }
 
-            var dispatcher = CreateDispatcher(out var scope);
-            using (scope)
-            using (var sendCts = new CancellationTokenSource(TeardownTimeout))
+        // The PublishOptions analogue of CreateSsbSendOptions: identical SSB header stamps on the publish path so
+        // an IEvent routes through Chatter's SSB sender exactly as a command does.
+        private static PublishOptions CreateSsbPublishOptions()
+        {
+            var options = new PublishOptions();
+            options.WithMessageContext(SSBMessageContext.ServiceName, ServiceBrokerProvisioning.InitiatorServiceName);
+            options.WithMessageContext(SSBMessageContext.ServiceContractName, ServiceBrokerProvisioning.ContractName);
+            options.WithMessageContext(SSBMessageContext.MessageTypeName, ServiceBrokerProvisioning.MessageTypeName);
+            return options;
+        }
+
+        // Races a tokenless dispatcher dispatch against a finite TeardownTimeout delay so a wedged BEGIN DIALOG /
+        // SEND fails fast instead of awaiting on CancellationToken.None forever. operationDescription names the
+        // operation for the TimeoutException message.
+        private static async Task AwaitBoundedAsync(Task dispatch, string operationDescription)
+        {
+            using var sendCts = new CancellationTokenSource(TeardownTimeout);
+            var completed = await Task.WhenAny(dispatch, Task.Delay(Timeout.Infinite, sendCts.Token))
+                .ConfigureAwait(false);
+            if (completed != dispatch)
             {
-                // Bound the dispatcher send so a wedged BEGIN DIALOG / SEND fails fast. The dispatcher Send
-                // overload takes no token, so race it against a finite delay rather than passing CancellationToken
-                // .None to an unbounded await.
-                var send = dispatcher.Send(message, _objectSet.TargetServiceName, options: options);
-                var completed = await Task.WhenAny(send, Task.Delay(Timeout.Infinite, sendCts.Token))
-                    .ConfigureAwait(false);
-                if (completed != send)
-                {
-                    throw new TimeoutException(
-                        $"Timed out after {TeardownTimeout} sending a '{typeof(TMessage).Name}' through the dispatcher.");
-                }
-
-                await send.ConfigureAwait(false);
+                throw new TimeoutException($"Timed out after {TeardownTimeout} {operationDescription}.");
             }
+
+            await dispatch.ConfigureAwait(false);
         }
 
         // The shared signal for TMessage. Configure ThrowOnHandle BEFORE the message is received to exercise

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ChatterSsbPipelineHarness.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 using Chatter.CQRS;
 using Chatter.CQRS.Commands;
 using Chatter.CQRS.Events;
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Receiving;
 using Chatter.MessageBrokers.Routing.Options;
 using Chatter.MessageBrokers.Sending;
 using Chatter.MessageBrokers.SqlServiceBroker.Configuration;
@@ -77,10 +79,30 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         // RecordingMessageHandler<TMessage> should be wired into Chatter's handler resolution; a closed
         // IMessageHandler<TMessage> is registered for each so Chatter's dispatcher resolves and invokes it on
         // the real receive path.
+        //
+        // This original overload (no global transaction mode) is preserved byte-for-byte so every existing SSB
+        // test resolves to it unchanged: it forwards to the mode-aware overload below with globalTransactionMode
+        // = null, which passes NO options delegate to AddMessageBrokers (the receiver falls back to its
+        // TransactionMode.ReceiveOnly default exactly as before).
         public static ChatterSsbPipelineHarness Build(
             string connectionString,
             ServiceBrokerProvisioning.ObjectSet objectSet,
             Action<SqlServiceBrokerOptionsBuilder> configureReceivers,
+            params Type[] messageTypes)
+            => Build(connectionString, objectSet, configureReceivers, globalTransactionMode: null, messageTypes);
+
+        // Mode-aware overload: globalTransactionMode sets the GLOBAL MessageBrokerOptions.TransactionMode for this
+        // harness instance. The SSB receive-side transaction mode is GLOBAL-per-container — SqlServiceBrokerReceiver
+        // captures it in its ctor from MessageBrokerOptions.TransactionMode (NOT per-receiver), so the only lever
+        // that reaches the receive-side RECEIVE transaction is AddMessageBrokers' options delegate via
+        // WithTransactionMode. When supplied, it is wired as opts => opts.WithTransactionMode(value) on the
+        // existing AddMessageBrokers call; when null, no options delegate is passed and behavior is byte-identical
+        // to the original overload above (the receiver falls back to its TransactionMode.ReceiveOnly default).
+        public static ChatterSsbPipelineHarness Build(
+            string connectionString,
+            ServiceBrokerProvisioning.ObjectSet objectSet,
+            Action<SqlServiceBrokerOptionsBuilder> configureReceivers,
+            TransactionMode? globalTransactionMode,
             params Type[] messageTypes)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
@@ -108,9 +130,15 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             // IsValidMessageHandler scan filter, so it is registered explicitly below.
             var testAssembly = typeof(ChatterSsbPipelineHarness).Assembly;
 
+            // Only pass an options delegate when a global transaction mode is requested; otherwise leave it null
+            // so the AddMessageBrokers call is byte-identical to the no-options form existing tests rely on.
+            Action<MessageBrokerOptionsBuilder> configureMessageBrokerOptions = globalTransactionMode is null
+                ? null
+                : opts => opts.WithTransactionMode(globalTransactionMode.Value);
+
             services
                 .AddChatterCqrs(configuration, testAssembly)
-                .AddMessageBrokers(receiverAssemblies: testAssembly)
+                .AddMessageBrokers(configureMessageBrokerOptions, receiverAssemblies: testAssembly)
                 .AddSqlServiceBroker(ssb =>
                 {
                     // Seed the options with the fixture's app connection string and a FINITE receiver timeout

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
@@ -60,11 +60,30 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                 DeadLetterQueueName: $"chatter_ssb_it_deadletter_queue_{suffix}",
                 DeadLetterServiceName: $"chatter_ssb_it_deadletter_service_{suffix}");
 
-        // The four well-known per-test-class object sets, one per integration test class.
+        // The four original per-test-class object sets, one per integration test class.
         public static readonly ObjectSet RoundTripSet = CreateSet("roundtrip");
         public static readonly ObjectSet NackSet = CreateSet("nack");
         public static readonly ObjectSet DeadLetterSet = CreateSet("deadletter");
         public static readonly ObjectSet DialogSet = CreateSet("dialog");
+
+        // Additional per-test-class object sets for the SSB core-behavior scenarios (STEP-006/007/008). Each is a
+        // full target+deadletter set on the shared contract, identical in shape to the four above, so the
+        // provisioning/teardown loops treat them uniformly.
+        //   PublishSet       — C2: IEvent publish (PublishAsync) routes to its own target service.
+        //   PoisonSet        — C8: poison/deadletter scenario with its own isolated queues.
+        //   TransactionSet   — C9: transaction-mode receiver scenario with its own isolated queues.
+        public static readonly ObjectSet PublishSet = CreateSet("publish");
+        public static readonly ObjectSet PoisonSet = CreateSet("poison");
+        public static readonly ObjectSet TransactionSet = CreateSet("transaction");
+
+        // C10 forwarding set. Beyond the standard target+deadletter set, forwarding requires a SECOND, DISTINCT
+        // destination service+queue so a handler on the primary target can Forward/Send to a service OTHER than the
+        // one it received on. Modeled as a primary ObjectSet plus a dedicated forward-destination service+queue;
+        // the harness destination override routes the forward to ForwardDestinationServiceName, and a test reads
+        // ForwardDestinationQueueName at the edge to prove the message arrived on the distinct destination.
+        public static readonly ObjectSet ForwardingSet = CreateSet("forwarding");
+        public const string ForwardDestinationQueueName = "chatter_ssb_it_forward_dest_queue";
+        public const string ForwardDestinationServiceName = "chatter_ssb_it_forward_dest_service";
 
         // Every object set, driving BOTH provisioning and teardown so the two loops can never diverge and leak.
         public static readonly IReadOnlyList<ObjectSet> AllSets = new[]
@@ -73,6 +92,10 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             NackSet,
             DeadLetterSet,
             DialogSet,
+            PublishSet,
+            PoisonSet,
+            TransactionSet,
+            ForwardingSet,
         };
 
         // Bounded readiness retry. A freshly started SQL Server container can refuse connections or report the
@@ -113,6 +136,11 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                 await ProvisionServiceAsync(connection, set.TargetServiceName, set.TargetQueueName, cancellationToken).ConfigureAwait(false);
                 await ProvisionServiceAsync(connection, set.DeadLetterServiceName, set.DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
             }
+
+            // C10 forward destination: a SECOND, DISTINCT target service+queue (on the shared contract) so a
+            // forwarding test can route to a service other than ForwardingSet.TargetServiceName.
+            await ProvisionQueueAsync(connection, ForwardDestinationQueueName, cancellationToken).ConfigureAwait(false);
+            await ProvisionServiceAsync(connection, ForwardDestinationServiceName, ForwardDestinationQueueName, cancellationToken).ConfigureAwait(false);
         }
 
         // Drops every provisioned Service Broker object (services, queues, contract, message type) and the
@@ -147,6 +175,10 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                     await DropQueueAsync(connection, set.TargetQueueName, cancellationToken).ConfigureAwait(false);
                     await DropQueueAsync(connection, set.DeadLetterQueueName, cancellationToken).ConfigureAwait(false);
                 }
+
+                // C10 forward destination, in reverse dependency order (service references queue).
+                await DropServiceAsync(connection, ForwardDestinationServiceName, cancellationToken).ConfigureAwait(false);
+                await DropQueueAsync(connection, ForwardDestinationQueueName, cancellationToken).ConfigureAwait(false);
 
                 // Shared objects last, in reverse dependency order: initiator service+queue, then contract+type.
                 await DropServiceAsync(connection, InitiatorServiceName, cancellationToken).ConfigureAwait(false);

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/ServiceBrokerProvisioning.cs
@@ -71,10 +71,14 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
         // provisioning/teardown loops treat them uniformly.
         //   PublishSet       — C2: IEvent publish (PublishAsync) routes to its own target service.
         //   PoisonSet        — C8: poison/deadletter scenario with its own isolated queues.
-        //   TransactionSet   — C9: transaction-mode receiver scenario with its own isolated queues.
+        //   TransactionSet   — C9 ReceiveOnly: transaction-mode receiver scenario with its own isolated queues.
+        //   NoneSet          — C9 None: transaction-mode None case gets its OWN isolated queues so it never
+        //                      shares the deadletter set's target/deadletter queues (cross-test poisoning would
+        //                      otherwise make the order-independent None assertion order-DEPENDENT).
         public static readonly ObjectSet PublishSet = CreateSet("publish");
         public static readonly ObjectSet PoisonSet = CreateSet("poison");
         public static readonly ObjectSet TransactionSet = CreateSet("transaction");
+        public static readonly ObjectSet NoneSet = CreateSet("none");
 
         // C10 forwarding set. Beyond the standard target+deadletter set, forwarding requires a SECOND, DISTINCT
         // destination service+queue so a handler on the primary target can Forward/Send to a service OTHER than the
@@ -95,6 +99,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             PublishSet,
             PoisonSet,
             TransactionSet,
+            NoneSet,
             ForwardingSet,
         };
 

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbForwardingTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbForwardingTests.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Threading.Tasks;
+using Chatter.CQRS;
+using Chatter.CQRS.Commands;
+using Chatter.CQRS.Context;
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Routing.Options;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Core-behavior C10 proof for the SQL Service Broker adapter (STEP-008): in-handler forward. The SYSTEM
+    // UNDER TEST is Chatter's own SSB send/forward + receive path. A command is sent through Chatter
+    // (IBrokeredMessageDispatcher.Send, via harness.SendAsync) to the ForwardingSet source service; a handler
+    // on that source service — resolved by Chatter on the receive path — forwards a follow-up to a SECOND,
+    // DISTINCT destination service (ServiceBrokerProvisioning.ForwardDestinationServiceName) via the broker
+    // context's Send (IMessageBrokerContext.Send). A SECOND in-process Chatter receiver on the destination
+    // service+queue then delivers the forwarded command to its RecordingMessageHandler<ForwardedCommand>,
+    // proving the forward routed through Chatter's SSB send path with its payload intact — end to end, with no
+    // raw SSB / ADO.NET edge. This is the SSB analogue of the Azure Service Bus PipelineForwardingTests
+    // forwarding scenario.
+    //
+    // TWO RECEIVERS IN ONE HOST: SSB permits multiple receivers in one host (unlike the single-receiver
+    // RabbitMQ host), so both the source receiver (AddQueueReceiver<SourceCommand> on the ForwardingSet target
+    // queue) and the destination receiver (AddQueueReceiver<ForwardedCommand> on the ForwardDestination queue)
+    // are registered together in the harness's configureReceivers delegate. The harness's single owning
+    // _objectSet (ForwardingSet) only governs the DEFAULT SendAsync target service; receiver registration is
+    // free-form in the delegate, so no harness change is needed to host the second receiver on a different
+    // service.
+    //
+    // SSB FORWARD STAMPS: the harness's SendAsync stamps the SSB initiator/contract/message-type headers the
+    // SqlServiceBrokerSender reads to BEGIN DIALOG / SEND. A handler-driven brokerContext.Send does NOT inherit
+    // those stamps automatically, so the forwarding handler stamps the SAME SSB headers (InitiatorServiceName,
+    // ContractName, MessageTypeName) on its SendOptions, mirroring the harness's CreateSsbSendOptions, and sends
+    // to the BARE ForwardDestinationServiceName (BeginDialogConversationCommand strips brackets and uses it as
+    // "TO SERVICE", so the destination must name the SERVICE, not the queue).
+    //
+    // The fact is gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green; the nightly SQL Server CI lane (`--filter Category=Integration`) runs it for real.
+    [Trait("Category", "Integration")]
+    [Collection(SqlServiceBrokerCollection.Name)]
+    public class SsbForwardingTests
+    {
+        // Generous on purpose: the forwarding chain (source-receive -> handler -> forward-send via BEGIN DIALOG /
+        // SEND -> dest-enqueue -> dest-receive) is a two-hop SSB path. 30 s matches the other SSB integration
+        // waits and gives headroom without masking a real wiring failure.
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
+
+        private readonly SqlServiceBrokerFixture _fixture;
+
+        public SsbForwardingTests(SqlServiceBrokerFixture fixture)
+            => _fixture = fixture;
+
+        // The command consumed on the ForwardingSet source service. Its handler forwards a ForwardedCommand to
+        // the distinct ForwardDestination service through Chatter's broker-context Send.
+        public sealed class SourceCommand : ICommand
+        {
+            public string Value { get; set; }
+        }
+
+        // The command the source handler forwards to the ForwardDestination service. A second in-process Chatter
+        // receiver on the destination delivers it to a RecordingMessageHandler, proving the forward landed
+        // through Chatter's SSB send path.
+        public sealed class ForwardedCommand : ICommand
+        {
+            public string Value { get; set; }
+        }
+
+        // A Chatter IMessageHandler<SourceCommand> that, on receipt, forwards a ForwardedCommand to the distinct
+        // ForwardDestination service via the broker context's Send — exercising Chatter's SSB send path from
+        // inside a handler. Mirrors the Azure Service Bus ForwardingSourceHandler, with the SSB difference that
+        // it must stamp the SSB initiator/contract/message-type headers on the SendOptions (a handler-driven Send
+        // does not inherit the harness's stamps) so the SqlServiceBrokerSender can BEGIN DIALOG / SEND. Registered
+        // explicitly into the test DI graph as the IMessageHandler<SourceCommand> Chatter resolves for the source
+        // receiver (instead of a RecordingMessageHandler).
+        private sealed class ForwardingSourceHandler : IMessageHandler<SourceCommand>
+        {
+            public Task Handle(SourceCommand message, IMessageHandlerContext context)
+            {
+                var brokerContext = context as IMessageBrokerContext;
+                brokerContext.Should().NotBeNull(
+                    "the source handler runs on Chatter's SSB broker receive path and must receive an IMessageBrokerContext");
+
+                // Stamp the SSB headers the SqlServiceBrokerSender reads to BEGIN DIALOG / SEND on the shared
+                // initiator service + //Chatter contract + //Chatter/BrokeredMessage message type, mirroring the
+                // harness's CreateSsbSendOptions. Without these the handler-driven Send cannot route through SSB.
+                var options = new SendOptions();
+                options.WithMessageContext(SSBMessageContext.ServiceName, ServiceBrokerProvisioning.InitiatorServiceName);
+                options.WithMessageContext(SSBMessageContext.ServiceContractName, ServiceBrokerProvisioning.ContractName);
+                options.WithMessageContext(SSBMessageContext.MessageTypeName, ServiceBrokerProvisioning.MessageTypeName);
+
+                // destinationPath is the BARE destination SERVICE name: BeginDialogConversationCommand strips
+                // brackets and uses it as "TO SERVICE", so it must name the service, not the queue.
+                return brokerContext.Send(
+                    new ForwardedCommand { Value = message.Value + "-forwarded" },
+                    ServiceBrokerProvisioning.ForwardDestinationServiceName,
+                    options);
+            }
+        }
+
+        // Builds one harness instance hosting BOTH receivers: the source receiver on the ForwardingSet target
+        // queue (handled by the explicitly-registered ForwardingSourceHandler) and the destination receiver on
+        // the ForwardDestination queue (handled by RecordingMessageHandler<ForwardedCommand>, wired by passing
+        // typeof(ForwardedCommand) as a recorded message type). Both receivers run in default ReceiveOnly mode.
+        // The harness is built with ForwardingSet as its owning object set so the default SendAsync routes the
+        // SourceCommand to the ForwardingSet source service.
+        private ChatterSsbPipelineHarness BuildHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.ForwardingSet,
+                ssb =>
+                {
+                    // Source receiver: consumes SourceCommand on the ForwardingSet target queue. Register the
+                    // forwarding handler explicitly so Chatter resolves it (not a RecordingMessageHandler) for
+                    // SourceCommand on the receive path.
+                    ssb.AddQueueReceiver<SourceCommand>(
+                        ServiceBrokerProvisioning.ForwardingSet.TargetQueuePathBracketed,
+                        deadLetterServicePath: ServiceBrokerProvisioning.ForwardingSet.DeadLetterServiceName);
+                    ssb.Services.AddTransient<IMessageHandler<SourceCommand>, ForwardingSourceHandler>();
+
+                    // Destination receiver: a SECOND receiver, on the distinct ForwardDestination queue, that
+                    // delivers the forwarded command to its RecordingMessageHandler<ForwardedCommand>. SSB hosts
+                    // both receivers in one instance.
+                    ssb.AddQueueReceiver<ForwardedCommand>(
+                        "[" + ServiceBrokerProvisioning.ForwardDestinationQueueName + "]",
+                        deadLetterServicePath: ServiceBrokerProvisioning.ForwardingSet.DeadLetterServiceName);
+                },
+                typeof(ForwardedCommand));
+
+        // C10 in-handler forward through Chatter: a SourceCommand sent to the ForwardingSet source service is
+        // consumed by a handler that forwards a ForwardedCommand to the distinct ForwardDestination service via
+        // the broker context's Send. A SECOND in-process Chatter receiver on the ForwardDestination service
+        // delivers the forwarded command to its RecordingMessageHandler, proving the forward routed through
+        // Chatter's SSB send path with the payload intact — end to end. Asserts the destination handler is
+        // invoked once with the forwarded "-forwarded" payload, observed at the Chatter handler / MessageContext
+        // level.
+        [RequiresDockerFact]
+        public async Task HandlerForwardsToDestinationServiceThroughChatterSsbSendPath()
+        {
+            var harness = BuildHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                // Drive the chain: send a SourceCommand to the ForwardingSet source service (the harness's
+                // owning object set, so the default SendAsync targets it).
+                await harness.SendAsync(new SourceCommand { Value = "origin" });
+
+                // The source handler's forward (Chatter's SSB send path) must land the ForwardedCommand on the
+                // distinct ForwardDestination service, where the second Chatter receiver delivers it to its
+                // RecordingMessageHandler.
+                var handled = await harness.WaitForHandledAsync<ForwardedCommand>(HandlerWait);
+
+                // Payload round-trip: the forwarded command must arrive with the exact payload the source handler
+                // forwarded, deserialized by Chatter on the destination receive path.
+                handled.Message.Should().NotBeNull(
+                    "the forwarded command must be delivered to the ForwardDestination service through Chatter's SSB send path");
+                handled.Message.Value.Should().Be(
+                    "origin-forwarded",
+                    "the destination receiver's handler must receive the exact payload the source handler forwarded");
+
+                // Inbound broker context: the destination handler must receive an IMessageBrokerContext on the SSB
+                // receive path, carrying the InfrastructureType stamp that identifies the SSB receiver.
+                handled.Context.Should().NotBeNull(
+                    "the destination handler context must be an IMessageBrokerContext on the broker receive path");
+                var inbound = handled.Context.BrokeredMessage;
+
+                inbound.MessageContext.Should().ContainKey(MessageContext.InfrastructureType);
+                inbound.MessageContext[MessageContext.InfrastructureType]
+                    .Should().Be(SSBMessageContext.InfrastructureType);
+
+                // The forwarded command must reach the destination handler exactly once. The post-dispatch
+                // EndDialog system message (EndConversationAfterDispatch default true) on the destination
+                // conversation is auto-acked by the receiver's classifier and never reaches the handler.
+                harness.GetSignal<ForwardedCommand>().InvocationCount
+                    .Should().Be(1,
+                        "the forwarded command reaches the destination handler once; the EndDialog system message " +
+                        "is auto-acked and must not reach the handler");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbPoisonMessageTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbPoisonMessageTests.cs
@@ -1,0 +1,260 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
+using System.Threading;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.Sending;
+using Chatter.MessageBrokers.SqlServiceBroker.Scripts;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Poison-message→DLQ integration proof (C8) for the SQL Service Broker integration harness. The SYSTEM UNDER
+    // TEST is Chatter's POISON path, which is DISTINCT from the throwing-handler deadletter path
+    // (SsbDeadLetterTests): when the inbound envelope's INNER body cannot be deserialized into TCommand,
+    // BrokeredMessageReceiver.ProcessMessageAsync wraps the failure in a PoisonedMessageException
+    // (GetMessageFromBody<TMessage> throws), and the worker's PoisonedMessageException catch deadletters
+    // IMMEDIATELY via TryDeadletterWithRecoveryAsync — BEFORE the handler dispatch and WITHOUT consulting
+    // MaxReceiveAttempts. So the message reaches the DLQ on the FIRST delivery, the handler is NEVER invoked
+    // (InvocationCount == 0), and there is no retry/redelivery climb to bound.
+    //
+    // HOW THE POISON IS RAW-INJECTED AT THE ADO.NET EDGE: Chatter's own SendAsync would serialize a VALID
+    // envelope whose inner body binds cleanly to TCommand, so it can never produce a poison. This test therefore
+    // bypasses Chatter's sender and SENDs raw, mirroring SsbDeadLetterTests' DLQ RECEIVE inverted into a SEND:
+    //   1. Build a REAL OutboundBrokeredMessage envelope via JsonUnicodeBodyConverter — the exact UTF-16-JSON
+    //      wire format SqlServiceBrokerReceiver expects — so the OUTER envelope deserialize in ReceiveMessageAsync
+    //      succeeds and message.MessageTypeName == //Chatter/BrokeredMessage (the Chatter-brokered path that
+    //      reaches ProcessMessageAsync). The envelope's ContentType header is stamped to the UTF-16 converter's
+    //      content type by OutboundBrokeredMessage's ctor, so the receiver decodes the INNER body with that same
+    //      converter.
+    //   2. Set the envelope's INNER Body to UTF-16 bytes of a NON-JSON string ("this-is-not-valid-json"). The
+    //      inner-body decode (JsonSerializer.Deserialize<PoisonCommand>) then throws, surfacing the
+    //      PoisonedMessageException the poison path keys on. The inner bytes are deliberately undeserializable to
+    //      TCommand rather than merely a different shape, so the poison trigger is deterministic.
+    //   3. Serialize that envelope to bytes with the SAME UTF-16 converter and SEND it raw via BEGIN DIALOG /
+    //      SEND ON CONVERSATION onto the harness's shared initiator service → the PoisonSet target service →
+    //      PoisonSet target queue, on the production-pinned //Chatter contract + //Chatter/BrokeredMessage
+    //      message type. This is the inverse of SsbDeadLetterTests' raw DLQ RECEIVE.
+    //
+    // The fact is gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green. Mirrors SsbDeadLetterTests / SsbNackRedeliveryTests for harness setup and
+    // collection membership; uses the dedicated PoisonSet so its queue state is isolated from the other
+    // integration test classes in the collection.
+    [Trait("Category", "Integration")]
+    [Collection(SqlServiceBrokerCollection.Name)]
+    public class SsbPoisonMessageTests
+    {
+        private static readonly TimeSpan DeadLetterWait = TimeSpan.FromSeconds(30);
+
+        // After the poison lands on the DLQ, how long to keep watching the handler signal to PROVE no retry climb
+        // ever invokes the handler. The poison deadletters before dispatch, so the handler must never run; a
+        // bounded settle confirms the negative is not merely un-raced.
+        private static readonly TimeSpan NoInvocationSettle = TimeSpan.FromSeconds(3);
+
+        private readonly SqlServiceBrokerFixture _fixture;
+
+        public SsbPoisonMessageTests(SqlServiceBrokerFixture fixture)
+            => _fixture = fixture;
+
+        // Distinct command type so this test's queue state is independent of the other integration tests in the
+        // collection. Its shape is irrelevant to the test: the poison body is deliberately NON-JSON so it can
+        // never bind to this (or any) command type.
+        public sealed class PoisonCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        private ChatterSsbPipelineHarness BuildHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.PoisonSet,
+                // maxReceiveAttempts is left at the default: the poison path deadletters on the FIRST delivery
+                // independent of MaxReceiveAttempts (the PoisonedMessageException catch runs before the
+                // delivery-count ladder), so the trigger does not depend on the attempt cap.
+                ssb => ssb.AddQueueReceiver<PoisonCommand>(
+                    ServiceBrokerProvisioning.PoisonSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.PoisonSet.DeadLetterServiceName),
+                typeof(PoisonCommand));
+
+        // Poison→DLQ: an undeserializable inner body raw-injected at the ADO.NET edge deadletters on the FIRST
+        // delivery. Assert (a) the poison lands on the deadletter QUEUE, (b) the deadletter envelope carries the
+        // poison failure headers (FailureDetails == "Poisoned message received"), (c) ReceiveAttempts == 1 (no
+        // retry climb), and (d) the handler was NEVER invoked (InvocationCount == 0), confirmed across a bounded
+        // settle so the negative is not vacuous.
+        [RequiresDockerFact]
+        public async Task UndeserializableBodyDeadlettersImmediatelyWithoutInvokingHandler()
+        {
+            var harness = BuildHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                // Raw-inject the poison: a valid //Chatter/BrokeredMessage envelope whose INNER body is non-JSON,
+                // sent bypassing Chatter's serializer so the receive-side inner-body decode throws
+                // PoisonedMessageException.
+                await SendRawPoisonAsync(DeadLetterWait);
+
+                // The poison deadletters AFTER the inner-body decode throws on the receiver thread, so poll the
+                // DLQ (bounded) until the deadlettered envelope arrives rather than racing the dispatch.
+                var deadLettered = await ReceiveFromDeadLetterQueueAsync(DeadLetterWait);
+
+                deadLettered.Should().NotBeNull(
+                    "an undeserializable inner body must surface a PoisonedMessageException whose worker catch " +
+                    "deadletters immediately to the configured deadletter service, which delivers onto the DLQ");
+
+                // The deadletter envelope carries the poison failure headers DeadletterMessageAsync stamps.
+                // FailureDetails is the deadLetterReason, fixed to "Poisoned message received" on the poison path.
+                deadLettered.MessageContext.Should().ContainKey(MessageContext.FailureDetails,
+                    "DeadletterMessageAsync stamps FailureDetails with the deadletter reason");
+                deadLettered.MessageContext[MessageContext.FailureDetails].ToString()
+                    .Should().Be("Poisoned message received",
+                        "the poison path passes the fixed 'Poisoned message received' reason to the deadletter");
+
+                deadLettered.MessageContext.Should().ContainKey(MessageContext.FailureDescription,
+                    "DeadletterMessageAsync stamps FailureDescription with the originating exception's ToString");
+                deadLettered.MessageContext[MessageContext.FailureDescription].ToString()
+                    .Should().Contain(nameof(PoisonCommand),
+                        "the poison failure description carries the PoisonedMessageException, which names the " +
+                        "target type it could not deserialize");
+
+                // InfrastructureType identifies the SSB receiver as the deadletter origin.
+                deadLettered.MessageContext.Should().ContainKey(MessageContext.InfrastructureType);
+                deadLettered.MessageContext[MessageContext.InfrastructureType].ToString()
+                    .Should().Be(SSBMessageContext.InfrastructureType);
+
+                // NO RETRY CLIMB: the poison deadletters on the first delivery, so the receiver's local attempt
+                // counter is at 1 — the poison path never nacks/redelivers to climb it.
+                deadLettered.MessageContext.Should().ContainKey(MessageContext.ReceiveAttempts);
+                Convert.ToInt32(deadLettered.MessageContext[MessageContext.ReceiveAttempts])
+                    .Should().Be(1, "the poison deadlettered on the first delivery with no redelivery climb");
+
+                // HANDLER NEVER INVOKED: the poison surfaces during the inner-body decode BEFORE the handler
+                // dispatch, so the handler is never reached. Let the pump loop for a bounded settle so a (wrongly)
+                // redelivered/dispatched poison would have time to invoke the handler, then assert it stayed at 0
+                // — proving the negative is observed, not merely un-raced.
+                await Task.Delay(NoInvocationSettle).ConfigureAwait(false);
+
+                harness.GetSignal<PoisonCommand>().InvocationCount
+                    .Should().Be(0,
+                        "the poison must deadletter before the handler dispatch, so the handler must never be " +
+                        "invoked even after a bounded settle window");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+
+        // Raw-injects a poison message at the ADO.NET edge: BEGIN DIALOG from the shared initiator service TO the
+        // PoisonSet target service on the //Chatter contract, then SEND ON CONVERSATION a valid
+        // //Chatter/BrokeredMessage envelope whose INNER body is non-JSON. Bypasses Chatter's sender entirely so
+        // the body is undeserializable to TCommand (Chatter's own SendAsync could only ever produce a clean
+        // envelope). Bounds every DB await to the supplied timeout so a wedged BEGIN DIALOG / SEND fails fast.
+        private async Task SendRawPoisonAsync(TimeSpan timeout)
+        {
+            var bodyConverter = new JsonUnicodeBodyConverter();
+
+            // The INNER body is UTF-16 bytes of a non-JSON string. OutboundBrokeredMessage's ctor stamps the
+            // envelope ContentType to the UTF-16 converter's content type, so the receiver decodes this inner
+            // body with the SAME UTF-16 converter and JsonSerializer.Deserialize<PoisonCommand> throws on it.
+            var poisonInnerBody = bodyConverter.GetBytes("this-is-not-valid-json");
+
+            // A real OutboundBrokeredMessage envelope (valid OUTER shape so the receiver's envelope deserialize
+            // succeeds and routes through the Chatter-brokered path) carrying the poison inner body. A destination
+            // is required by the ctor but is irrelevant to the raw SEND below, which targets the PoisonSet service
+            // directly; use the target service name for clarity.
+            var envelope = new OutboundBrokeredMessage(
+                Guid.NewGuid().ToString(),
+                poisonInnerBody,
+                new Dictionary<string, object>(),
+                ServiceBrokerProvisioning.PoisonSet.TargetServiceName,
+                bodyConverter);
+
+            var envelopeBytes = bodyConverter.Convert(envelope);
+
+            using var operationCts = new CancellationTokenSource(timeout);
+            var operationToken = operationCts.Token;
+
+            await using var connection = new SqlConnection(_fixture.GetAppConnectionString());
+            await connection.OpenAsync(operationToken).ConfigureAwait(false);
+
+            // BEGIN DIALOG FROM the shared initiator service TO the PoisonSet target service on the //Chatter
+            // contract — the same dialog Chatter's sender would open, but here we drive it raw so we control the
+            // body. BeginDialogConversationCommand strips brackets from the target and uses it as TO SERVICE.
+            var beginDialog = new BeginDialogConversationCommand(
+                connection,
+                targetServiceName: ServiceBrokerProvisioning.PoisonSet.TargetServiceName,
+                initiatorServiceName: ServiceBrokerProvisioning.InitiatorServiceName,
+                serviceContractName: ServiceBrokerProvisioning.ContractName);
+            var conversationHandle = await beginDialog.ExecuteAsync(operationToken).ConfigureAwait(false);
+
+            // SEND the poison envelope on the //Chatter/BrokeredMessage message type so the receiver classifies it
+            // as the Chatter-brokered path and reaches ProcessMessageAsync (where the inner-body decode throws).
+            var sendOnConversation = new SendOnConversationCommand(
+                connection,
+                conversationHandle,
+                envelopeBytes,
+                messageType: ServiceBrokerProvisioning.MessageTypeName);
+            await sendOnConversation.ExecuteAsync(operationToken).ConfigureAwait(false);
+        }
+
+        // Bounded poll of the deadletter queue, reading the deadlettered OutboundBrokeredMessage envelope at the
+        // test edge via raw ADO.NET. Mirrors SsbDeadLetterTests' DLQ RECEIVE: RECEIVE is non-blocking so an empty
+        // queue returns immediately and the poll loop sleeps before retrying; returns null if the deadline
+        // elapses so the caller's assertion fails fast rather than hanging. The decompress CASE mirrors
+        // production's RECEIVE so the message_body bytes are the raw envelope regardless of broker-side
+        // compression.
+        private async Task<OutboundBrokeredMessage> ReceiveFromDeadLetterQueueAsync(TimeSpan timeout)
+        {
+            var bodyConverter = new JsonUnicodeBodyConverter();
+            var deadline = DateTime.UtcNow + timeout;
+
+            using var operationCts = new CancellationTokenSource(timeout);
+            var operationToken = operationCts.Token;
+
+            await using var connection = new SqlConnection(_fixture.GetAppConnectionString());
+            await connection.OpenAsync(operationToken).ConfigureAwait(false);
+
+            while (DateTime.UtcNow < deadline)
+            {
+                await using var transaction = (SqlTransaction)await connection.BeginTransactionAsync(operationToken).ConfigureAwait(false);
+
+                byte[] messageBody = null;
+                await using (var command = connection.CreateCommand())
+                {
+                    command.Transaction = transaction;
+                    command.CommandText =
+                        "RECEIVE TOP(1) " +
+                        "CASE WHEN SUBSTRING(message_body, 1, 2) = 0x1F8B " +
+                        "THEN CAST(decompress(message_body) AS VARBINARY(MAX)) " +
+                        "ELSE message_body END AS message_body, message_type_name " +
+                        $"FROM [{ServiceBrokerProvisioning.PoisonSet.DeadLetterQueueName}]";
+
+                    await using var reader = await command.ExecuteReaderAsync(operationToken).ConfigureAwait(false);
+                    if (reader.Read() && !reader.IsDBNull(0))
+                    {
+                        messageBody = reader.GetSqlBytes(0).Buffer;
+                    }
+                }
+
+                await transaction.CommitAsync().ConfigureAwait(false);
+
+                if (messageBody != null)
+                {
+                    // The deadletter message type is //Chatter/BrokeredMessage, so the body is the serialized
+                    // OutboundBrokeredMessage envelope the SqlServiceBrokerSender wrote.
+                    return bodyConverter.Convert<OutboundBrokeredMessage>(messageBody);
+                }
+
+                await Task.Delay(TimeSpan.FromMilliseconds(250)).ConfigureAwait(false);
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbPublishTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbPublishTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading.Tasks;
+using Chatter.CQRS.Events;
+using Chatter.MessageBrokers;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Core-behavior C2 proof for the SQL Service Broker adapter (STEP-006): an IEvent PUBLISHED through Chatter
+    // (IBrokeredMessageDispatcher.Publish, via harness.PublishAsync) is delivered by Chatter's in-process SSB
+    // receiver pump to a Chatter-resolved RecordingMessageHandler<TEvent> exactly once, with its payload intact.
+    // The SYSTEM UNDER TEST is Chatter's own SSB publish + receive path; every assertion reads the event Chatter
+    // deserialized and the IMessageBrokerContext Chatter built — never a raw SSB / ADO.NET type. This is the
+    // publish-side analogue of SsbRoundTripTests (which proves the command Send path) and confirms the receiver
+    // graph and AddQueueReceiver<TEvent> registration accept an IEvent type cleanly.
+    //
+    // C4 (per-message content-type selection) is N/A for SSB and intentionally NOT tested: the SSB sender selects
+    // its body converter from the fixed _options.MessageBodyType, never from a per-message ContentType (confirmed
+    // STEP-005).
+    //
+    // The fact is gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green; the nightly SQL Server CI lane (`--filter Category=Integration`) runs it for real.
+    [Trait("Category", "Integration")]
+    [Collection(SqlServiceBrokerCollection.Name)]
+    public class SsbPublishTests
+    {
+        private static readonly TimeSpan HandlerWait = TimeSpan.FromSeconds(30);
+
+        private readonly SqlServiceBrokerFixture _fixture;
+
+        public SsbPublishTests(SqlServiceBrokerFixture fixture)
+            => _fixture = fixture;
+
+        // An event carrying string/int fields so the publish body round-trip exercises Chatter's STJ body
+        // converter and the on-receive materialization restores the exact CLR values. Declared a class implementing
+        // IEvent so it satisfies AddQueueReceiver<TMessage>'s `where TMessage : class, IMessage` constraint
+        // (IEvent : IMessage) and PublishAsync's `where TEvent : class, IEvent` constraint.
+        public sealed class TestIntegrationEvent : IEvent
+        {
+            public string Name { get; set; }
+            public int Count { get; set; }
+        }
+
+        private ChatterSsbPipelineHarness BuildHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.PublishSet,
+                ssb => ssb.AddQueueReceiver<TestIntegrationEvent>(
+                    ServiceBrokerProvisioning.PublishSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.PublishSet.DeadLetterServiceName),
+                typeof(TestIntegrationEvent));
+
+        // C2: an event published through Chatter's dispatcher is delivered by Chatter's SSB pump to the registered
+        // handler exactly once, with its string/int payload deserialized EXACTLY, and the inbound SSBMessageContext
+        // carries the SSB InfrastructureType stamp. The post-dispatch EndDialog system message is auto-acked by the
+        // receiver's classifier and must NOT reach the handler, so the handler is invoked exactly once.
+        [RequiresDockerFact]
+        public async Task PublishedEventReachesHandlerExactlyOnceWithPayloadIntact()
+        {
+            var harness = BuildHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                var published = new TestIntegrationEvent { Name = "ssb-publish", Count = 7 };
+                await harness.PublishAsync(published);
+
+                var handled = await harness.WaitForHandledAsync<TestIntegrationEvent>(HandlerWait);
+
+                // Payload round-trip: the published event must survive the OutboundBrokeredMessage envelope
+                // round-trip through SQL Service Broker verbatim.
+                handled.Message.Should().NotBeNull("Chatter's SSB publish pipeline must deliver the event to the handler");
+                handled.Message.Name.Should().Be("ssb-publish");
+                handled.Message.Count.Should().Be(7);
+
+                // Inbound broker context: the handler must receive an IMessageBrokerContext on the SSB receive path,
+                // carrying the InfrastructureType stamp that identifies the SSB receiver.
+                handled.Context.Should().NotBeNull(
+                    "the handler context must be an IMessageBrokerContext on the broker receive path");
+                var inbound = handled.Context.BrokeredMessage;
+
+                inbound.MessageContext.Should().ContainKey(MessageContext.InfrastructureType);
+                inbound.MessageContext[MessageContext.InfrastructureType]
+                    .Should().Be(SSBMessageContext.InfrastructureType);
+
+                // Exactly-once: the post-dispatch EndDialog system message (EndConversationAfterDispatch default
+                // true) is auto-acked by the receiver's classifier and never reaches the handler, so the handler is
+                // invoked exactly once — for the published event alone.
+                harness.GetSignal<TestIntegrationEvent>().InvocationCount
+                    .Should().Be(1, "the EndDialog system message is auto-acked and must not reach the handler");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbTransactionModeTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbTransactionModeTests.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Chatter.CQRS.Commands;
+using Chatter.MessageBrokers;
+using Chatter.MessageBrokers.Receiving;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
+{
+    // Transaction-mode integration proof (C9) for the SQL Service Broker integration harness. The SYSTEM UNDER
+    // TEST is how the GLOBAL MessageBrokerOptions.TransactionMode governs the SSB receive-side RECEIVE
+    // transaction, which is what makes nack→redelivery possible (or not):
+    //
+    //   * ReceiveOnly — SqlServiceBrokerReceiver BEGINs a transaction around the RECEIVE, so when the handler
+    //     throws, NackMessageAsync ROLLS BACK that transaction and the message returns to the queue and is
+    //     REDELIVERED (InvocationCount climbs, ReceiveAttempts climbs). This is the same redelivery SsbNack
+    //     RedeliveryTests proves; here it is the POSITIVE control for the transaction-mode lever.
+    //   * None — the receiver BEGINs NO transaction around the RECEIVE (SqlServiceBrokerReceiver only opens a
+    //     transaction when _transactionMode != TransactionMode.None), so the RECEIVE is already committed when
+    //     the handler throws — there is nothing to roll back, so the message is NOT returned to the queue and is
+    //     NOT redelivered. The handler is invoked EXACTLY ONCE.
+    //
+    // WHY TWO HARNESS INSTANCES: the SSB receive-side transaction mode is GLOBAL-PER-CONTAINER. SqlService
+    // BrokerReceiver captures it ONCE in its ctor from MessageBrokerOptions.TransactionMode
+    // (SqlServiceBrokerReceiver.cs: `_transactionMode = messageBrokerOptions?.TransactionMode ??
+    // TransactionMode.ReceiveOnly`), NOT per-receiver — the AddQueueReceiver(transactionMode:) param does not
+    // reach the SSB receive-side SQL transaction. So the only lever is the GLOBAL MessageBrokerOptions
+    // .TransactionMode set via AddMessageBrokers(opts => opts.WithTransactionMode(...)). Each mode therefore
+    // needs its OWN harness instance (its own DI graph / receiver) built with that global mode, and each runs on
+    // its OWN provisioned object set so their queue state can never bleed into one another.
+    //
+    // Both facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
+    // `dotnet test` stays green. Mirrors SsbNackRedeliveryTests for harness setup and collection membership.
+    [Trait("Category", "Integration")]
+    [Collection(SqlServiceBrokerCollection.Name)]
+    public class SsbTransactionModeTests
+    {
+        private static readonly TimeSpan RedeliveryWait = TimeSpan.FromSeconds(30);
+
+        // For the None case: how long to keep watching after the single delivery is confirmed to PROVE no
+        // redelivery ever invokes the handler a second time. With no receive transaction to roll back, a (wrong)
+        // redelivery would have to happen within this window; a bounded settle confirms the negative is not
+        // merely un-raced.
+        private static readonly TimeSpan NoRedeliverySettle = TimeSpan.FromSeconds(5);
+
+        private readonly SqlServiceBrokerFixture _fixture;
+
+        public SsbTransactionModeTests(SqlServiceBrokerFixture fixture)
+            => _fixture = fixture;
+
+        // Distinct command type for the ReceiveOnly case so its queue state is independent of every other
+        // integration test class in the collection.
+        public sealed class ReceiveOnlyTransactionCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        // Distinct command type for the None case, on a DIFFERENT object set, so the two transaction-mode cases
+        // never share a queue.
+        public sealed class NoneTransactionCommand : ICommand
+        {
+            public string Marker { get; set; }
+        }
+
+        // ReceiveOnly harness: built on the dedicated TransactionSet with the GLOBAL transaction mode set to
+        // ReceiveOnly so the receiver BEGINs a transaction around the RECEIVE and a throwing handler's nack rolls
+        // it back to redeliver.
+        private ChatterSsbPipelineHarness BuildReceiveOnlyHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.TransactionSet,
+                ssb => ssb.AddQueueReceiver<ReceiveOnlyTransactionCommand>(
+                    ServiceBrokerProvisioning.TransactionSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.TransactionSet.DeadLetterServiceName),
+                globalTransactionMode: TransactionMode.ReceiveOnly,
+                typeof(ReceiveOnlyTransactionCommand));
+
+        // None harness: built on a SEPARATE object set (DeadLetterSet) with the GLOBAL transaction mode set to
+        // None so the receiver BEGINs NO transaction around the RECEIVE — a throwing handler cannot redeliver
+        // because there is no receive transaction to roll back. Uses DeadLetterSet's target queue so it never
+        // shares a queue with the ReceiveOnly case above.
+        private ChatterSsbPipelineHarness BuildNoneHarness()
+            => ChatterSsbPipelineHarness.Build(
+                _fixture.GetAppConnectionString(),
+                ServiceBrokerProvisioning.DeadLetterSet,
+                ssb => ssb.AddQueueReceiver<NoneTransactionCommand>(
+                    ServiceBrokerProvisioning.DeadLetterSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterSet.DeadLetterServiceName),
+                globalTransactionMode: TransactionMode.None,
+                typeof(NoneTransactionCommand));
+
+        // Global ReceiveOnly + throwing handler → redelivery. The receiver wraps the RECEIVE in a transaction, so
+        // NackMessageAsync rolls it back and the message returns to the queue. Assert (a) the handler is invoked
+        // at least twice and (b) ReceiveAttempts climbs above 1 across deliveries. ANTI-INFINITE-LOOP: stop
+        // throwing once >= 2 invocations are observed so the message finally acks and the conversation closes
+        // before DisposeAsync drains the pump.
+        [RequiresDockerFact]
+        public async Task GlobalReceiveOnlyModeRedeliversThrowingHandler()
+        {
+            var harness = BuildReceiveOnlyHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                // Arm the throw BEFORE sending so the handler throws on the very first delivery.
+                harness.GetSignal<ReceiveOnlyTransactionCommand>().ThrowOnHandle =
+                    () => new InvalidOperationException("receive-only-transaction-mode forced throw");
+
+                await harness.SendAsync(new ReceiveOnlyTransactionCommand { Marker = "receive-only" });
+
+                // Wait until at least 2 handler invocations have been observed (first delivery + at least one
+                // redelivery). WaitForInvocationCountAsync returns the last observed count, which may be below
+                // minCount when the timeout elapses — the assertion below catches that case explicitly.
+                var observedCount = await harness.WaitForInvocationCountAsync<ReceiveOnlyTransactionCommand>(
+                    minCount: 2, RedeliveryWait);
+
+                // ANTI-INFINITE-LOOP: stop throwing so the next receive acks and the conversation closes cleanly.
+                harness.GetSignal<ReceiveOnlyTransactionCommand>().ThrowOnHandle = null;
+
+                observedCount.Should().BeGreaterThanOrEqualTo(2,
+                    "under global ReceiveOnly mode the receiver wraps the RECEIVE in a transaction, so a throwing " +
+                    "handler's nack rolls it back and the message is redelivered — the handler must be invoked at " +
+                    "least twice");
+
+                // ReceiveAttempts must climb: the receiver's in-memory attempt counter increments on each
+                // re-receive of the same conversation handle.
+                var records = harness.GetSignal<ReceiveOnlyTransactionCommand>().Records.ToList();
+                var maxAttempts = records
+                    .Where(r => r.Context?.BrokeredMessage?.MessageContext?.ContainsKey(MessageContext.ReceiveAttempts) == true)
+                    .Select(r => Convert.ToInt32(r.Context.BrokeredMessage.MessageContext[MessageContext.ReceiveAttempts]))
+                    .DefaultIfEmpty(0)
+                    .Max();
+
+                maxAttempts.Should().BeGreaterThan(1,
+                    "ReceiveAttempts must climb above 1 once the rolled-back RECEIVE redelivers the same " +
+                    "conversation handle at least once");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+
+        // Global None + throwing handler → exactly one invocation, NO redelivery. The receiver opens NO
+        // transaction around the RECEIVE, so the RECEIVE is already committed when the handler throws — there is
+        // nothing to roll back and the message is not returned to the queue. First CONFIRM the single delivery
+        // landed (non-vacuous: the handler really was invoked once), then assert it stays at exactly 1 across a
+        // bounded settle so the no-redelivery negative is observed, not merely un-raced.
+        [RequiresDockerFact]
+        public async Task GlobalNoneModeDoesNotRedeliverThrowingHandler()
+        {
+            var harness = BuildNoneHarness();
+            try
+            {
+                await harness.StartAsync();
+
+                // Arm the throw BEFORE sending so the handler throws on the first (and only) delivery.
+                harness.GetSignal<NoneTransactionCommand>().ThrowOnHandle =
+                    () => new InvalidOperationException("none-transaction-mode forced throw");
+
+                await harness.SendAsync(new NoneTransactionCommand { Marker = "none" });
+
+                // NON-VACUOUS: first confirm the single delivery actually landed (handler invoked at least once)
+                // so the no-redelivery assertion below is not trivially true on a message that never arrived.
+                var firstObservedCount = await harness.WaitForInvocationCountAsync<NoneTransactionCommand>(
+                    minCount: 1, RedeliveryWait);
+
+                firstObservedCount.Should().BeGreaterThanOrEqualTo(1,
+                    "the message must be delivered at least once under None mode before asserting it is not " +
+                    "redelivered — otherwise the no-redelivery assertion would be vacuous");
+
+                // NO REDELIVERY: with no receive transaction to roll back, the throwing handler cannot return the
+                // message to the queue. Let the pump loop for a bounded settle so a (wrongly) redelivered message
+                // would have time to invoke the handler again, then assert the count stayed at exactly 1.
+                await Task.Delay(NoRedeliverySettle).ConfigureAwait(false);
+
+                harness.GetSignal<NoneTransactionCommand>().InvocationCount
+                    .Should().Be(1,
+                        "under global None mode the receiver opens no transaction around the RECEIVE, so a " +
+                        "throwing handler has nothing to roll back — the message is not redelivered and the " +
+                        "handler is invoked exactly once even after a bounded settle window");
+            }
+            finally
+            {
+                await harness.DisposeAsync();
+            }
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbTransactionModeTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbTransactionModeTests.cs
@@ -79,17 +79,20 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                 globalTransactionMode: TransactionMode.ReceiveOnly,
                 typeof(ReceiveOnlyTransactionCommand));
 
-        // None harness: built on a SEPARATE object set (DeadLetterSet) with the GLOBAL transaction mode set to
+        // None harness: built on its OWN dedicated object set (NoneSet) with the GLOBAL transaction mode set to
         // None so the receiver BEGINs NO transaction around the RECEIVE — a throwing handler cannot redeliver
-        // because there is no receive transaction to roll back. Uses DeadLetterSet's target queue so it never
-        // shares a queue with the ReceiveOnly case above.
+        // because there is no receive transaction to roll back. A dedicated set (not the shared DeadLetterSet)
+        // is required: the collection fixture provisions once and never clears queues between test classes, so
+        // reusing DeadLetterSet's target/deadletter queues would let leftover state or class-order interaction
+        // from SsbDeadLetterTests bleed into this receiver and make the exactly-once None assertion
+        // order-dependent. Its own set keeps C9-None isolated, exactly as Publish/Poison/Transaction/Forwarding.
         private ChatterSsbPipelineHarness BuildNoneHarness()
             => ChatterSsbPipelineHarness.Build(
                 _fixture.GetAppConnectionString(),
-                ServiceBrokerProvisioning.DeadLetterSet,
+                ServiceBrokerProvisioning.NoneSet,
                 ssb => ssb.AddQueueReceiver<NoneTransactionCommand>(
-                    ServiceBrokerProvisioning.DeadLetterSet.TargetQueuePathBracketed,
-                    deadLetterServicePath: ServiceBrokerProvisioning.DeadLetterSet.DeadLetterServiceName),
+                    ServiceBrokerProvisioning.NoneSet.TargetQueuePathBracketed,
+                    deadLetterServicePath: ServiceBrokerProvisioning.NoneSet.DeadLetterServiceName),
                 globalTransactionMode: TransactionMode.None,
                 typeof(NoneTransactionCommand));
 


### PR DESCRIPTION
## Summary
Adds integration tests so broker-agnostic **core** `Chatter.MessageBrokers` / `Chatter.CQRS` pipeline behaviors are proven **through** the RabbitMQ and SqlServiceBroker adapters — not just through Azure Service Bus. Each test drives a message through the Chatter dispatcher → receiver pump → CQRS handler and asserts at the Chatter handler / `MessageContext` level (never raw SDK). **Test-only — no shipped library code changes, no version bump.**

Motivation: an audit found core behaviors (publish, poison-deadletter, transaction-mode, in-handler forward) were integration-tested only via ASB; the other adapters had only broker-specific + roundtrip/deadletter coverage.

## Added — RabbitMQ (+6 tests)
- **C2** publish(`IEvent`)→handler (`RabbitMqPublishTests`) + harness `PublishToQueueAsync<TEvent>`
- **C8** poison/undeserializable body → immediate deadletter, handler never invoked (`RabbitMqPoisonMessageTests`, quorum+classic)
- **C9** transaction-mode: `ReceiveOnly` redelivers (climbing `ReceiveAttempts`) vs `None` at-most-once drop (`RabbitMqTransactionModeTests`)
- **C10** in-handler `IMessageBrokerContext.Send` forward, observed via a second harness instance (single-RMQ-receiver-per-process guard) (`RabbitMqForwardingTests`)

## Added — SqlServiceBroker (+5 tests)
- Harness/provisioning extended additively (`PublishAsync<TEvent>`, destination override, global-`TransactionMode` Build overload, new object sets incl. a second forward-destination service)
- **C2** publish→handler (`SsbPublishTests`)
- **C8** poison → immediate deadletter (`SsbPoisonMessageTests`)
- **C9** transaction-mode `ReceiveOnly` vs `None` (`SsbTransactionModeTests`)
- **C10** in-handler forward to a second service, second receiver in same host (`SsbForwardingTests`)

All gated `[RequiresDockerFact]` + `[Trait("Category","Integration")]` — skip cleanly without Docker.

## Validation
`dotnet test` green on net8.0 + net10.0 (Docker present): RabbitMQ 300, SqlServiceBroker 218, no regressions across the solution.

## Deferred (not in this PR)
- **C11 MaxConcurrentCalls** integration tests for RMQ/SSB — blocked on a real gap: only ASB exposes a `MaxConcurrentCalls` configuration surface; RMQ/SSB (and core per-receiver `AddReceiver`) have none, so receivers are pinned at 1 and the knob can't be set the real way. Tracked separately.
- **SqlChangeFeed** inherited-pump test — deferred-with-scope (inherited settle path already proven on SSB directly).

## Findings surfaced (candidate follow-ups, not fixed here)
- **`MaxConcurrentCalls` config-surface gap:** only ASB lets you raise it; RMQ/SSB/core lack a setter.
- **SSB transaction-mode is global, not per-receiver:** `SqlServiceBrokerReceiver` captures it from `MessageBrokerOptions.TransactionMode` at construction; the per-receiver `AddQueueReceiver(transactionMode:)` arg never reaches the SSB receive-side SQL transaction (diverges from core/ASB/RMQ).
- **SSB has no per-message content-type converter selection (C4 N/A):** sender selects from the fixed `_options.MessageBodyType`.