### PR TITLE
ci: migrate NuGet CD to nuget.org trusted publishing + add Cosmos CD

### DIFF
--- a/.github/workflows/azureservicebus-auth-cicd.yml
+++ b/.github/workflows/azureservicebus-auth-cicd.yml
@@ -28,10 +28,10 @@ jobs:
     environment:
       name: production-azureservicebus-auth
     env:
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
       NUGET_URL: ${{ vars.NUGET_URL }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,11 +59,16 @@ jobs:
         run: dotnet restore 'src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/Chatter.MessageBrokers.AzureServiceBus.Auth/Chatter.MessageBrokers.AzureServiceBus.Auth.csproj' --locked-mode
       - name: Pack
         run: dotnet pack 'src/Chatter.MessageBrokers.AzureServiceBus.Auth/src/Chatter.MessageBrokers.AzureServiceBus.Auth/Chatter.MessageBrokers.AzureServiceBus.Auth.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push NuGet packages
         shell: bash
         run: |
           dotnet nuget push "./dist/nuget/*.nupkg" \
-            -k '${{ env.NUGET_AUTH_TOKEN }}' \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
 

--- a/.github/workflows/azureservicebus-cicd.yml
+++ b/.github/workflows/azureservicebus-cicd.yml
@@ -28,10 +28,10 @@ jobs:
     environment:
       name: production-azureservicebus
     env:
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
       NUGET_URL: ${{ vars.NUGET_URL }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,11 +59,16 @@ jobs:
         run: dotnet restore 'src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj' --locked-mode
       - name: Pack
         run: dotnet pack 'src/Chatter.MessageBrokers.AzureServiceBus/src/Chatter.MessageBrokers.AzureServiceBus/Chatter.MessageBrokers.AzureServiceBus.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push NuGet packages
         shell: bash
         run: |
           dotnet nuget push "./dist/nuget/*.nupkg" \
-            -k '${{ env.NUGET_AUTH_TOKEN }}' \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
 

--- a/.github/workflows/cosmos-cicd.yml
+++ b/.github/workflows/cosmos-cicd.yml
@@ -1,0 +1,85 @@
+name: Chatter.MessageBrokers.Reliability.Cosmos CD
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: 'The reason for running the workflow'
+        required: true
+        default: 'Manual build from GitHub UI'
+  push:
+    branches: [master]
+    paths:
+      - 'src/Chatter.MessageBrokers.Reliability.Cosmos/src/**'
+      - '.github/workflows/cosmos-cicd.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-cosmos
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: deploy
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    environment:
+      name: production-cosmos
+    env:
+      NUGET_URL: ${{ vars.NUGET_URL }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: |
+            8.0.x
+            10.0.x
+          cache: true
+          cache-dependency-path: |
+            **/packages.lock.json
+      - name: Guard against duplicate release
+        shell: bash
+        run: |
+          VERSION=$(grep -m1 '<Version>' 'src/Chatter.MessageBrokers.Reliability.Cosmos/src/Chatter.MessageBrokers.Reliability.Cosmos/Chatter.MessageBrokers.Reliability.Cosmos.csproj' | sed 's/.*<Version>\(.*\)<\/Version>.*/\1/' | tr -d ' \r')
+          TAG='cosmos/v'"${VERSION}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "ERROR: Tag $TAG already exists — version was not bumped. Refusing to deploy (would silently discard merged code)." >&2
+            exit 1
+          fi
+          echo "Release guard passed: $TAG does not yet exist."
+      - name: Restore
+        run: dotnet restore 'src/Chatter.MessageBrokers.Reliability.Cosmos/src/Chatter.MessageBrokers.Reliability.Cosmos/Chatter.MessageBrokers.Reliability.Cosmos.csproj' --locked-mode
+      - name: Pack
+        run: dotnet pack 'src/Chatter.MessageBrokers.Reliability.Cosmos/src/Chatter.MessageBrokers.Reliability.Cosmos/Chatter.MessageBrokers.Reliability.Cosmos.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
+      - name: Push NuGet packages
+        shell: bash
+        run: |
+          dotnet nuget push "./dist/nuget/*.nupkg" \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
+            -s '${{ env.NUGET_URL }}' \
+            --skip-duplicate
+
+  tag:
+    name: tag
+    uses: ./.github/workflows/create-version-tag.yml
+    needs: deploy
+    if: github.ref == 'refs/heads/master' && github.event_name == 'push'
+    permissions:
+      contents: write
+    with:
+      csproj-path: 'src/Chatter.MessageBrokers.Reliability.Cosmos/src/Chatter.MessageBrokers.Reliability.Cosmos/Chatter.MessageBrokers.Reliability.Cosmos.csproj'
+      tag-prefix: 'cosmos'
+      package-name: 'Chatter.MessageBrokers.Reliability.Cosmos'

--- a/.github/workflows/cqrs-cicd.yml
+++ b/.github/workflows/cqrs-cicd.yml
@@ -28,10 +28,10 @@ jobs:
     environment:
       name: production-cqrs
     env:
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
       NUGET_URL: ${{ vars.NUGET_URL }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,11 +59,16 @@ jobs:
         run: dotnet restore 'src/Chatter.CQRS/src/Chatter.CQRS/Chatter.CQRS.csproj' --locked-mode
       - name: Pack
         run: dotnet pack 'src/Chatter.CQRS/src/Chatter.CQRS/Chatter.CQRS.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push NuGet packages
         shell: bash
         run: |
           dotnet nuget push "./dist/nuget/*.nupkg" \
-            -k '${{ env.NUGET_AUTH_TOKEN }}' \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
 

--- a/.github/workflows/messagebrokers-cicd.yml
+++ b/.github/workflows/messagebrokers-cicd.yml
@@ -28,10 +28,10 @@ jobs:
     environment:
       name: production-messagebrokers
     env:
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
       NUGET_URL: ${{ vars.NUGET_URL }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,11 +59,16 @@ jobs:
         run: dotnet restore 'src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj' --locked-mode
       - name: Pack
         run: dotnet pack 'src/Chatter.MessageBrokers/src/Chatter.MessageBrokers/Chatter.MessageBrokers.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push NuGet packages
         shell: bash
         run: |
           dotnet nuget push "./dist/nuget/*.nupkg" \
-            -k '${{ env.NUGET_AUTH_TOKEN }}' \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
 

--- a/.github/workflows/rabbitmq-cicd.yml
+++ b/.github/workflows/rabbitmq-cicd.yml
@@ -28,10 +28,10 @@ jobs:
     environment:
       name: production-rabbitmq
     env:
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
       NUGET_URL: ${{ vars.NUGET_URL }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,11 +59,16 @@ jobs:
         run: dotnet restore 'src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/Chatter.MessageBrokers.RabbitMQ.csproj' --locked-mode
       - name: Pack
         run: dotnet pack 'src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/Chatter.MessageBrokers.RabbitMQ.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push NuGet packages
         shell: bash
         run: |
           dotnet nuget push "./dist/nuget/*.nupkg" \
-            -k '${{ env.NUGET_AUTH_TOKEN }}' \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
 

--- a/.github/workflows/reliability-ef-cicd.yml
+++ b/.github/workflows/reliability-ef-cicd.yml
@@ -28,10 +28,10 @@ jobs:
     environment:
       name: production-reliability-ef
     env:
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
       NUGET_URL: ${{ vars.NUGET_URL }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,11 +59,16 @@ jobs:
         run: dotnet restore 'src/Chatter.MessageBrokers.Reliability.EntityFramework/src/Chatter.MessageBrokers.Reliability.EntityFramework/Chatter.MessageBrokers.Reliability.EntityFramework.csproj' --locked-mode
       - name: Pack
         run: dotnet pack 'src/Chatter.MessageBrokers.Reliability.EntityFramework/src/Chatter.MessageBrokers.Reliability.EntityFramework/Chatter.MessageBrokers.Reliability.EntityFramework.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push NuGet packages
         shell: bash
         run: |
           dotnet nuget push "./dist/nuget/*.nupkg" \
-            -k '${{ env.NUGET_AUTH_TOKEN }}' \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
 

--- a/.github/workflows/sqlchangefeed-cicd.yml
+++ b/.github/workflows/sqlchangefeed-cicd.yml
@@ -28,10 +28,10 @@ jobs:
     environment:
       name: production-sqlchangefeed
     env:
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
       NUGET_URL: ${{ vars.NUGET_URL }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,11 +59,16 @@ jobs:
         run: dotnet restore 'src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj' --locked-mode
       - name: Pack
         run: dotnet pack 'src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push NuGet packages
         shell: bash
         run: |
           dotnet nuget push "./dist/nuget/*.nupkg" \
-            -k '${{ env.NUGET_AUTH_TOKEN }}' \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
 

--- a/.github/workflows/sqlservicebroker-cicd.yml
+++ b/.github/workflows/sqlservicebroker-cicd.yml
@@ -28,10 +28,10 @@ jobs:
     environment:
       name: production-sqlservicebroker
     env:
-      NUGET_AUTH_TOKEN: ${{ secrets.NUGET_AUTH_TOKEN }}
       NUGET_URL: ${{ vars.NUGET_URL }}
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -59,11 +59,16 @@ jobs:
         run: dotnet restore 'src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj' --locked-mode
       - name: Pack
         run: dotnet pack 'src/Chatter.MessageBrokers.SqlServiceBroker/src/Chatter.MessageBrokers.SqlServiceBroker/Chatter.MessageBrokers.SqlServiceBroker.csproj' -c Release -o ./dist/nuget
+      - name: NuGet login (OIDC)
+        id: login
+        uses: NuGet/login@v1
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Push NuGet packages
         shell: bash
         run: |
           dotnet nuget push "./dist/nuget/*.nupkg" \
-            -k '${{ env.NUGET_AUTH_TOKEN }}' \
+            --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' \
             -s '${{ env.NUGET_URL }}' \
             --skip-duplicate
 

--- a/.github/workflows/version-check-all.yml
+++ b/.github/workflows/version-check-all.yml
@@ -56,3 +56,17 @@ jobs:
       src-path: 'src/Chatter.SqlChangeFeed/src/'
       csproj-path: 'src/Chatter.SqlChangeFeed/src/Chatter.SqlChangeFeed/Chatter.SqlChangeFeed.csproj'
       tag-prefix: 'sqlchangefeed'
+
+  rabbitmq:
+    uses: ./.github/workflows/version-check.yml
+    with:
+      src-path: 'src/Chatter.MessageBrokers.RabbitMQ/src/'
+      csproj-path: 'src/Chatter.MessageBrokers.RabbitMQ/src/Chatter.MessageBrokers.RabbitMQ/Chatter.MessageBrokers.RabbitMQ.csproj'
+      tag-prefix: 'rabbitmq'
+
+  cosmos:
+    uses: ./.github/workflows/version-check.yml
+    with:
+      src-path: 'src/Chatter.MessageBrokers.Reliability.Cosmos/src/'
+      csproj-path: 'src/Chatter.MessageBrokers.Reliability.Cosmos/src/Chatter.MessageBrokers.Reliability.Cosmos/Chatter.MessageBrokers.Reliability.Cosmos.csproj'
+      tag-prefix: 'cosmos'


### PR DESCRIPTION
## What

Migrates all NuGet publishing from a long-lived API key (`NUGET_AUTH_TOKEN`) to **nuget.org Trusted Publishing (OIDC)**, and adds the missing CD + version-check wiring for the Cosmos module.

### 1. OIDC migration — 8 existing CD workflows
`cqrs`, `messagebrokers`, `azureservicebus`, `azureservicebus-auth`, `rabbitmq`, `reliability-ef`, `sqlchangefeed`, `sqlservicebroker`. Per `deploy` job:
- add job-level `permissions: id-token: write` (kept `contents: read`),
- remove the `NUGET_AUTH_TOKEN` env,
- insert a `NuGet/login@v1` step (`user: ${{ secrets.NUGET_USER }}`) immediately before the push (the minted key is short-lived/single-use),
- push now uses `--api-key '${{ steps.login.outputs.NUGET_API_KEY }}'`.

`NUGET_URL` and `--skip-duplicate` unchanged. The `tag` job (reusable `create-version-tag.yml`) is untouched and does not push to NuGet — the login step runs inline in each top-level workflow, so the known `NuGet/login` reusable-workflow filename bug does not apply.

### 2. New Cosmos CD — `cosmos-cicd.yml`
Mirrors the migrated template: environment `production-cosmos`, concurrency `release-cosmos`, push paths on the Cosmos `src/**` + the workflow file, OIDC trusted publishing from the start, duplicate-release guard `cosmos/v<version>`, and a `tag` job (`tag-prefix: cosmos`, package `Chatter.MessageBrokers.Reliability.Cosmos`). Merging this publishes **Cosmos 0.2.0** (its first release).

### 3. version-check-all.yml — close pre-merge gate gaps
Added `cosmos` AND `rabbitmq` jobs (rabbitmq was a pre-existing gap — had a CD workflow but no version-bump gate). The gate now covers all 9 modules.

## Required human setup BEFORE merge
- nuget.org Trusted Publishing policies per workflow file (owner `brenpike`, repo `Chatter`, Workflow File = `<module>-cicd.yml`, Environment = `production-<module>`) — including `cosmos-cicd.yml` / `production-cosmos`. **(done)**
- `NUGET_USER` secret (nuget.org profile name) at repo or environment scope — **pending**; the workflows reference `secrets.NUGET_USER`.
- After the first green OIDC publish, delete the now-unused `NUGET_AUTH_TOKEN` secret.

## Validation

CI-only change confined to `.github/workflows/**`; no compiled code touched (test suite was green at base). All 10 touched workflow files parse clean (PyYAML; actionlint not installed locally). Local Codex review: OIDC migration clean; one finding (cosmos missing from version-check gate) remediated in this PR.

## Versioning

Not required — no package `src/**` or `<Version>` changed.