### PR TITLE
fix(messagebrokers/sqlservicebroker): honor per-receiver TransactionMode on SSB receive-side

### DIFF
--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/CHANGELOG.md
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/CHANGELOG.md
@@ -12,6 +12,8 @@ This project follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) an
 
 ### Fixed
 
+- Receive-side SQL transaction now honors the per-receiver `ReceiverOptions.TransactionMode` (set via `AddQueueReceiver<T>(transactionMode:)`) instead of always falling back to the global `MessageBrokerOptions.TransactionMode` — two receivers configured with different modes both previously used the global mode. (#235)
+
 ## [0.12.1] - 2026-06-14
 
 ### Fixed

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PackageId>Chatter.MessageBrokers.SqlServiceBroker</PackageId>
-    <Version>0.12.1</Version>
+    <Version>0.12.2</Version>
     <Authors>Brennan Pike</Authors>
     <Owners>Brennan Pike</Owners>
     <Description>An implementation of the Chatter.MessageBrokers adapter library for SQL Service Broker.</Description>

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Receiving/SqlServiceBrokerReceiver.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Receiving/SqlServiceBrokerReceiver.cs
@@ -50,6 +50,11 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Receiving
         public Task InitializeAsync(ReceiverOptions options, CancellationToken cancellationToken)
         {
             _options = options;
+            // options.TransactionMode is already core-normalized: BrokeredMessageReceiver.StartReceiverImpl
+            // does `options.TransactionMode ??= _messageBrokerOptions.TransactionMode` before calling
+            // InitializeAsync, so per-receiver wins; absent per-receiver inherits the ctor-captured global;
+            // absent both, the ctor default (ReceiveOnly) holds.
+            _transactionMode = options.TransactionMode ?? _transactionMode;
             return Task.CompletedTask;
         }
 

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbTransactionModeTests.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Integration/SsbTransactionModeTests.cs
@@ -12,8 +12,8 @@ using Xunit;
 namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
 {
     // Transaction-mode integration proof (C9) for the SQL Service Broker integration harness. The SYSTEM UNDER
-    // TEST is how the GLOBAL MessageBrokerOptions.TransactionMode governs the SSB receive-side RECEIVE
-    // transaction, which is what makes nack→redelivery possible (or not):
+    // TEST is how the PER-RECEIVER transactionMode passed to AddQueueReceiver<T> governs the SSB receive-side
+    // RECEIVE transaction, which is what makes nack→redelivery possible (or not):
     //
     //   * ReceiveOnly — SqlServiceBrokerReceiver BEGINs a transaction around the RECEIVE, so when the handler
     //     throws, NackMessageAsync ROLLS BACK that transaction and the message returns to the queue and is
@@ -24,14 +24,11 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
     //     the handler throws — there is nothing to roll back, so the message is NOT returned to the queue and is
     //     NOT redelivered. The handler is invoked EXACTLY ONCE.
     //
-    // WHY TWO HARNESS INSTANCES: the SSB receive-side transaction mode is GLOBAL-PER-CONTAINER. SqlService
-    // BrokerReceiver captures it ONCE in its ctor from MessageBrokerOptions.TransactionMode
-    // (SqlServiceBrokerReceiver.cs: `_transactionMode = messageBrokerOptions?.TransactionMode ??
-    // TransactionMode.ReceiveOnly`), NOT per-receiver — the AddQueueReceiver(transactionMode:) param does not
-    // reach the SSB receive-side SQL transaction. So the only lever is the GLOBAL MessageBrokerOptions
-    // .TransactionMode set via AddMessageBrokers(opts => opts.WithTransactionMode(...)). Each mode therefore
-    // needs its OWN harness instance (its own DI graph / receiver) built with that global mode, and each runs on
-    // its OWN provisioned object set so their queue state can never bleed into one another.
+    // WHY TWO HARNESS INSTANCES: each mode must run on its OWN provisioned object set (TransactionSet vs
+    // NoneSet) so their queue state can never bleed into one another. The collection fixture provisions once and
+    // never clears queues between test classes, so reusing a shared set would make the exactly-once None
+    // assertion order-dependent on whatever left state in that set. The per-receiver transactionMode param on
+    // AddQueueReceiver<T> is the lever — no global MessageBrokerOptions.TransactionMode override is required.
     //
     // Both facts are gated by [RequiresDockerFact] and SKIPPED (never failed) when Docker is absent so a plain
     // `dotnet test` stays green. Mirrors SsbNackRedeliveryTests for harness setup and collection membership.
@@ -66,43 +63,44 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             public string Marker { get; set; }
         }
 
-        // ReceiveOnly harness: built on the dedicated TransactionSet with the GLOBAL transaction mode set to
-        // ReceiveOnly so the receiver BEGINs a transaction around the RECEIVE and a throwing handler's nack rolls
-        // it back to redeliver.
+        // ReceiveOnly harness: built on the dedicated TransactionSet with the PER-RECEIVER transaction mode set
+        // to ReceiveOnly so the receiver BEGINs a transaction around the RECEIVE and a throwing handler's nack
+        // rolls it back to redeliver.
         private ChatterSsbPipelineHarness BuildReceiveOnlyHarness()
             => ChatterSsbPipelineHarness.Build(
                 _fixture.GetAppConnectionString(),
                 ServiceBrokerProvisioning.TransactionSet,
                 ssb => ssb.AddQueueReceiver<ReceiveOnlyTransactionCommand>(
                     ServiceBrokerProvisioning.TransactionSet.TargetQueuePathBracketed,
+                    transactionMode: TransactionMode.ReceiveOnly,
                     deadLetterServicePath: ServiceBrokerProvisioning.TransactionSet.DeadLetterServiceName),
-                globalTransactionMode: TransactionMode.ReceiveOnly,
                 typeof(ReceiveOnlyTransactionCommand));
 
-        // None harness: built on its OWN dedicated object set (NoneSet) with the GLOBAL transaction mode set to
-        // None so the receiver BEGINs NO transaction around the RECEIVE — a throwing handler cannot redeliver
-        // because there is no receive transaction to roll back. A dedicated set (not the shared DeadLetterSet)
-        // is required: the collection fixture provisions once and never clears queues between test classes, so
-        // reusing DeadLetterSet's target/deadletter queues would let leftover state or class-order interaction
-        // from SsbDeadLetterTests bleed into this receiver and make the exactly-once None assertion
-        // order-dependent. Its own set keeps C9-None isolated, exactly as Publish/Poison/Transaction/Forwarding.
+        // None harness: built on its OWN dedicated object set (NoneSet) with the PER-RECEIVER transaction mode
+        // set to None so the receiver BEGINs NO transaction around the RECEIVE — a throwing handler cannot
+        // redeliver because there is no receive transaction to roll back. A dedicated set (not the shared
+        // DeadLetterSet) is required: the collection fixture provisions once and never clears queues between
+        // test classes, so reusing DeadLetterSet's target/deadletter queues would let leftover state or
+        // class-order interaction from SsbDeadLetterTests bleed into this receiver and make the exactly-once
+        // None assertion order-dependent. Its own set keeps C9-None isolated, exactly as
+        // Publish/Poison/Transaction/Forwarding.
         private ChatterSsbPipelineHarness BuildNoneHarness()
             => ChatterSsbPipelineHarness.Build(
                 _fixture.GetAppConnectionString(),
                 ServiceBrokerProvisioning.NoneSet,
                 ssb => ssb.AddQueueReceiver<NoneTransactionCommand>(
                     ServiceBrokerProvisioning.NoneSet.TargetQueuePathBracketed,
+                    transactionMode: TransactionMode.None,
                     deadLetterServicePath: ServiceBrokerProvisioning.NoneSet.DeadLetterServiceName),
-                globalTransactionMode: TransactionMode.None,
                 typeof(NoneTransactionCommand));
 
-        // Global ReceiveOnly + throwing handler → redelivery. The receiver wraps the RECEIVE in a transaction, so
-        // NackMessageAsync rolls it back and the message returns to the queue. Assert (a) the handler is invoked
-        // at least twice and (b) ReceiveAttempts climbs above 1 across deliveries. ANTI-INFINITE-LOOP: stop
-        // throwing once >= 2 invocations are observed so the message finally acks and the conversation closes
-        // before DisposeAsync drains the pump.
+        // Per-receiver ReceiveOnly + throwing handler → redelivery. The receiver wraps the RECEIVE in a
+        // transaction, so NackMessageAsync rolls it back and the message returns to the queue. Assert (a) the
+        // handler is invoked at least twice and (b) ReceiveAttempts climbs above 1 across deliveries.
+        // ANTI-INFINITE-LOOP: stop throwing once >= 2 invocations are observed so the message finally acks and
+        // the conversation closes before DisposeAsync drains the pump.
         [RequiresDockerFact]
-        public async Task GlobalReceiveOnlyModeRedeliversThrowingHandler()
+        public async Task PerReceiverReceiveOnlyModeRedeliversThrowingHandler()
         {
             var harness = BuildReceiveOnlyHarness();
             try
@@ -125,9 +123,9 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
                 harness.GetSignal<ReceiveOnlyTransactionCommand>().ThrowOnHandle = null;
 
                 observedCount.Should().BeGreaterThanOrEqualTo(2,
-                    "under global ReceiveOnly mode the receiver wraps the RECEIVE in a transaction, so a throwing " +
-                    "handler's nack rolls it back and the message is redelivered — the handler must be invoked at " +
-                    "least twice");
+                    "under per-receiver ReceiveOnly mode the receiver wraps the RECEIVE in a transaction, so a " +
+                    "throwing handler's nack rolls it back and the message is redelivered — the handler must be " +
+                    "invoked at least twice");
 
                 // ReceiveAttempts must climb: the receiver's in-memory attempt counter increments on each
                 // re-receive of the same conversation handle.
@@ -148,13 +146,13 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
             }
         }
 
-        // Global None + throwing handler → exactly one invocation, NO redelivery. The receiver opens NO
+        // Per-receiver None + throwing handler → exactly one invocation, NO redelivery. The receiver opens NO
         // transaction around the RECEIVE, so the RECEIVE is already committed when the handler throws — there is
         // nothing to roll back and the message is not returned to the queue. First CONFIRM the single delivery
         // landed (non-vacuous: the handler really was invoked once), then assert it stays at exactly 1 across a
         // bounded settle so the no-redelivery negative is observed, not merely un-raced.
         [RequiresDockerFact]
-        public async Task GlobalNoneModeDoesNotRedeliverThrowingHandler()
+        public async Task PerReceiverNoneModeDoesNotRedeliverThrowingHandler()
         {
             var harness = BuildNoneHarness();
             try
@@ -183,7 +181,7 @@ namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Integration
 
                 harness.GetSignal<NoneTransactionCommand>().InvocationCount
                     .Should().Be(1,
-                        "under global None mode the receiver opens no transaction around the RECEIVE, so a " +
+                        "under per-receiver None mode the receiver opens no transaction around the RECEIVE, so a " +
                         "throwing handler has nothing to roll back — the message is not redelivered and the " +
                         "handler is invoked exactly once even after a bounded settle window");
             }

--- a/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Receiving/UsingSqlServiceBrokerReceiver/WhenSelectingTransactionMode.cs
+++ b/src/Chatter.MessageBrokers.SqlServiceBroker/tests/Receiving/UsingSqlServiceBrokerReceiver/WhenSelectingTransactionMode.cs
@@ -1,0 +1,110 @@
+using Chatter.MessageBrokers.Configuration;
+using Chatter.MessageBrokers.Receiving;
+using Chatter.MessageBrokers.SqlServiceBroker.Configuration;
+using Chatter.MessageBrokers.SqlServiceBroker.Receiving;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.SqlServiceBroker.Tests.Receiving.UsingSqlServiceBrokerReceiver
+{
+    // Pins the per-receiver TransactionMode selection contract introduced in STEP-001 (#235):
+    // SqlServiceBrokerReceiver.InitializeAsync applies options.TransactionMode when non-null,
+    // falling back to the ctor-captured global otherwise.
+    //
+    // Observation seam: reflection on the private _transactionMode field after InitializeAsync.
+    // Rationale: InitializeAsync only sets the field and returns Task.CompletedTask — no SQL
+    // connection is touched — so the field value is directly observable without driving
+    // ReceiveMessageAsync (which requires a live SqlConnection for BeginTransactionAsync).
+    // No production code changes are required; InternalsVisibleTo already grants the test
+    // assembly access to the internal SqlServiceBrokerReceiver type.
+    public class WhenSelectingTransactionMode : Testing.Core.Context
+    {
+        // INVARIANT: the private field name must match the production source exactly; a rename
+        // breaks this test loudly rather than silently misreporting the selected mode.
+        private const string TransactionModeFieldName = "_transactionMode";
+
+        private static SqlServiceBrokerOptions SsbOptions()
+            => new SqlServiceBrokerOptions(
+                connectionString: "Server=(local);Database=test;Integrated Security=true;",
+                messageBodyType: "application/json; charset=utf-16");
+
+        private static SqlServiceBrokerReceiver CreateReceiver(TransactionMode? globalMode)
+        {
+            MessageBrokerOptions brokerOptions = globalMode.HasValue
+                ? new MessageBrokerOptions { TransactionMode = globalMode.Value }
+                : null;
+
+            return new SqlServiceBrokerReceiver(
+                SsbOptions(),
+                new InMemorySqlConnectionSource(),
+                brokerOptions,
+                Mock.Of<ILogger<SqlServiceBrokerReceiver>>(),
+                Mock.Of<IBodyConverterFactory>(),
+                Mock.Of<Microsoft.Extensions.DependencyInjection.IServiceScopeFactory>());
+        }
+
+        private static TransactionMode ReadTransactionMode(SqlServiceBrokerReceiver receiver)
+        {
+            FieldInfo field = typeof(SqlServiceBrokerReceiver)
+                .GetField(TransactionModeFieldName, BindingFlags.NonPublic | BindingFlags.Instance);
+
+            field.Should().NotBeNull(
+                $"production field '{TransactionModeFieldName}' must exist; a rename breaks this contract test");
+
+            return (TransactionMode)field.GetValue(receiver);
+        }
+
+        private static ReceiverOptions BuildOptions(TransactionMode? perReceiverMode)
+            => new ReceiverOptions
+            {
+                MessageReceiverPath = "test-queue",
+                TransactionMode = perReceiverMode,
+            };
+
+        // INVARIANT: per-receiver None overrides the ctor-captured global of ReceiveOnly so the
+        // receiver commits without starting a SQL transaction.
+        [Fact]
+        public async Task MustApplyNoneWhenPerReceiverModeIsNone()
+        {
+            var receiver = CreateReceiver(globalMode: TransactionMode.ReceiveOnly);
+
+            await receiver.InitializeAsync(BuildOptions(TransactionMode.None), CancellationToken.None);
+
+            ReadTransactionMode(receiver).Should().Be(TransactionMode.None,
+                "per-receiver None must win over the global ReceiveOnly default");
+        }
+
+        // INVARIANT: per-receiver ReceiveOnly is preserved explicitly so callers can override a
+        // global None back to transactional without relying on the ctor default.
+        [Fact]
+        public async Task MustApplyReceiveOnlyWhenPerReceiverModeIsReceiveOnly()
+        {
+            var receiver = CreateReceiver(globalMode: TransactionMode.None);
+
+            await receiver.InitializeAsync(BuildOptions(TransactionMode.ReceiveOnly), CancellationToken.None);
+
+            ReadTransactionMode(receiver).Should().Be(TransactionMode.ReceiveOnly,
+                "per-receiver ReceiveOnly must win over a global None");
+        }
+
+        // INVARIANT: null per-receiver TransactionMode leaves the ctor-captured global intact.
+        // The ctor default when no MessageBrokerOptions is supplied is ReceiveOnly.
+        [Fact]
+        public async Task MustInheritCtorCapturedGlobalWhenPerReceiverModeIsNull()
+        {
+            // Pass null brokerOptions so the ctor default (ReceiveOnly) is the global.
+            var receiver = CreateReceiver(globalMode: null);
+
+            await receiver.InitializeAsync(BuildOptions(perReceiverMode: null), CancellationToken.None);
+
+            ReadTransactionMode(receiver).Should().Be(TransactionMode.ReceiveOnly,
+                "null per-receiver TransactionMode must leave the ctor-captured default (ReceiveOnly) intact");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Fixes #235. The `Chatter.MessageBrokers.SqlServiceBroker` receive-side SQL transaction now honors the **per-receiver** `ReceiverOptions.TransactionMode` instead of only the global `MessageBrokerOptions.TransactionMode` — bringing SSB into line with the core contract and with ASB/RMQ, which already honor per-receiver mode on receive.

### Root cause
`SqlServiceBrokerReceiver` captured `_transactionMode` from the global singleton in its ctor; `InitializeAsync(ReceiverOptions options,…)` stored `_options` but never read `options.TransactionMode`. Two SSB receivers configured with different `transactionMode` both silently used the global mode (default `ReceiveOnly`).

### Fix
`InitializeAsync` now sets `_transactionMode = options.TransactionMode ?? _transactionMode`. The core (`BrokeredMessageReceiver.StartReceiverImpl`) already folds the global default into `options.TransactionMode` via `??=` before `InitializeAsync` runs, so per-receiver wins, absent per-receiver inherits the ctor-captured global, absent both stays `ReceiveOnly`. The ctor global capture is retained as the null-fallback. `CreateTransaction` and the null-transaction-safe settle path are unchanged.

## Changes
- `SqlServiceBrokerReceiver.InitializeAsync` reads per-receiver mode (RMQ idiom).
- New un-gated unit test `WhenSelectingTransactionMode` proving per-receiver None / ReceiveOnly / null-inherits-global.
- Re-pointed docker-gated `SsbTransactionModeTests` from driving the global mode (two-harness workaround) to per-receiver `AddQueueReceiver<T>(transactionMode:)`.
- `Chatter.MessageBrokers.SqlServiceBroker` bumped 0.12.1 → 0.12.2 + CHANGELOG `### Fixed`.

## Validation
`dotnet test Chatter.sln` — all suites green except one pre-existing flaky cross-module ASB integration atomicity test (`PipelineSingleEntityAtomicityTests`), which passes in isolation and is unrelated to this SSB-only change. New SSB unit tests pass on net8.0 and net10.0. SSB integration tests are docker-gated (not run here).

## Versioning
Required — `Chatter.MessageBrokers.SqlServiceBroker` patch 0.12.1 → 0.12.2 (production receive-side behavior fix, no API change).