### PR TITLE
test(reliability-ef): docker-gated SQL Server outbox/inbox integration suite (#177)

### DIFF
--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Chatter.MessageBrokers.Reliability.EntityFramework.Tests.csproj
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Chatter.MessageBrokers.Reliability.EntityFramework.Tests.csproj
@@ -8,6 +8,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net8.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.27" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.27" />
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
   </ItemGroup>
@@ -15,6 +16,7 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net10.0' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.0" />
     <PackageReference Include="FluentAssertions" Version="7.2.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
   </ItemGroup>
@@ -25,6 +27,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.12.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/EfReliabilitySqlServerFixture.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/EfReliabilitySqlServerFixture.cs
@@ -1,0 +1,179 @@
+using System;
+using Microsoft.Data.SqlClient;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Testcontainers.MsSql;
+using Chatter.Testing.Core.Integration;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Integration
+{
+    // Collection fixture that brings up a SQL Server container once per test collection for the EntityFramework
+    // reliability (outbox/inbox) integration suite. It provisions NO schema: each test class repoints to a
+    // uniquely-named database on the shared container and the SqlServerOutboxContextHarness EnsureCreated()s the
+    // OutboxMessage/InboxMessage tables there. Per-class DB isolation prevents cross-test row bleed on the single
+    // OutboxMessage/InboxMessage tables.
+    //
+    // When Docker is unavailable the fixture is a no-op: InitializeAsync starts nothing (the container stays null)
+    // and the connection-string accessors throw. The RequiresDockerFact attribute SKIPS the tests at discovery
+    // time in that case, so a no-Docker `dotnet test` stays green and the fixture's throw is never reached. This
+    // mirrors the SQL Service Broker / SqlChangeFeed integration fixtures.
+    public sealed class EfReliabilitySqlServerFixture : IAsyncLifetime
+    {
+        // The SQL Server image is passed explicitly to MsSqlBuilder (the parameterless ctor is obsolete), mirroring
+        // the SQL Service Broker / SqlChangeFeed integration fixtures.
+        private const string SqlServerImage = "mcr.microsoft.com/mssql/server:2022-CU14-ubuntu-22.04";
+
+        // Bounds container start so a wedged Docker pull/start fails fast instead of hanging the test collection.
+        // Generous because a cold image pull is slow; still finite.
+        private static readonly TimeSpan StartupTimeout = TimeSpan.FromMinutes(5);
+
+        // Bounds the best-effort teardown so a hung database drop cannot block container disposal indefinitely.
+        private static readonly TimeSpan TeardownTimeout = TimeSpan.FromSeconds(30);
+
+        // Bounded readiness retry. A freshly started SQL Server container can refuse connections for a brief window;
+        // these caps keep the connect + database-create retry short and finite.
+        private const int MaxConnectAttempts = 10;
+        private static readonly TimeSpan ConnectRetryDelay = TimeSpan.FromSeconds(2);
+
+        private MsSqlContainer _container;
+
+        // Tracks the per-class databases created on the shared container so teardown can drop each one.
+        private readonly List<string> _createdDatabases = new List<string>();
+
+        // The master connection string for the running container. Throws if the container was not started (Docker
+        // unavailable), mirroring the sibling SQL fixtures' throw.
+        public string GetMasterConnectionString()
+        {
+            if (_container is null)
+            {
+                throw new InvalidOperationException(
+                    "The SQL Server container was not started (Docker unavailable). " +
+                    "Integration tests must be guarded with [RequiresDockerFact].");
+            }
+
+            return _container.GetConnectionString();
+        }
+
+        // Creates a uniquely-named database on the shared container and returns a connection string pointed at it.
+        // Each test class calls this once so it gets an isolated OutboxMessage/InboxMessage table set, preventing
+        // cross-test row bleed. The InitialCatalog is repointed off the master connection string so every other
+        // setting (credentials, encryption, trust flags) the container configured is preserved. Throws if the
+        // container was not started.
+        public async Task<string> CreateDatabaseAsync(string databasePrefix, CancellationToken cancellationToken = default)
+        {
+            var masterConnectionString = GetMasterConnectionString();
+            var databaseName = $"{databasePrefix}_{Guid.NewGuid():N}";
+
+            await CreateDatabaseWithRetryAsync(masterConnectionString, databaseName, cancellationToken).ConfigureAwait(false);
+            _createdDatabases.Add(databaseName);
+
+            return RepointCatalog(masterConnectionString, databaseName);
+        }
+
+        public async Task InitializeAsync()
+        {
+            if (!DockerEnvironment.IsAvailable)
+            {
+                return;
+            }
+
+            using var startupCts = new CancellationTokenSource(StartupTimeout);
+
+            _container = new MsSqlBuilder(SqlServerImage).Build();
+            await _container.StartAsync(startupCts.Token).ConfigureAwait(false);
+        }
+
+        public async Task DisposeAsync()
+        {
+            if (_container is null)
+            {
+                return;
+            }
+
+            try
+            {
+                using var teardownCts = new CancellationTokenSource(TeardownTimeout);
+                var masterConnectionString = _container.GetConnectionString();
+                foreach (var databaseName in _createdDatabases)
+                {
+                    await DropDatabaseAsync(masterConnectionString, databaseName, teardownCts.Token).ConfigureAwait(false);
+                }
+            }
+            catch (Exception)
+            {
+                // Best-effort teardown: the container is disposed below regardless, so a database-drop failure (or a
+                // teardown that exceeded TeardownTimeout) must not mask container disposal.
+            }
+
+            await _container.DisposeAsync().ConfigureAwait(false);
+        }
+
+        // Connects to 'master' and creates the named database. Wrapped in a bounded retry so a not-yet-ready
+        // container surfaces as a retry rather than a hard failure.
+        private static async Task CreateDatabaseWithRetryAsync(string masterConnectionString, string databaseName, CancellationToken cancellationToken)
+        {
+            var attempt = 0;
+            while (true)
+            {
+                attempt++;
+                try
+                {
+                    await using var connection = new SqlConnection(masterConnectionString);
+                    await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+                    await ExecuteNonQueryAsync(connection,
+                        $"IF DB_ID('{databaseName}') IS NULL CREATE DATABASE [{databaseName}];",
+                        cancellationToken).ConfigureAwait(false);
+
+                    return;
+                }
+                catch (SqlException) when (attempt < MaxConnectAttempts)
+                {
+                    await Task.Delay(ConnectRetryDelay, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        // Drops the named database, forcing SINGLE_USER WITH ROLLBACK IMMEDIATE first so lingering context
+        // connections cannot block it. Idempotent: a missing database is a no-op.
+        private static async Task DropDatabaseAsync(string masterConnectionString, string databaseName, CancellationToken cancellationToken)
+        {
+            await using var connection = new SqlConnection(masterConnectionString);
+            await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await ExecuteNonQueryAsync(connection,
+                $"IF DB_ID('{databaseName}') IS NOT NULL " +
+                "BEGIN " +
+                $"ALTER DATABASE [{databaseName}] SET SINGLE_USER WITH ROLLBACK IMMEDIATE; " +
+                $"DROP DATABASE [{databaseName}]; " +
+                "END;",
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        // Returns the supplied connection string repointed at the named database, preserving every other setting
+        // (credentials, encryption, trust flags) the container configured.
+        private static string RepointCatalog(string connectionString, string databaseName)
+        {
+            var builder = new SqlConnectionStringBuilder(connectionString)
+            {
+                InitialCatalog = databaseName,
+            };
+            return builder.ConnectionString;
+        }
+
+        private static async Task ExecuteNonQueryAsync(SqlConnection connection, string commandText, CancellationToken cancellationToken)
+        {
+            await using var command = connection.CreateCommand();
+            command.CommandText = commandText;
+            await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    [CollectionDefinition(Name)]
+    public sealed class EfReliabilitySqlServerCollection : ICollectionFixture<EfReliabilitySqlServerFixture>
+    {
+        public const string Name = "EfReliabilitySqlServer";
+    }
+}

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/WhenClaimingOutboxConcurrentlyOnSqlServer.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/WhenClaimingOutboxConcurrentlyOnSqlServer.cs
@@ -1,0 +1,104 @@
+using Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Support;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using Chatter.Testing.Core.Creators.MessageBrokers;
+using Chatter.Testing.Core.Integration;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Integration
+{
+    // CRITERION 1: exactly-once outbox claim under optimistic concurrency, proven over a real SQL Server database
+    // with the PRODUCTION model (Id PK + ProcessedFromOutboxAtUtc concurrency token). Two stores load the SAME
+    // unprocessed row, both try to claim it (UpdateProcessedDate), and exactly one commits while the loser throws
+    // DbUpdateConcurrencyException (the rethrow at BrokeredMessageOutbox.SaveOutboxAsync).
+    [Trait("Category", "Integration")]
+    [Collection(EfReliabilitySqlServerCollection.Name)]
+    public class WhenClaimingOutboxConcurrentlyOnSqlServer : Testing.Core.Context
+    {
+        private readonly EfReliabilitySqlServerFixture _fixture;
+
+        public WhenClaimingOutboxConcurrentlyOnSqlServer(EfReliabilitySqlServerFixture fixture)
+            => _fixture = fixture;
+
+        [RequiresDockerFact]
+        public async Task MustAllowExactlyOneClaimWhenTwoStoresRaceForTheSameRow()
+        {
+            var (harness, messageId) = await CreateHarnessWithOneUnprocessedMessageAsync();
+
+            // Two separate contexts/stores over the same database.
+            using var firstContext = harness.CreateContext();
+            using var secondContext = harness.CreateContext();
+            var firstStore = new BrokeredMessageOutbox<SqlServerOutboxContext>(firstContext, CreateLoggerFactory());
+            var secondStore = new BrokeredMessageOutbox<SqlServerOutboxContext>(secondContext, CreateLoggerFactory());
+
+            // CRITICAL ORDERING: BOTH contexts must load the row at its original ProcessedFromOutboxAtUtc == null
+            // value BEFORE either saves. Loading after the other has committed would observe the new concurrency
+            // token and there would be no conflict.
+            var firstMessage = await firstContext.Set<OutboxMessage>().SingleAsync(m => m.MessageId == messageId);
+            var secondMessage = await secondContext.Set<OutboxMessage>().SingleAsync(m => m.MessageId == messageId);
+
+            firstMessage.ProcessedFromOutboxAtUtc.Should().BeNull();
+            secondMessage.ProcessedFromOutboxAtUtc.Should().BeNull();
+
+            // First claim commits.
+            await firstStore.UpdateProcessedDate(firstMessage);
+
+            // Second claim races on the same now-stale row and must lose with a concurrency exception.
+            Func<Task> secondClaim = () => secondStore.UpdateProcessedDate(secondMessage);
+            await secondClaim.Should().ThrowAsync<DbUpdateConcurrencyException>();
+        }
+
+        [RequiresDockerFact]
+        public async Task MustClaimRowExactlyOnceWhenTwoStoresRaceForTheSameRow()
+        {
+            var (harness, messageId) = await CreateHarnessWithOneUnprocessedMessageAsync();
+
+            using (var firstContext = harness.CreateContext())
+            using (var secondContext = harness.CreateContext())
+            {
+                var firstStore = new BrokeredMessageOutbox<SqlServerOutboxContext>(firstContext, CreateLoggerFactory());
+                var secondStore = new BrokeredMessageOutbox<SqlServerOutboxContext>(secondContext, CreateLoggerFactory());
+
+                var firstMessage = await firstContext.Set<OutboxMessage>().SingleAsync(m => m.MessageId == messageId);
+                var secondMessage = await secondContext.Set<OutboxMessage>().SingleAsync(m => m.MessageId == messageId);
+
+                await firstStore.UpdateProcessedDate(firstMessage);
+
+                Func<Task> secondClaim = () => secondStore.UpdateProcessedDate(secondMessage);
+                await secondClaim.Should().ThrowAsync<DbUpdateConcurrencyException>();
+            }
+
+            // Reload in a fresh context: the row is processed exactly once (single claim, no silent double-dispatch).
+            using var verifyContext = harness.CreateContext();
+            var reloaded = await verifyContext.Set<OutboxMessage>().SingleAsync(m => m.MessageId == messageId);
+            reloaded.ProcessedFromOutboxAtUtc.Should().NotBeNull();
+        }
+
+        private async Task<(SqlServerOutboxContextHarness Harness, string MessageId)> CreateHarnessWithOneUnprocessedMessageAsync()
+        {
+            var connectionString = await _fixture.CreateDatabaseAsync("ef_outbox_claim");
+            var harness = SqlServerOutboxContextHarness.Create(connectionString);
+
+            OutboxMessage message = New.MessageBrokers().OutboxMessage().ThatIsNotProcessed();
+
+            using var seedContext = harness.CreateContext();
+            await seedContext.Set<OutboxMessage>().AddAsync(message);
+            await seedContext.SaveChangesAsync();
+
+            return (harness, message.MessageId);
+        }
+
+        private static ILoggerFactory CreateLoggerFactory()
+        {
+            var loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+            return loggerFactory.Object;
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/WhenDeduplicatingInboxOnSqlServer.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/WhenDeduplicatingInboxOnSqlServer.cs
@@ -1,0 +1,108 @@
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Reliability.Configuration;
+using Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Support;
+using Chatter.MessageBrokers.Reliability.Inbox;
+using Chatter.Testing.Core.Integration;
+using FluentAssertions;
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Integration
+{
+    // CRITERION 3: DB-enforced inbox idempotency over a real SQL Server database with the PRODUCTION model
+    // (MessageId primary key). The MessageId PK is the backstop behind BrokeredMessageInbox's read-then-add: even
+    // when two receivers both pass the AnyAsync check, the unique constraint admits exactly one row.
+    [Trait("Category", "Integration")]
+    [Collection(EfReliabilitySqlServerCollection.Name)]
+    public class WhenDeduplicatingInboxOnSqlServer
+    {
+        // SQL Server error number for a primary-key / unique-constraint violation.
+        private const int PrimaryKeyViolationNumber = 2627;
+
+        private readonly EfReliabilitySqlServerFixture _fixture;
+
+        public WhenDeduplicatingInboxOnSqlServer(EfReliabilitySqlServerFixture fixture)
+            => _fixture = fixture;
+
+        [RequiresDockerFact]
+        public async Task MustRejectDuplicateInboxMessageIdAtThePrimaryKeyConstraint()
+        {
+            var harness = await CreateHarnessAsync();
+            var messageId = Guid.NewGuid().ToString();
+
+            using (var firstContext = harness.CreateContext())
+            {
+                firstContext.Set<InboxMessage>().Add(new InboxMessage { MessageId = messageId, ReceivedByInboxAtUtc = DateTime.UtcNow });
+                await firstContext.SaveChangesAsync();
+            }
+
+            using var secondContext = harness.CreateContext();
+            secondContext.Set<InboxMessage>().Add(new InboxMessage { MessageId = messageId, ReceivedByInboxAtUtc = DateTime.UtcNow });
+
+            Func<Task> duplicateInsert = () => secondContext.SaveChangesAsync();
+
+            var thrown = await duplicateInsert.Should().ThrowAsync<DbUpdateException>();
+            thrown.WithInnerException<SqlException>()
+                .Which.Number.Should().Be(PrimaryKeyViolationNumber,
+                    "a duplicate inbox MessageId must violate the primary-key constraint (SQL Server error 2627)");
+        }
+
+        [RequiresDockerFact]
+        public async Task MustPersistExactlyOneInboxRowWhenTwoReceiversRaceForTheSameMessageId()
+        {
+            var harness = await CreateHarnessAsync();
+            var messageId = Guid.NewGuid().ToString();
+
+            using var firstContext = harness.CreateContext();
+            using var secondContext = harness.CreateContext();
+            var firstInbox = new BrokeredMessageInbox<SqlServerOutboxContext>(firstContext, CreateLogger(), new ReliabilityOptions());
+            var secondInbox = new BrokeredMessageInbox<SqlServerOutboxContext>(secondContext, CreateLogger(), new ReliabilityOptions());
+
+            // ReceiveViaInbox only AddAsync's to the change tracker; it does NOT SaveChanges. Each receiver must
+            // explicitly save to hit the DB constraint. With both contexts having passed the AnyAsync check before
+            // either saved, exactly one SaveChanges commits and the other violates the MessageId PK.
+            await firstInbox.ReceiveViaInbox("payload", CreateBrokerContext(messageId), () => Task.CompletedTask);
+            await secondInbox.ReceiveViaInbox("payload", CreateBrokerContext(messageId), () => Task.CompletedTask);
+
+            await firstContext.SaveChangesAsync();
+
+            Func<Task> secondSave = () => secondContext.SaveChangesAsync();
+            await secondSave.Should().ThrowAsync<DbUpdateException>();
+
+            using var verifyContext = harness.CreateContext();
+            var rows = await verifyContext.Set<InboxMessage>().Where(m => m.MessageId == messageId).ToListAsync();
+            rows.Should().HaveCount(1, "the MessageId primary key admits exactly one inbox row");
+        }
+
+        private async Task<SqlServerOutboxContextHarness> CreateHarnessAsync()
+        {
+            var connectionString = await _fixture.CreateDatabaseAsync("ef_inbox_dedup");
+            return SqlServerOutboxContextHarness.Create(connectionString);
+        }
+
+        private static IMessageBrokerContext CreateBrokerContext(string messageId)
+        {
+            var converter = new Mock<IBrokeredMessageBodyConverter>();
+            converter.Setup(c => c.ContentType).Returns("application/json");
+
+            return new MessageBrokerContext(
+                messageId,
+                Array.Empty<byte>(),
+                new Dictionary<string, object>(),
+                "test-receiver",
+                CancellationToken.None,
+                converter.Object);
+        }
+
+        private static ILogger<BrokeredMessageInbox<SqlServerOutboxContext>> CreateLogger()
+            => new Mock<ILogger<BrokeredMessageInbox<SqlServerOutboxContext>>>().Object;
+    }
+}

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/WhenDeduplicatingInboxOnSqlServer.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/WhenDeduplicatingInboxOnSqlServer.cs
@@ -75,7 +75,10 @@ namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Integration
             await firstContext.SaveChangesAsync();
 
             Func<Task> secondSave = () => secondContext.SaveChangesAsync();
-            await secondSave.Should().ThrowAsync<DbUpdateException>();
+            var thrown = await secondSave.Should().ThrowAsync<DbUpdateException>();
+            thrown.WithInnerException<SqlException>()
+                .Which.Number.Should().Be(PrimaryKeyViolationNumber,
+                    "the losing receiver must lose specifically at the MessageId primary-key constraint (SQL Server error 2627)");
 
             using var verifyContext = harness.CreateContext();
             var rows = await verifyContext.Set<InboxMessage>().Where(m => m.MessageId == messageId).ToListAsync();

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/WhenExecutingUnitOfWorkOnSqlServer.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Integration/WhenExecutingUnitOfWorkOnSqlServer.cs
@@ -1,0 +1,191 @@
+using Chatter.MessageBrokers.Context;
+using Chatter.MessageBrokers.Reliability;
+using Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Support;
+using Chatter.MessageBrokers.Reliability.Outbox;
+using Chatter.MessageBrokers.Sending;
+using Chatter.Testing.Core.Creators.MessageBrokers;
+using Chatter.Testing.Core.Integration;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Integration
+{
+    // CRITERIA 2 + 4: outbox atomicity and unit-of-work lifecycle, proven over REAL SQL Server transactions via
+    // BrokeredMessageOutbox<SqlServerOutboxContext> acting as IUnitOfWork. Mirrors the assertions in
+    // WhenExecutingUnitOfWorkOverSqlite.cs but against the production model on a real SQL Server database.
+    [Trait("Category", "Integration")]
+    [Collection(EfReliabilitySqlServerCollection.Name)]
+    public class WhenExecutingUnitOfWorkOnSqlServer : Testing.Core.Context
+    {
+        private readonly EfReliabilitySqlServerFixture _fixture;
+
+        public WhenExecutingUnitOfWorkOnSqlServer(EfReliabilitySqlServerFixture fixture)
+            => _fixture = fixture;
+
+        // (a) commit persists the staged domain write together with the UoW; reload in a fresh context sees it.
+        [RequiresDockerFact]
+        public async Task MustPersistOutboxMessageWhenOperationCommits()
+        {
+            var harness = await CreateHarnessAsync();
+            using var context = harness.CreateContext();
+            var sut = CreateUnitOfWork(context);
+
+            OutboxMessage message = New.MessageBrokers().OutboxMessage().ThatIsNotProcessed();
+
+            await sut.ExecuteAsync(async ct =>
+            {
+                await context.Set<OutboxMessage>().AddAsync(message, ct);
+            }, null);
+
+            sut.HasActiveTransaction.Should().BeFalse();
+
+            using var freshContext = harness.CreateContext();
+            var persisted = await freshContext.Set<OutboxMessage>()
+                .SingleOrDefaultAsync(m => m.MessageId == message.MessageId);
+            persisted.Should().NotBeNull();
+        }
+
+        // (b) an operation throw rolls the staged domain write back; reload sees nothing.
+        [RequiresDockerFact]
+        public async Task MustDiscardOutboxMessageWhenOperationThrows()
+        {
+            var harness = await CreateHarnessAsync();
+            using var context = harness.CreateContext();
+            var sut = CreateUnitOfWork(context);
+
+            OutboxMessage message = New.MessageBrokers().OutboxMessage().ThatIsNotProcessed();
+            var operationException = new InvalidOperationException("operation failed");
+
+            Func<Task> act = () => sut.ExecuteAsync(async ct =>
+            {
+                await context.Set<OutboxMessage>().AddAsync(message, ct);
+                throw operationException;
+            }, null);
+
+            await act.Should().ThrowAsync<InvalidOperationException>();
+
+            sut.HasActiveTransaction.Should().BeFalse();
+
+            using var freshContext = harness.CreateContext();
+            var persisted = await freshContext.Set<OutboxMessage>()
+                .SingleOrDefaultAsync(m => m.MessageId == message.MessageId);
+            persisted.Should().BeNull();
+        }
+
+        // (c) a SendToOutbox enqueue inside a UoW commits atomically with a co-staged domain entity. Both the
+        // hand-staged outbox row and the SendToOutbox-enqueued row are present after commit.
+        [RequiresDockerFact]
+        public async Task MustCommitSendToOutboxEnqueueAtomicallyWithCoStagedEntity()
+        {
+            var harness = await CreateHarnessAsync();
+            using var context = harness.CreateContext();
+            var store = new BrokeredMessageOutbox<SqlServerOutboxContext>(context, CreateLoggerFactory());
+            var sut = (IUnitOfWork)store;
+
+            OutboxMessage coStaged = New.MessageBrokers().OutboxMessage().ThatIsNotProcessed();
+            var enqueuedMessageId = Guid.NewGuid().ToString();
+            var transactionContext = new TransactionContext("receiver");
+
+            await sut.ExecuteAsync(async ct =>
+            {
+                await context.Set<OutboxMessage>().AddAsync(coStaged, ct);
+                await store.SendToOutbox(
+                    new[] { CreateOutboundMessage(enqueuedMessageId) },
+                    transactionContext,
+                    ct);
+            }, transactionContext);
+
+            sut.HasActiveTransaction.Should().BeFalse();
+
+            using var freshContext = harness.CreateContext();
+            var coStagedPersisted = await freshContext.Set<OutboxMessage>()
+                .SingleOrDefaultAsync(m => m.MessageId == coStaged.MessageId);
+            var enqueuedPersisted = await freshContext.Set<OutboxMessage>()
+                .SingleOrDefaultAsync(m => m.MessageId == enqueuedMessageId);
+
+            coStagedPersisted.Should().NotBeNull("the co-staged domain write commits atomically with the enqueue");
+            enqueuedPersisted.Should().NotBeNull("the SendToOutbox enqueue commits atomically with the co-staged write");
+        }
+
+        // (d) when a transaction is already open on the context, BeginAsync returns the existing CurrentTransaction
+        // rather than starting a second one. The operation observes the pre-existing TransactionId.
+        [RequiresDockerFact]
+        public async Task MustReuseExistingTransactionWhenOneIsAlreadyOpen()
+        {
+            var harness = await CreateHarnessAsync();
+            using var context = harness.CreateContext();
+            var sut = CreateUnitOfWork(context);
+
+            await using var existingTransaction = await context.Database.BeginTransactionAsync();
+            var existingTransactionId = existingTransaction.TransactionId;
+
+            Guid observedTransactionId = Guid.Empty;
+
+            await sut.ExecuteAsync(_ =>
+            {
+                observedTransactionId = sut.CurrentTransaction.TransactionId;
+                return Task.CompletedTask;
+            }, null);
+
+            observedTransactionId.Should().Be(existingTransactionId);
+            observedTransactionId.Should().NotBe(Guid.Empty);
+        }
+
+        // (e) the TransactionContext.Container is populated with the IPersistanceTransaction and CurrentTransactionId.
+        [RequiresDockerFact]
+        public async Task MustPopulateTransactionContextContainerWhenContextProvided()
+        {
+            var harness = await CreateHarnessAsync();
+            using var context = harness.CreateContext();
+            var sut = CreateUnitOfWork(context);
+
+            var transactionContext = new TransactionContext("receiver");
+
+            Guid transactionIdInsideOperation = Guid.Empty;
+
+            await sut.ExecuteAsync(_ =>
+            {
+                transactionIdInsideOperation = sut.CurrentTransaction.TransactionId;
+                return Task.CompletedTask;
+            }, transactionContext);
+
+            var containedTransaction = transactionContext.Container.GetOrDefault<IPersistanceTransaction>();
+            containedTransaction.Should().NotBeNull();
+
+            var containedTransactionId = transactionContext.Container.Get<Guid>("CurrentTransactionId");
+            containedTransactionId.Should().Be(transactionIdInsideOperation);
+            containedTransactionId.Should().NotBe(Guid.Empty);
+        }
+
+        private async Task<SqlServerOutboxContextHarness> CreateHarnessAsync()
+        {
+            var connectionString = await _fixture.CreateDatabaseAsync("ef_outbox_uow");
+            return SqlServerOutboxContextHarness.Create(connectionString);
+        }
+
+        private static IUnitOfWork CreateUnitOfWork(SqlServerOutboxContext context)
+            => new BrokeredMessageOutbox<SqlServerOutboxContext>(context, CreateLoggerFactory());
+
+        private static OutboundBrokeredMessage CreateOutboundMessage(string messageId)
+            => new OutboundBrokeredMessage(
+                messageId,
+                Array.Empty<byte>(),
+                new Dictionary<string, object>(),
+                "destination",
+                new TextPlainBodyConverter());
+
+        private static ILoggerFactory CreateLoggerFactory()
+        {
+            var loggerFactory = new Mock<ILoggerFactory>();
+            loggerFactory.Setup(f => f.CreateLogger(It.IsAny<string>())).Returns(new Mock<ILogger>().Object);
+            return loggerFactory.Object;
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Support/SqlServerOutboxContext.cs
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/Support/SqlServerOutboxContext.cs
@@ -1,0 +1,63 @@
+using Chatter.MessageBrokers.Reliability.EntityFramework;
+using Microsoft.EntityFrameworkCore;
+
+namespace Chatter.MessageBrokers.Reliability.EntityFramework.Tests.Support
+{
+    /// <summary>
+    /// A relational DbContext backed by a real SQL Server database. Unlike <c>SqliteOutboxContext</c>,
+    /// it applies the PRODUCTION <see cref="OutboxMessageConfiguration"/> and <see cref="InboxMessageConfiguration"/>
+    /// rather than a hand-rolled model.
+    ///
+    /// INVARIANT: applying the production configurations is LOAD-BEARING. They give the outbox table the Id
+    /// primary key plus the <c>ProcessedFromOutboxAtUtc</c> concurrency token, and key the inbox on MessageId.
+    /// SqliteOutboxContext deliberately drops the concurrency token and keys the outbox on MessageId, which would
+    /// make the optimistic-concurrency claim test prove nothing — so it must NOT be reused for the SQL Server suite.
+    /// </summary>
+    public sealed class SqlServerOutboxContext : DbContext
+    {
+        public SqlServerOutboxContext(DbContextOptions<SqlServerOutboxContext> options)
+            : base(options)
+        { }
+
+        protected override void OnModelCreating(ModelBuilder modelBuilder)
+        {
+            modelBuilder.ApplyConfiguration(new OutboxMessageConfiguration());
+            modelBuilder.ApplyConfiguration(new InboxMessageConfiguration());
+        }
+    }
+
+    /// <summary>
+    /// Wraps a SQL Server connection string and hands out fresh <see cref="SqlServerOutboxContext"/> instances over
+    /// it. A one-time <see cref="DatabaseFacade.EnsureCreated"/> initialises the schema. Two <see cref="CreateContext"/>
+    /// calls over the same connection string give the "two contexts, same DB/row" setup the optimistic-concurrency
+    /// claim test needs.
+    /// </summary>
+    public sealed class SqlServerOutboxContextHarness
+    {
+        private readonly string _connectionString;
+
+        private SqlServerOutboxContextHarness(string connectionString)
+            => _connectionString = connectionString;
+
+        public static SqlServerOutboxContextHarness Create(string connectionString)
+        {
+            var harness = new SqlServerOutboxContextHarness(connectionString);
+            using (var context = harness.CreateContext())
+            {
+                // INVARIANT: EnsureCreated (NOT Migrate) — the module ships no migrations.
+                context.Database.EnsureCreated();
+            }
+
+            return harness;
+        }
+
+        public SqlServerOutboxContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder<SqlServerOutboxContext>()
+                .UseSqlServer(_connectionString)
+                .Options;
+
+            return new SqlServerOutboxContext(options);
+        }
+    }
+}

--- a/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/packages.lock.json
+++ b/src/Chatter.MessageBrokers.Reliability.EntityFramework/tests/packages.lock.json
@@ -17,6 +17,24 @@
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
+      "Microsoft.Data.SqlClient": {
+        "type": "Direct",
+        "requested": "[7.0.1, )",
+        "resolved": "7.0.1",
+        "contentHash": "9jZFXAJ2ThNYK7lhj2RhH7klXVNaWSvZpQncq3bPIOjmHBrdjwgeO4c8wucUVxQwFT8rAA13Z2F2jzoYR7ICDw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "9.0.13",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "1.0.0",
+          "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.Extensions.Caching.Memory": "9.0.13",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "9.0.13",
+          "System.Security.Cryptography.Pkcs": "9.0.13"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Direct",
         "requested": "[10.0.0, )",
@@ -30,6 +48,19 @@
           "Microsoft.Extensions.Logging": "10.0.0",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.11",
           "SQLitePCLRaw.core": "2.1.11"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "9ip+r8Wtu0qNtFLYnQC3bkhQAsINIyo8XWYJHCVY22BFLxIT4rPxZPkbto56SjCnkwxS6nnbFZTU6KuAO2Nu1g==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "6.1.1",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging": "10.0.0"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -60,6 +91,15 @@
           "Castle.Core": "5.1.1"
         }
       },
+      "Testcontainers.MsSql": {
+        "type": "Direct",
+        "requested": "[4.12.0, )",
+        "resolved": "4.12.0",
+        "contentHash": "CvgBpBfCm9D0tA3n1rgWLrvx4iL8zae6cKq3bYzDQIWv8SoIkMHTL8mD/hyOjDeN1O/0iMi2Krh1f/XcwWb5gw==",
+        "dependencies": {
+          "Testcontainers": "4.12.0"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -77,6 +117,11 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
@@ -85,10 +130,94 @@
           "System.Diagnostics.EventLog": "6.0.0"
         }
       },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "tm2V/DpnaURbBhMQ7Z3orNR3u+H863KQuYfA/sgGjI5py07dEeV0I02f6pGrx2869KG9uNM/E96puf9i0gId2w==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0",
+          "Docker.DotNet.Enhanced.LegacyHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.NPipe": "4.2.0",
+          "Docker.DotNet.Enhanced.NativeHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.Unix": "4.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.Handler.Abstractions": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "cQNxpdadEPdNdfjFCl9vgoCQIK3aVHRn1Qlu36aZUFpp4xHfPrk4hRPNVLR/CpobIFJ+dAt8AceTKMlCfPSccw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.LegacyHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "sfbMX1HBPUec3PEMoqlP5ak6skXclcTBmu4gG3aUJatP34J2DgvYMP13bvz/rfrjVkAhPqnIiDKiHAkBCokajg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NativeHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "/ll+2ePYm1qrsMdgMO5BzCQnbfTGmPJAc9SqXEManbliVBZvEpBKHXLugx/OeEca2oC/b4RV+UNPtue5u4jAuA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NPipe": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "8wyYOD6VkvqRkITwsvkt3UbW/1WDl6NFypNAsIIDaMiglNRzFrQcK0nK9VUEZa6Oja8Bso3UYySDoL8qatatAA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Unix": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "x0wNcbww1+p9nUfw8i+JvsSArBDGkoZ9GI2PZ1wPo85B2OiFrdzp89omounNhO2GKyaIRWAqAm5jYZyNg9EnxA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "nMw+FHGwGZieDi7kBgpIVl+E8MzjzXeXHvMQpidLADT06fts2Gw6G+K+p0hMGv7liZULxyYiZnQ1UbE2B9NNQg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "5T+bH3Lb1nEe8Hf/ixMxLmhlrx5wRi53wv7OhVwG2F1ZviW1ejFRS1NHur3uqPpJRGtkQwUchtY6zhVK2R+v+w=="
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+      },
+      "Microsoft.Data.SqlClient.Extensions.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "rlnxc0KfwDSbE8ZHntFnl8SCgOa9QtJZblMv2zXLhRwl1Je7fsdsVzxSjzzC4JMsfAK+jXJWyezRB8SxUY4BdA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0"
+        }
+      },
+      "Microsoft.Data.SqlClient.Internal.Logging": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "Kue/7CF8KNT9zozfr30C94dMZVZml3atqWZvQemSXvTau76tRdypzeKiBKXadqgbOME0UiQIyVTNo5WxCRNVNg=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
@@ -450,6 +579,58 @@
         "resolved": "10.0.8",
         "contentHash": "OBPo4nYhMyIbtueoC10CBm6AGAbo/A9IV8QQ/6ryZS7VvmqpGT7hunazeHLxFawRzn3oLOq4jhqhpBX4tfswWQ=="
       },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "h4yVXyJsEBBX5lg2G5ftMsi5JzcNEGAzrNphA6DQ6eOd8P0s+cDCOyPwVTYLePZvJL5unbPvYIvzrbTXzFjXnQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "System.IdentityModel.Tokens.Jwt": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Microsoft.IdentityModel.Logging": "8.16.0"
+        }
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.6.0",
@@ -464,11 +645,6 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
-      },
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "13.0.3",
@@ -482,6 +658,11 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.9",
           "Microsoft.Extensions.DependencyModel": "3.1.6"
         }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -510,13 +691,22 @@
           "SQLitePCLRaw.core": "2.1.11"
         }
       },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "7T+m0kDSlIPTHIkPMIu6m6tV6qsMqJpvQWW2jIc2qi7sn40qxFo0q+7mEQAhMPXZHMKnWrnv47ntGlM/ejvw3g==",
+        "resolved": "9.0.13",
+        "contentHash": "GbBrJq9S/gYpHzm7Pxx6Y5tDyfSfyxW6tlP5oiKJV38uf19Wp+GIIAnWfyL1zmNiz1+EjwVapw2WkBFvvqKQzg==",
         "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Security.Permissions": "6.0.0"
+          "System.Diagnostics.EventLog": "9.0.13",
+          "System.Security.Cryptography.ProtectedData": "9.0.13"
         }
       },
       "System.Diagnostics.EventLog": {
@@ -524,33 +714,35 @@
         "resolved": "10.0.0",
         "contentHash": "uaFRda9NjtbJRkdx311eXlAA3n2em7223c1A8d1VWyl+4FL9vkG7y2lpPfBU9HYdj/9KgdRNdn1vFK8ZYCYT/A=="
       },
-      "System.Drawing.Common": {
+      "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "resolved": "8.16.0",
+        "contentHash": "rrs2u7DRMXQG2yh0oVyF/vLwosfRv20Ld2iEpYcKwQWXHjfV+gFXNQsQ9p008kR9Ou4pxBs68Q6/9zC8Gi1wjg==",
         "dependencies": {
-          "Microsoft.Win32.SystemEvents": "6.0.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "9.0.13",
+        "contentHash": "dxJhkuoaelvWy588wPXjShNks+ZMiSgXnN75/u+DPbER5PqKrLPDftE0BvGM7nDK/scQAVlD+gRXlCAAjWi58Q=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+        "resolved": "9.0.13",
+        "contentHash": "t8S9IDpjJKsLpLkeBdW8cWtcPyYqrGu93Dej1RO6WwuL/lkFSqWlan3rMJfortqz1mRIh+sys2AFsSA6jWJ3Jg=="
       },
-      "System.Security.Permissions": {
+      "Testcontainers": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
+        "resolved": "4.12.0",
+        "contentHash": "PTZRdG1ZVkFMsFbc3cK/VUaOB5L3l4wYL+OkWAK33/cvgd/5FcmZlQ6NhMAl3PWBqYkpdWmeYmQW9U2OIXqtFA==",
         "dependencies": {
-          "System.Windows.Extensions": "6.0.0"
-        }
-      },
-      "System.Windows.Extensions": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
-        "dependencies": {
-          "System.Drawing.Common": "6.0.0"
+          "Docker.DotNet.Enhanced": "4.2.0",
+          "Docker.DotNet.Enhanced.X509": "4.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
         }
       },
       "xunit.abstractions": {
@@ -614,7 +806,7 @@
       "chatter.messagebrokers.reliability.entityframework": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers": "[0.13.2, )",
+          "Chatter.MessageBrokers": "[0.14.1, )",
           "Microsoft.EntityFrameworkCore": "[10.0.0, )",
           "Microsoft.EntityFrameworkCore.Relational": "[10.0.0, )"
         }
@@ -622,7 +814,7 @@
       "chatter.testing.core": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.1, )",
+          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.2, )",
           "Microsoft.EntityFrameworkCore": "[10.0.8, )",
           "Microsoft.EntityFrameworkCore.InMemory": "[10.0.8, )",
           "Moq": "[4.20.72, )",
@@ -646,6 +838,24 @@
           "System.Configuration.ConfigurationManager": "6.0.0"
         }
       },
+      "Microsoft.Data.SqlClient": {
+        "type": "Direct",
+        "requested": "[7.0.1, )",
+        "resolved": "7.0.1",
+        "contentHash": "9jZFXAJ2ThNYK7lhj2RhH7klXVNaWSvZpQncq3bPIOjmHBrdjwgeO4c8wucUVxQwFT8rAA13Z2F2jzoYR7ICDw==",
+        "dependencies": {
+          "Microsoft.Bcl.Cryptography": "8.0.0",
+          "Microsoft.Data.SqlClient.Extensions.Abstractions": "1.0.0",
+          "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0",
+          "Microsoft.Data.SqlClient.SNI.runtime": "6.0.2",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.16.0",
+          "Microsoft.SqlServer.Server": "1.0.0",
+          "System.Configuration.ConfigurationManager": "8.0.1",
+          "System.Security.Cryptography.Pkcs": "8.0.1"
+        }
+      },
       "Microsoft.EntityFrameworkCore.Sqlite": {
         "type": "Direct",
         "requested": "[8.0.27, )",
@@ -654,6 +864,16 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Sqlite.Core": "8.0.27",
           "SQLitePCLRaw.bundle_e_sqlite3": "2.1.6"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.SqlServer": {
+        "type": "Direct",
+        "requested": "[8.0.27, )",
+        "resolved": "8.0.27",
+        "contentHash": "zOjIHog/Irl4rhNfJ8oH9javl/P5WH8xp152ETEQ3CW+8i7btG4+kGk0pasVGlArAuiGUtXDmRmj4k+NTGzRcA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient": "5.1.7",
+          "Microsoft.EntityFrameworkCore.Relational": "8.0.27"
         }
       },
       "Microsoft.Extensions.Configuration.Abstractions": {
@@ -684,6 +904,15 @@
           "Castle.Core": "5.1.1"
         }
       },
+      "Testcontainers.MsSql": {
+        "type": "Direct",
+        "requested": "[4.12.0, )",
+        "resolved": "4.12.0",
+        "contentHash": "CvgBpBfCm9D0tA3n1rgWLrvx4iL8zae6cKq3bYzDQIWv8SoIkMHTL8mD/hyOjDeN1O/0iMi2Krh1f/XcwWb5gw==",
+        "dependencies": {
+          "Testcontainers": "4.12.0"
+        }
+      },
       "xunit": {
         "type": "Direct",
         "requested": "[2.9.3, )",
@@ -701,6 +930,11 @@
         "resolved": "3.1.5",
         "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
       },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
       "Castle.Core": {
         "type": "Transitive",
         "resolved": "5.1.1",
@@ -709,10 +943,95 @@
           "System.Diagnostics.EventLog": "6.0.0"
         }
       },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "tm2V/DpnaURbBhMQ7Z3orNR3u+H863KQuYfA/sgGjI5py07dEeV0I02f6pGrx2869KG9uNM/E96puf9i0gId2w==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0",
+          "Docker.DotNet.Enhanced.LegacyHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.NPipe": "4.2.0",
+          "Docker.DotNet.Enhanced.NativeHttp": "4.2.0",
+          "Docker.DotNet.Enhanced.Unix": "4.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "System.IO.Pipelines": "8.0.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Handler.Abstractions": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "cQNxpdadEPdNdfjFCl9vgoCQIK3aVHRn1Qlu36aZUFpp4xHfPrk4hRPNVLR/CpobIFJ+dAt8AceTKMlCfPSccw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.LegacyHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "sfbMX1HBPUec3PEMoqlP5ak6skXclcTBmu4gG3aUJatP34J2DgvYMP13bvz/rfrjVkAhPqnIiDKiHAkBCokajg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NativeHttp": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "/ll+2ePYm1qrsMdgMO5BzCQnbfTGmPJAc9SqXEManbliVBZvEpBKHXLugx/OeEca2oC/b4RV+UNPtue5u4jAuA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.NPipe": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "8wyYOD6VkvqRkITwsvkt3UbW/1WDl6NFypNAsIIDaMiglNRzFrQcK0nK9VUEZa6Oja8Bso3UYySDoL8qatatAA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.Unix": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "x0wNcbww1+p9nUfw8i+JvsSArBDGkoZ9GI2PZ1wPo85B2OiFrdzp89omounNhO2GKyaIRWAqAm5jYZyNg9EnxA==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "4.2.0",
+        "contentHash": "nMw+FHGwGZieDi7kBgpIVl+E8MzjzXeXHvMQpidLADT06fts2Gw6G+K+p0hMGv7liZULxyYiZnQ1UbE2B9NNQg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.2.0"
+        }
+      },
+      "Microsoft.Bcl.Cryptography": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "Y3t/c7C5XHJGFDnohjf1/9SYF3ZOfEU1fkNQuKg/dGf9hN18yrQj2owHITGfNS3+lKJdW6J4vY98jYu57jCO8A=="
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "18.6.0",
         "contentHash": "bkmCXn/65Cd0LdO2zTb/ValGAJ1H8y/CgYOiBb3jsDyHI3Y1ljKx6RBvhvn3e5D/4R4I00RRwLf+Bd2Sn6bJjA=="
+      },
+      "Microsoft.Data.SqlClient.Extensions.Abstractions": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "rlnxc0KfwDSbE8ZHntFnl8SCgOa9QtJZblMv2zXLhRwl1Je7fsdsVzxSjzzC4JMsfAK+jXJWyezRB8SxUY4BdA==",
+        "dependencies": {
+          "Microsoft.Data.SqlClient.Internal.Logging": "1.0.0"
+        }
+      },
+      "Microsoft.Data.SqlClient.Internal.Logging": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "Kue/7CF8KNT9zozfr30C94dMZVZml3atqWZvQemSXvTau76tRdypzeKiBKXadqgbOME0UiQIyVTNo5WxCRNVNg=="
+      },
+      "Microsoft.Data.SqlClient.SNI.runtime": {
+        "type": "Transitive",
+        "resolved": "6.0.2",
+        "contentHash": "f+pRODTWX7Y67jXO3T5S2dIPZ9qMJNySjlZT/TKmWVNWe19N8jcWmHaqHnnchaq3gxEKv1SWVY5EFzOD06l41w=="
       },
       "Microsoft.Data.Sqlite.Core": {
         "type": "Transitive",
@@ -972,8 +1291,8 @@
       },
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "Transitive",
-        "resolved": "8.0.2",
-        "contentHash": "nroMDjS7hNBPtkZqVBbSiQaQjWRDxITI8Y7XnDs97rqG3EbzVTNLZQf7bIeUJcaHOV8bca47s1Uxq94+2oGdxA==",
+        "resolved": "8.0.3",
+        "contentHash": "dL0QGToTxggRLMYY4ZYX5AMwBb+byQBd/5dMiZE07Nv73o6I5Are3C7eQTh7K2+A4ct0PVISSr7TZANbiNb2yQ==",
         "dependencies": {
           "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.2"
         }
@@ -1065,6 +1384,58 @@
         "resolved": "8.0.0",
         "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
       },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "gSxKLWRZzBpIsEoeUPkxfywNCCvRvl7hkq146XHPk5vOQc9izSf1I+uL1vh4y2U19QPxd9Z8K/8AdWyxYz2lSg=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "prBU72cIP4V8E9fhN+o/YdskTsLeIcnKPbhZf0X6mD7fdxoZqnS/NdEkSr+9Zp+2q7OZBOMfNBKGbTbhXODO4w==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "MTzXmETkNQPACR7/XCXM1OGM6oU9RkyibqeJRtO9Ndew2LnGjMf9Atqj2VSf4XC27X0FQycUAlzxxEgQMWn2xQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "UFrU7d46UTsPQTa2HIEIpB9H1uJe1BW9FLw5uhEJ2ZuKdur8bcUA/bO5caq5dlBt5gNJeRIB3QQXYNs5fCQCZA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "h4yVXyJsEBBX5lg2G5ftMsi5JzcNEGAzrNphA6DQ6eOd8P0s+cDCOyPwVTYLePZvJL5unbPvYIvzrbTXzFjXnQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.16.0",
+          "System.IdentityModel.Tokens.Jwt": "8.16.0"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.16.0",
+        "contentHash": "rtViGJcGsN7WcfUNErwNeQgjuU5cJNl6FDQsfi9TncwO+Epzn0FTfBsg3YuFW1Q0Ch/KPxaVdjLw3/+5Z5ceFQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Microsoft.IdentityModel.Logging": "8.16.0"
+        }
+      },
+      "Microsoft.SqlServer.Server": {
+        "type": "Transitive",
+        "resolved": "1.0.0",
+        "contentHash": "N4KeF3cpcm1PUHym1RmakkzfkEv3GRMyofVv40uXsQhCQeglr2OHNcUk2WOG51AKpGO8ynGpo9M/kFXSzghwug=="
+      },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
         "resolved": "18.6.0",
@@ -1079,11 +1450,6 @@
           "Newtonsoft.Json": "13.0.3"
         }
       },
-      "Microsoft.Win32.SystemEvents": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "hqTM5628jSsQiv+HGpiq3WKBl2c8v1KZfby2J6Pr7pEPlK9waPdgEO6b8A/+/xn/yZ9ulv8HuqK71ONy2tg67A=="
-      },
       "Newtonsoft.Json": {
         "type": "Transitive",
         "resolved": "13.0.3",
@@ -1097,6 +1463,11 @@
           "Microsoft.Extensions.DependencyInjection.Abstractions": "3.1.9",
           "Microsoft.Extensions.DependencyModel": "3.1.6"
         }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
       },
       "SQLitePCLRaw.bundle_e_sqlite3": {
         "type": "Transitive",
@@ -1125,47 +1496,63 @@
           "SQLitePCLRaw.core": "2.1.6"
         }
       },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
       "System.Configuration.ConfigurationManager": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "7T+m0kDSlIPTHIkPMIu6m6tV6qsMqJpvQWW2jIc2qi7sn40qxFo0q+7mEQAhMPXZHMKnWrnv47ntGlM/ejvw3g==",
+        "resolved": "8.0.1",
+        "contentHash": "gPYFPDyohW2gXNhdQRSjtmeS6FymL2crg4Sral1wtvEJ7DUqFCDWDVbbLobASbzxfic8U1hQEdC7hmg9LHncMw==",
         "dependencies": {
-          "System.Security.Cryptography.ProtectedData": "6.0.0",
-          "System.Security.Permissions": "6.0.0"
+          "System.Diagnostics.EventLog": "8.0.1",
+          "System.Security.Cryptography.ProtectedData": "8.0.0"
         }
       },
       "System.Diagnostics.EventLog": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "fdYxcRjQqTTacKId/2IECojlDSFvp7LP5N78+0z/xH7v/Tuw5ZAxu23Y6PTCRinqyu2ePx+Gn1098NC6jM6d+A=="
+        "resolved": "8.0.1",
+        "contentHash": "n1ZP7NM2Gkn/MgD8+eOT5MulMj6wfeQMNS2Pizvq5GHCZfjlFMXV2irQlQmJhwA2VABC57M0auudO89Iu2uRLg=="
       },
-      "System.Drawing.Common": {
+      "System.IdentityModel.Tokens.Jwt": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "NfuoKUiP2nUWwKZN6twGqXioIe1zVD0RIj2t976A+czLHr2nY454RwwXs6JU9Htc6mwqL6Dn/nEL3dpVf2jOhg==",
+        "resolved": "8.16.0",
+        "contentHash": "rrs2u7DRMXQG2yh0oVyF/vLwosfRv20Ld2iEpYcKwQWXHjfV+gFXNQsQ9p008kR9Ou4pxBs68Q6/9zC8Gi1wjg==",
         "dependencies": {
-          "Microsoft.Win32.SystemEvents": "6.0.0"
+          "Microsoft.IdentityModel.JsonWebTokens": "8.16.0",
+          "Microsoft.IdentityModel.Tokens": "8.16.0"
         }
+      },
+      "System.IO.Pipelines": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "FHNOatmUq0sqJOkTx+UF/9YK1f180cnW5FVqnQMvYUN0elp6wFzbtPSiqbo1/ru8ICp43JM1i7kKkk6GsNGHlA=="
+      },
+      "System.Security.Cryptography.Pkcs": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "CoCRHFym33aUSf/NtWSVSZa99dkd0Hm7OCZUxORBjRB16LNhIEOf8THPqzIYlvKM0nNDAPTRBa1FxEECrgaxxA=="
       },
       "System.Security.Cryptography.ProtectedData": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "rp1gMNEZpvx9vP0JW0oHLxlf8oSiQgtno77Y4PLUBjSiDYoD77Y8uXHr1Ea5XG4/pIKhqAdxZ8v8OTUtqo9PeQ=="
+        "resolved": "8.0.0",
+        "contentHash": "+TUFINV2q2ifyXauQXRwy4CiBhqvDEDZeVJU7qfxya4aRYOKzVBpN+4acx25VcPB9ywUN6C0n8drWl110PhZEg=="
       },
-      "System.Security.Permissions": {
+      "Testcontainers": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "T/uuc7AklkDoxmcJ7LGkyX1CcSviZuLCa4jg3PekfJ7SU0niF0IVTXwUiNVP9DSpzou2PpxJ+eNY2IfDM90ZCg==",
+        "resolved": "4.12.0",
+        "contentHash": "PTZRdG1ZVkFMsFbc3cK/VUaOB5L3l4wYL+OkWAK33/cvgd/5FcmZlQ6NhMAl3PWBqYkpdWmeYmQW9U2OIXqtFA==",
         "dependencies": {
-          "System.Windows.Extensions": "6.0.0"
-        }
-      },
-      "System.Windows.Extensions": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "IXoJOXIqc39AIe+CIR7koBtRGMiCt/LPM3lI+PELtDIy9XdyeSrwXFdWV9dzJ2Awl0paLWUaknLxFQ5HpHZUog==",
-        "dependencies": {
-          "System.Drawing.Common": "6.0.0"
+          "Docker.DotNet.Enhanced": "4.2.0",
+          "Docker.DotNet.Enhanced.X509": "4.2.0",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
         }
       },
       "xunit.abstractions": {
@@ -1229,7 +1616,7 @@
       "chatter.messagebrokers.reliability.entityframework": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers": "[0.13.2, )",
+          "Chatter.MessageBrokers": "[0.14.1, )",
           "Microsoft.EntityFrameworkCore": "[8.0.27, )",
           "Microsoft.EntityFrameworkCore.Relational": "[8.0.27, )"
         }
@@ -1237,7 +1624,7 @@
       "chatter.testing.core": {
         "type": "Project",
         "dependencies": {
-          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.1, )",
+          "Chatter.MessageBrokers.Reliability.EntityFramework": "[0.4.2, )",
           "Microsoft.EntityFrameworkCore": "[8.0.27, )",
           "Microsoft.EntityFrameworkCore.InMemory": "[8.0.27, )",
           "Moq": "[4.20.72, )",


### PR DESCRIPTION
## What

Adds a docker-gated integration test suite for `Chatter.MessageBrokers.Reliability.EntityFramework` that exercises outbox/inbox/UnitOfWork against a **containerized real SQL Server** (Testcontainers.MsSql), closing the provider-behavior gap left by the existing EF-InMemory + SQLite tests. SQLite gives real transactions but NOT SqlServer provider semantics (concurrency-token conflict resolution under contention, provider-specific PK violations) — exactly where exactly-once / at-least-once correctness can break and was previously unverified.

Proves, against real SQL Server:
1. **Exactly-once outbox claim** — two contexts loading the same unprocessed row drive `UpdateProcessedDate` concurrently; exactly one commits, the loser surfaces `DbUpdateConcurrencyException` (the EF outbox has no row-lock; exactly-once rests entirely on the `ProcessedFromOutboxAtUtc` optimistic-concurrency token).
2. **Atomic domain-write + outbox-enqueue** — commit persists both together; a thrown operation rolls both back; over real `SqlServer` transactions.
3. **DB-enforced inbox idempotency** — duplicate `MessageId` insert throws `DbUpdateException` wrapping `SqlException` number `2627` (PK violation); a concurrent `ReceiveViaInbox` race leaves exactly one inbox row, proving the DB constraint backstops the read-then-add TOCTOU.
4. **UnitOfWork / PersistanceTransaction lifecycle** over real SqlServer transactions (begin/commit/rollback, reuse-existing-transaction, `TransactionContext.Container`).

The new test DbContext applies the **production** `OutboxMessageConfiguration` (Id PK + `ProcessedFromOutboxAtUtc` concurrency token) and `InboxMessageConfiguration` (MessageId PK) — not the SQLite hand-rolled model — so the SqlServer schema enforces real provider behavior.

## Scope

- **TEST + CI ONLY.** No production `src/**` change. Reliability.EF `<Version>` stays `0.4.2` — no version bump (test-only change does not trigger a SemVer bump).
- New: `SqlServerOutboxContext` + harness, `EfReliabilitySqlServerFixture` (MsSql `2022-CU14`, no-docker no-op, per-class DB isolation, bounded teardown), 3 integration test classes.
- Deps added to the test csproj: `Microsoft.EntityFrameworkCore.SqlServer` (8.0.27/10.0.0 per TFM), `Testcontainers.MsSql` 4.12.0, `Microsoft.Data.SqlClient` 7.0.1; `packages.lock.json` regenerated.
- Every integration method uses `[RequiresDockerFact]` (skips at discovery without Docker); class-level `[Trait("Category","Integration")]`. No-docker `dotnet test` stays green; CI `integration (docker)` lane sweeps them via the existing solution-wide `Category=Integration` filter — no workflow edit needed.

## Validation

- `dotnet test Chatter.sln` (Docker present): Reliability.EF **80/80** passed on both net8.0 and net10.0 (integration included). Whole solution green except one pre-existing, unrelated ASB net8.0 atomicity flake that passes in isolation (re-ran 1/1 green).
- No-docker `dotnet test --filter Category!=Integration`: green, integration tests correctly excluded.

## Versioning

Not required — test + CI only, no package `src/**` touched.

Closes #177. Unblocks #178 (E2E outbox reliability).