### PR TITLE
fix(messagebrokers): preserve handler-supplied MessageId through Send/Publish merge (#245)

### DIFF
--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/CHANGELOG.md
@@ -18,6 +18,7 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+- A handler-supplied outbound `MessageId` set via `SendOptions`/`PublishOptions` now survives the handler-context Send/Publish merge and is no longer replaced by a framework-generated id (#245).
 - Per-send `SendOptions`/`PublishOptions` no longer leak into the inbound handler message context: `SendOptions.Create`/`PublishOptions.Create` now copy the inbound context so a routed/configured send does not persist its options (exchange/routing key, subject, TTL, correlation-id, etc.) into subsequent sends on the same handler context (#201).
 
 ## [0.13.1] - 2026-06-09

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj
@@ -7,7 +7,7 @@
          TryEncodeUnicodeScalar) is char*-pointer based, so the overrides must be unsafe. -->
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageId>Chatter.MessageBrokers</PackageId>
-    <Version>0.14.0</Version>
+    <Version>0.14.1</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>A message broker adapter library built on top of Chatter.CQRS.</Description>

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/PublishOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/PublishOptions.cs
@@ -9,6 +9,14 @@ namespace Chatter.MessageBrokers.Routing.Options
         internal static PublishOptions Create(IDictionary<string, object> messageContext)
             => new PublishOptions(messageContext is null ? null : new Dictionary<string, object>(messageContext));
 
-        public PublishOptions Merge(PublishOptions optionsToMerge) => Merge(optionsToMerge?.MessageContext) as PublishOptions;
+        public PublishOptions Merge(PublishOptions optionsToMerge)
+        {
+            Merge(optionsToMerge?.MessageContext);
+            if (!string.IsNullOrWhiteSpace(optionsToMerge?.MessageId))
+            {
+                this.MessageId = optionsToMerge.MessageId;
+            }
+            return this;
+        }
     }
 }

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/RoutingOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/RoutingOptions.cs
@@ -14,7 +14,8 @@ namespace Chatter.MessageBrokers.Routing.Options
             => MessageContext = context ?? new Dictionary<string, object>();
 
         public RoutingOptions(RoutingOptions optionsToMerge)
-            : this(optionsToMerge?.MessageContext) { }
+            : this(optionsToMerge?.MessageContext)
+            => MessageId = optionsToMerge?.MessageId;
 
         public string MessageId { get; set; }
         public string ContentType

--- a/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/SendOptions.cs
+++ b/src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Routing/Options/SendOptions.cs
@@ -10,7 +10,15 @@ namespace Chatter.MessageBrokers.Routing.Options
         internal static SendOptions Create(IDictionary<string, object> messageContext)
             => new SendOptions(messageContext is null ? null : new Dictionary<string, object>(messageContext));
         
-        public SendOptions Merge(SendOptions optionsToMerge) => Merge(optionsToMerge?.MessageContext) as SendOptions;
+        public SendOptions Merge(SendOptions optionsToMerge)
+        {
+            Merge(optionsToMerge?.MessageContext);
+            if (!string.IsNullOrWhiteSpace(optionsToMerge?.MessageId))
+            {
+                this.MessageId = optionsToMerge.MessageId;
+            }
+            return this;
+        }
 
         public SendOptions WithSubject(string subject)
         {

--- a/src/Chatter.MessageBrokers/tests/Sending/UsingBrokeredMessageDispatcher/WhenDispatching.cs
+++ b/src/Chatter.MessageBrokers/tests/Sending/UsingBrokeredMessageDispatcher/WhenDispatching.cs
@@ -1,4 +1,5 @@
 using Chatter.CQRS.Commands;
+using Chatter.CQRS.Events;
 using Chatter.MessageBrokers.Context;
 using Chatter.MessageBrokers.Receiving;
 using Chatter.MessageBrokers.Routing;
@@ -48,6 +49,8 @@ namespace Chatter.MessageBrokers.Tests.Sending.UsingBrokeredMessageDispatcher
 
         private class FakeCommand : ICommand { }
 
+        private class FakeEvent : IEvent { }
+
         // A real MessageBrokerContext carries an inbound InboundBrokeredMessage whose internal MessageContextImpl
         // is what BrokeredMessageDispatcher merges per-send SendOptions over via SendOptions.Create(...).Merge(...).
         private static MessageBrokerContext HandlerContextWithInbound(Mock<IBrokeredMessageBodyConverter> bodyConverter)
@@ -79,6 +82,53 @@ namespace Chatter.MessageBrokers.Tests.Sending.UsingBrokeredMessageDispatcher
             await _sut.Send(new FakeCommand(), "destination", handlerContext, new SendOptions());
 
             _routedMessages.Single().GetMessageContextByKey<string>(MessageContext.Subject).Should().BeNull();
+        }
+
+        [Fact]
+        public async Task MustCarryHandlerSuppliedMessageIdOntoOutboundWhenSendingThroughHandlerContext()
+        {
+            var handlerContext = HandlerContextWithInbound(_bodyConverter);
+            var options = new SendOptions { MessageId = "explicit-id" };
+
+            await _sut.Send(new FakeCommand(), "destination", handlerContext, options);
+
+            _routedMessages.Single().MessageId.Should().Be("explicit-id");
+        }
+
+        [Fact]
+        public async Task MustCarryHandlerSuppliedMessageIdOntoOutboundWhenPublishingThroughHandlerContext()
+        {
+            var handlerContext = HandlerContextWithInbound(_bodyConverter);
+            var options = new PublishOptions { MessageId = "explicit-id" };
+
+            await _sut.Publish(new FakeEvent(), "destination", handlerContext, options);
+
+            _routedMessages.Single().MessageId.Should().Be("explicit-id");
+        }
+
+        [Fact]
+        public async Task MustFallBackToGeneratedMessageIdWhenNoMessageIdSuppliedThroughHandlerContext()
+        {
+            var generatedId = Guid.NewGuid();
+            _idGenerator.Setup(g => g.GenerateId(It.IsAny<byte[]>())).Returns(generatedId);
+            var handlerContext = HandlerContextWithInbound(_bodyConverter);
+
+            await _sut.Send(new FakeCommand(), "destination", handlerContext, new SendOptions());
+
+            _routedMessages.Single().MessageId.Should().Be(generatedId.ToString());
+            _routedMessages.Single().MessageId.Should().NotBe("explicit-id");
+        }
+
+        [Fact]
+        public async Task MustCarryBothHandlerSuppliedMessageIdAndDictionaryOverrideOntoOutbound()
+        {
+            var handlerContext = HandlerContextWithInbound(_bodyConverter);
+            var options = new SendOptions { MessageId = "explicit-id" }.WithSubject("explicit-subject");
+
+            await _sut.Send(new FakeCommand(), "destination", handlerContext, options);
+
+            _routedMessages.Single().MessageId.Should().Be("explicit-id");
+            _routedMessages.Single().GetMessageContextByKey<string>(MessageContext.Subject).Should().Be("explicit-subject");
         }
     }
 }


### PR DESCRIPTION
## What
Fixes #245. A handler-supplied outbound `MessageId` (set via `SendOptions`/`PublishOptions`) is now preserved through the handler-context Send/Publish merge instead of being silently replaced by a framework-generated id.

## Root cause
The handler-context merge carried the `MessageContext` dictionary but dropped the `MessageId` scalar: the typed `SendOptions.Merge`/`PublishOptions.Merge` overloads forwarded only `optionsToMerge?.MessageContext` to the base `RoutingOptions.Merge(IDictionary)`, which never sees a scalar. So `options.MessageId` was null at the dispatcher's id-selection and the framework id generator always won.

## Fix
- Carry `optionsToMerge.MessageId` in the typed `SendOptions.Merge`/`PublishOptions.Merge` overloads, guarded with `!string.IsNullOrWhiteSpace` so a supplied id wins and a null/whitespace id never clobbers the framework-generated fallback. Existing `MessageContext` dict merge preserved (additive).
- Hardened the unused `RoutingOptions(RoutingOptions)` copy-ctor to also copy `MessageId` (dead-code regression guard; zero live callers).
- No public API shape change; no new overloads.

## Tests
Added 4 facts to `WhenDispatching`: handler-context Send/Publish with an explicit `MessageId` carries it onto the outbound; no-id falls back to the framework-generated id; a `MessageId` + dict override (`.WithSubject(...)`) both survive.

## Versioning
`Chatter.MessageBrokers` patch bump `0.14.0` → `0.14.1` + CHANGELOG `### Fixed` entry. No dependent-adapter ripple.

## Validation
`dotnet test Chatter.sln --filter Category!=Integration` — all projects pass both TFMs (net8.0 / net10.0), 0 failures. Pre-PR Codex adversarial review: approve, zero findings.